### PR TITLE
renovate: schema fix

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -58,7 +58,9 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": "^.github/workflows/validate.yml$",
+      "managerFilePatterns": [
+        '/^.github/workflows/validate.yml$/',
+      ],
       "matchStrings": [
         "LINT_VERSION:\\s+(?<currentValue>.+)\\s*"
       ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -50,8 +50,6 @@
    *** Repository-specific configuration options ***
    *************************************************/
 
-  // Don't leave dep. update. PRs "hanging", assign them to people.
-  // "assignees": ["rhatdan", "vrothberg", "Luap99"],
   "postUpdateOptions": [
     "gomodVendor",
     "gomodTidy"


### PR DESCRIPTION
See https://github.com/containers/container-libs/pull/280, the custom file regex manager now uses the managerFilePatterns key which accept an array.

Note the .github/workflows/validate.yml doesn't actually exists right now but is again being renamed in https://github.com/containers/container-libs/pull/33 so let's just keep it at that.

Also drop the assignees comment