### PR TITLE
Add fields for TLS material to destination config

### DIFF
--- a/common/docs/containers.conf.5.md
+++ b/common/docs/containers.conf.5.md
@@ -935,15 +935,15 @@ URI to access the Podman service
 
 Path to file containing ssh identity key
 
-**tls_cert_file="/path/to/certs/podman/tls.crt"**
+**tls_cert="/path/to/certs/podman/tls.crt"**
 
 Path to PEM file containing TLS client certificate
 
-**tls_key_file="/path/to/certs/podman/tls.key"**
+**tls_key="/path/to/certs/podman/tls.key"**
 
 Path to PEM file containing TLS client certificate private key
 
-**tls_ca_file="/path/to/certs/podman/ca.crt"**
+**tls_ca="/path/to/certs/podman/ca.crt"**
 
 Path to PEM file containing TLS certificate authority (CA) bundle
 

--- a/common/pkg/config/config.go
+++ b/common/pkg/config/config.go
@@ -708,11 +708,11 @@ type Destination struct {
 	Identity string `json:",omitempty" toml:"identity,omitempty"`
 
 	// Path to TLS client certificate PEM file, optional
-	TLSCertFile string `json:",omitempty" toml:"tls_cert_file,omitempty"`
+	TLSCert string `json:",omitempty" toml:"tls_cert,omitempty"`
 	// Path to TLS client certificate private key PEM file, optional
-	TLSKeyFile string `json:",omitempty" toml:"tls_key_file,omitempty"`
+	TLSKey string `json:",omitempty" toml:"tls_key,omitempty"`
 	// Path to TLS certificate authority PEM file, optional
-	TLSCAFile string `json:",omitempty" toml:"tls_ca_file,omitempty"`
+	TLSCA string `json:",omitempty" toml:"tls_ca,omitempty"`
 
 	// isMachine describes if the remote destination is a machine.
 	IsMachine bool `json:",omitempty" toml:"is_machine,omitempty"`

--- a/common/pkg/config/connections_test.go
+++ b/common/pkg/config/connections_test.go
@@ -105,7 +105,7 @@ var _ = Describe("Connections conf", func() {
 	})
 
 	Context("GetConnection/Farm", func() {
-		const defConnectionsConf = `{"Connection":{"Default":"test","Connections":{"test":{"URI":"ssh://podman.io"},"QA":{"URI":"ssh://test","Identity":".ssh/id","IsMachine":true},"TLS": {"URI": "tcp://podman.io:443", "TLSCAFile":"/path/to/ca.pem"},"mTLS":{"URI": "tcp://podman.io:443/subpath", "TLSCAFile": "/path/to/ca.pem", "TLSCertFile": "/path/to/tls.crt", "TLSKeyFile": "/path/to/tls.key"}}},"farm":{"Default":"farm1","List":{"farm1":["test"]}}}`
+		const defConnectionsConf = `{"Connection":{"Default":"test","Connections":{"test":{"URI":"ssh://podman.io"},"QA":{"URI":"ssh://test","Identity":".ssh/id","IsMachine":true},"TLS": {"URI": "tcp://podman.io:443", "TLSCA":"/path/to/ca.pem"},"mTLS":{"URI": "tcp://podman.io:443/subpath", "TLSCA": "/path/to/ca.pem", "TLSCert": "/path/to/tls.crt", "TLSKey": "/path/to/tls.key"}}},"farm":{"Default":"farm1","List":{"farm1":["test"]}}}`
 		const defContainersConf = `
 [engine]
   active_service = "containers"
@@ -164,7 +164,7 @@ var _ = Describe("Connections conf", func() {
 				Name:        "TLS",
 				Default:     false,
 				ReadWrite:   true,
-				Destination: Destination{URI: "tcp://podman.io:443", TLSCAFile: "/path/to/ca.pem"},
+				Destination: Destination{URI: "tcp://podman.io:443", TLSCA: "/path/to/ca.pem"},
 			}))
 
 			con, err = conf.GetConnection("mTLS", false)
@@ -173,7 +173,7 @@ var _ = Describe("Connections conf", func() {
 				Name:        "mTLS",
 				Default:     false,
 				ReadWrite:   true,
-				Destination: Destination{URI: "tcp://podman.io:443/subpath", TLSCAFile: "/path/to/ca.pem", TLSCertFile: "/path/to/tls.crt", TLSKeyFile: "/path/to/tls.key"},
+				Destination: Destination{URI: "tcp://podman.io:443/subpath", TLSCA: "/path/to/ca.pem", TLSCert: "/path/to/tls.crt", TLSKey: "/path/to/tls.key"},
 			}))
 
 			con, err = conf.GetConnection("containers", false)

--- a/common/pkg/config/containers.conf
+++ b/common/pkg/config/containers.conf
@@ -783,11 +783,11 @@ default_sysctls = [
 #    Path to file containing ssh identity key
 #    identity = "~/.ssh/id_rsa"
 #    Path to PEM file containing TLS client certificate
-#    tls_cert_file = "/path/to/certs/podman/tls.crt"
+#    tls_cert = "/path/to/certs/podman/tls.crt"
 #    Path to PEM file containing TLS client certificate private key
-#    tls_key_file = "/path/to/certs/podman/tls.key"
+#    tls_key = "/path/to/certs/podman/tls.key"
 #    Path to PEM file containing TLS certificate authority (CA) bundle
-#    tls_ca_file = "/path/to/certs/podman/ca.crt"
+#    tls_ca = "/path/to/certs/podman/ca.crt"
 
 # Directory for temporary files. Must be tmpfs (wiped after reboot)
 #

--- a/common/pkg/config/containers.conf-freebsd
+++ b/common/pkg/config/containers.conf-freebsd
@@ -604,11 +604,11 @@ default_sysctls = [
 #    Path to file containing ssh identity key
 #    identity = "~/.ssh/id_rsa"
 #    Path to PEM file containing TLS client certificate
-#    tls_cert_file = "/path/to/certs/podman/tls.crt"
+#    tls_cert = "/path/to/certs/podman/tls.crt"
 #    Path to PEM file containing TLS client certificate private key
-#    tls_key_file = "/path/to/certs/podman/tls.key"
+#    tls_key = "/path/to/certs/podman/tls.key"
 #    Path to PEM file containing TLS certificate authority (CA) bundle
-#    tls_ca_file = "/path/to/certs/podman/ca.crt"
+#    tls_ca = "/path/to/certs/podman/ca.crt"
 
 # Directory for temporary files. Must be tmpfs (wiped after reboot)
 #


### PR DESCRIPTION
Adds optional fields tls_cert_file, tls_key_file, and tls_cafile to the configuration TOML to support connecting to TLS and mTLS podman API sockets.

This is in support of https://github.com/containers/podman/pull/24601 to fix https://github.com/containers/podman/issues/24583 .

This PR is a carry-over from https://github.com/containers/common/pull/2249
