### PR TITLE
storage: Ensure file flags are reset before removing temp dir

### DIFF
--- a/storage/internal/tempdir/tempdir.go
+++ b/storage/internal/tempdir/tempdir.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"go.podman.io/storage/internal/staging_lockfile"
+	"go.podman.io/storage/pkg/system"
 )
 
 /*
@@ -148,7 +149,7 @@ func RecoverStaleDirs(rootDir string) error {
 			continue
 		}
 
-		if rmErr := os.RemoveAll(tempDirPath); rmErr != nil {
+		if rmErr := system.EnsureRemoveAll(tempDirPath); rmErr != nil {
 			recoveryErrors = append(recoveryErrors, fmt.Errorf("error removing stale temp dir: %w", rmErr))
 		}
 		if unlockErr := instanceLock.UnlockAndDelete(); unlockErr != nil {
@@ -218,7 +219,7 @@ func (td *TempDir) Cleanup() error {
 		return nil
 	}
 
-	if err := os.RemoveAll(td.tempDirPath); err != nil {
+	if err := system.EnsureRemoveAll(td.tempDirPath); err != nil {
 		return fmt.Errorf("removing temp dir failed: %w", err)
 	}
 


### PR DESCRIPTION
In FreeBSD, when the user decides to use the VFS driver instead of ZFS and creates a container from the FreeBSD OCI image, after deleting that container, an 'operation not permitted' error is displayed due to the 'schg' flags that are set on some files included in that image.

When this occurs, commands such as 'buildah containers' or 'buildah images' stop working completely and display the following error:

```
Error: loading primary layer store data: error removing stale temp dir /var/db/containers/storage/vfs/tempdirs/temp-dir-3664526854: unlinkat /var/db/containers/storage/vfs/tempdirs/temp-dir-3664526854/0-57291436912a1f0c21a3636fd44714e804fdd63ea72dd12500dc3edf1f4f3545/lib/libc.so.7: operation not permitted
WARN[0000] failed to shutdown storage: "error removing stale temp dir /var/db/containers/storage/vfs/tempdirs/temp-dir-3664526854: unlinkat /var/db/containers/storage/vfs/tempdirs/temp-dir-3664526854/0-57291436912a1f0c21a3636fd44714e804fdd63ea72dd12500dc3edf1f4f3545/lib/libc.so.7: operation not permitted"
```

Manually resetting the flags for that directory temporarily fixes the above error until the user deletes another container.

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
