### PR TITLE
image/docker: Log at debug level if we fail to find size for GetBlob

### DIFF
--- a/image/docker/docker_client.go
+++ b/image/docker/docker_client.go
@@ -1066,6 +1066,8 @@ func (c *dockerClient) getBlob(ctx context.Context, ref dockerReference, info ty
 	cache.RecordKnownLocation(ref.Transport(), bicTransportScope(ref), info.Digest, newBICLocationReference(ref))
 	blobSize, err := getBlobSize(res)
 	if err != nil {
+		// See above, we don't guarantee returning a size
+		logrus.Debugf("failed to get blob size: %v", err)
 		blobSize = -1
 	}
 


### PR DESCRIPTION
This helped me debug https://github.com/bootc-dev/bootc/issues/1567
