### PR TITLE
common: remove go.mod retract

### DIFF
--- a/common/go.mod
+++ b/common/go.mod
@@ -139,8 +139,3 @@ require (
 	google.golang.org/protobuf v1.36.8 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-retract (
-	v1.0.1 // This version is used only to publish retraction of v1.0.1.
-	v1.0.0 // We reverted to v0.… version numbers; the v1.0.0 tag was actually deleted.
-)


### PR DESCRIPTION
Now the we have a new repo there are no v1 tags anymore that we must retract, we start with a fresh repo without tags so delete them.

<!--- Please read the [contributing guidelines](https://github.com/containers/common-files/blob/master/.github/CONTRIBUTING.md) before proceeding --->
