### PR TITLE
Vendor also the current c/storage and c/common into Skopeo

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -226,7 +226,7 @@ image_test_skopeo_task:
     gce_instance: *fedora_vm
     env:
         HOME: "/root"  # default unset, needed by golangci-lint.
-        GOSRC: "${CIRRUS_WORKING_DIR}/image"
+        GOSRC: "${CIRRUS_WORKING_DIR}"
         GOPATH: "/var/tmp/go"
         SKOPEO_CI_BRANCH: "main"
         SCRIPT_BASE: "./contrib/cirrus"

--- a/image/contrib/cirrus/runner.sh
+++ b/image/contrib/cirrus/runner.sh
@@ -22,8 +22,6 @@ export "PATH=$PATH:$GOPATH/bin"
 _run_setup() {
     req_env_vars SKOPEO_PATH SKOPEO_CI_BRANCH GOSRC
 
-    project_module=$(go list .)
-
     rm -rf "${SKOPEO_PATH}"
     git clone -b ${SKOPEO_CI_BRANCH} \
         https://github.com/containers/skopeo.git ${SKOPEO_PATH}
@@ -35,8 +33,9 @@ _run_setup() {
         git checkout FETCH_HEAD
     fi
 
-    msg "Replacing upstream skopeo $SKOPEO_CI_BRANCH branch $project_module module"
-    go mod edit -replace ${project_module}=$GOSRC
+    go mod edit -replace go.podman.io/storage="$GOSRC/storage"
+    go mod edit -replace go.podman.io/image/v5="$GOSRC/image"
+    go mod edit -replace go.podman.io/common="$GOSRC/common"
 
     "${SKOPEO_PATH}/${SCRIPT_BASE}/runner.sh" setup
 }


### PR DESCRIPTION
This is ~necessary to benefit from the monorepo, so that interdependent updates to c/storage and c/image are tested as a single unit by the Skopeo test.

Proven in https://github.com/containers/container-libs/pull/299 .