### PR TITLE
HACK: storage: overlay: only unmount storage home if needed

### DIFF
--- a/storage/drivers/overlay/overlay.go
+++ b/storage/drivers/overlay/overlay.go
@@ -863,7 +863,11 @@ func (d *Driver) Cleanup() error {
 	if anyPresent {
 		return nil
 	}
-	return mount.Unmount(d.home)
+	// Ensure that we do not unmount anything not mounted by us
+	if !d.options.skipMountHome {
+		return mount.Unmount(d.home)
+	}
+	return nil
 }
 
 // pruneStagingDirectories cleans up any staging directory that was leaked.


### PR DESCRIPTION
Do not attempt to unmount storage home directory if we were not supposed
to mount or remount it at all. This is never useful and may also break
certain (unsupported) setups.

Fixes: containers/podman#27012
