### PR TITLE
Add additional `userns` values to containers.conf.5

### DIFF
--- a/common/docs/containers.conf.5.md
+++ b/common/docs/containers.conf.5.md
@@ -397,8 +397,11 @@ Sets umask inside the container.
 
 Default way to create a USER namespace for the container.
 Options are:
-  `private` Create private USER Namespace for the container.
-  `host`    Share host USER Namespace with the container.
+  `private` Create private USER Namespace for the container, without adding any UID mappings.
+  `host`    Share host USER Namespace with the container. Root in the container is mapped to the host user UID.
+  `auto`    Automatically create a USER namespace with a unique mapping.
+  `keep-id` Like `private`, but container UIDs are mapped to the host user's subordinate UIDs listed in `/etc/subuid`, and the current user's `UID:GID` are mapped to the same values in the container.
+  `no-map`  Like `keep-id`, but the current user's `UID:GID` does not map to any `UID:GID` inside the container.
 
 **utsns**="private"
 

--- a/common/pkg/config/containers.conf
+++ b/common/pkg/config/containers.conf
@@ -317,11 +317,13 @@ default_sysctls = [
 #
 #umask = "0022"
 
-# Default way to to create a User namespace for the container
+# Default way to create a USER namespace for the container.
 # Options are:
-# `auto`        Create unique User Namespace for the container.
-# `host`    Share host User Namespace with the container.
-#
+#   `private` Create private USER Namespace for the container, without adding any UID mappings.
+#   `host`    Share host USER Namespace with the container. Root in the container is mapped to the host user UID.
+#   `auto`    Automatically create a USER namespace with a unique mapping.
+#   `keep-id` Like `private`, but container UIDs are mapped to the host user's subordinate UIDs listed in `/etc/subuid`, and the current user's `UID:GID` are mapped to the same values in the container.
+#   `no-map`  Like `keep-id`, but the current user's `UID:GID` does not map to any `UID:GID` inside the container.
 #userns = "host"
 
 # Default way to to create a UTS namespace for the container


### PR DESCRIPTION
I was suggested to set `containers.userns="nomap"` in https://github.com/containers/podman/issues/26939#issuecomment-3242866375, but this value is only documented as allowed in `podman-run(1)` and `podman-systemd.unit(5)`, not `containers.conf(5)`. But `containers.userns="nomap"` seems to work as expected, so I've copied the documentation from https://github.com/containers/podman/blob/main/docs/source/markdown/options/userns.container.md to here.

I have no idea what `private` does, so I've just left the current description as-is. If someone can tell me what it does, I can try and give it a description that explains how it's different from the other options.
