### PR TITLE
.github/opendownstream: fix check for exisiting PR url

### DIFF
--- a/.github/workflows/opendownstream-pr.yml
+++ b/.github/workflows/opendownstream-pr.yml
@@ -110,7 +110,7 @@ jobs:
           # Check if PR already exists for this branch
           echo "Searching for existing PR with branch: $BRANCH_NAME"
 
-          EXISTING_PR_URL=$(gh pr list --repo containers/buildah --head "podmanbot:$BRANCH_NAME" --json url --jq '.[0].url // empty' 2>/dev/null || echo "")
+          EXISTING_PR_URL=$(gh pr list --repo containers/buildah --head "$BRANCH_NAME" --json url --jq '.[0].url // empty' 2>/dev/null || echo "")
 
           if [ -n "$EXISTING_PR_URL" ]; then
             echo "Found existing PR: $EXISTING_PR_URL"


### PR DESCRIPTION
Remove `<username>:<branch>` from `--head` when trying to find exisiting PR URL

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
