### PR TITLE
gh action: add PR labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,11 @@
+# Add labels based on file paths in PR
+#   https://github.com/actions/labeler
+common:
+  - changed-files:
+    - any-glob-to-any-file: common/**
+image:
+  - changed-files:
+    - any-glob-to-any-file: image/**
+storage:
+  - changed-files:
+    - any-glob-to-any-file: storage/**

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,13 @@
+# https://github.com/actions/labeler
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v5


### PR DESCRIPTION
This action should automatically label any PR with common, image or storage based on the files changed. This should help reviewers focus on their specific areas of interest.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
