### PR TITLE
gh action: fix git-validation workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,7 +17,7 @@ jobs:
   codespell:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: install deps
       # Version of codespell bundled with Ubuntu is way old, so use pip.
       run: pip install --break-system-packages codespell==v2.4.1
@@ -30,7 +30,7 @@ jobs:
       run:
         working-directory: ./common
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 2
     - uses: actions/setup-go@v5
@@ -71,7 +71,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         # By default github actions creates a merge commit which fails the validation,
         # we only must validate the actual commits of the author.


### PR DESCRIPTION
In general if we hand a range like 'HEAD\~2..HEAD' to git it fails if the
repo only has two commits as HEAD\~2 doesn't resolve in such case.
git-validation doesn't seem to fail in such case but it still misses the
first commit.

To fix this we already checked out all PR commits anyway so we can just
validate all commits. But because there is special gh action handling in
git-validation we must disable it as it seem to only check the last
commit based from the GITHUB_ENV var.