### PR TITLE
cirrus: add missing common nv setup to run all tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -266,6 +266,8 @@ common_testing_task:
     modules_cache:
         fingerprint_script: cat common/go.sum
         folder: $GOPATH/pkg/mod
+    env:
+        NETAVARK_BINARY: "/usr/libexec/podman/netavark"
     test_script: |
       cd common
       make build


### PR DESCRIPTION
We need to define the NETAVARK_BINARY env to run all tests in the netavark test suite in common/libnetwork/netavark/.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
