### PR TITLE
PolicyContext: add new `SetRejectInsecure` method

### DIFF
--- a/image/signature/policy_eval.go
+++ b/image/signature/policy_eval.go
@@ -79,8 +79,9 @@ type PolicyReferenceMatch interface {
 // PolicyContext encapsulates a policy and possible cached state
 // for speeding up its evaluation.
 type PolicyContext struct {
-	Policy *Policy
-	state  policyContextState // Internal consistency checking
+	Policy         *Policy
+	state          policyContextState // Internal consistency checking
+	rejectInsecure bool
 }
 
 // policyContextState is used internally to verify the users are not misusing a PolicyContext.
@@ -130,6 +131,13 @@ func (pc *PolicyContext) Destroy() error {
 // ONLY use this for log messages, not for any decisions!
 func policyIdentityLogName(ref types.ImageReference) string {
 	return ref.Transport().Name() + ":" + ref.PolicyConfigurationIdentity()
+}
+
+// SetRejectInsecure modifies insecure policy requirement handling. If
+// passed `true`, policy checking by IsRunningImageAllowed will ignore the
+// "insecureAcceptAnything" policy type.
+func (pc *PolicyContext) SetRejectInsecure(val bool) {
+	pc.rejectInsecure = val
 }
 
 // requirementsForImageRef selects the appropriate requirements for ref.
@@ -273,6 +281,24 @@ func (pc *PolicyContext) IsRunningImageAllowed(ctx context.Context, publicImage 
 
 	logrus.Debugf("IsRunningImageAllowed for image %s", policyIdentityLogName(image.Reference()))
 	reqs := pc.requirementsForImageRef(image.Reference())
+
+	// Create a filtered version of the policy which always ignores
+	// insecureAcceptAnything. In practice, it's likely the only requirement, so
+	// then we'd fall in the `len(reqs) == 0` case just below. In theory, it's
+	// possible to have additional requirements combined with insecureAcceptAnything
+	// even if not useful (it'd be the equivalent of a `&& true`).
+	if pc.rejectInsecure {
+		var filteredReqs PolicyRequirements
+		for reqNumber, req := range reqs {
+			_, ok := req.(*prInsecureAcceptAnything)
+			if ok {
+				logrus.Debugf("Requirement %d: ignoring insecureAcceptAnything by runtime request", reqNumber)
+				continue
+			}
+			filteredReqs = append(filteredReqs, req)
+		}
+		reqs = filteredReqs
+	}
 
 	if len(reqs) == 0 {
 		return false, PolicyRequirementError("List of verification policy requirements must not be empty")

--- a/image/signature/policy_eval_test.go
+++ b/image/signature/policy_eval_test.go
@@ -497,3 +497,113 @@ func assertRunningRejectedPolicyRequirement(t *testing.T, allowed bool, err erro
 	assertRunningRejected(t, allowed, err)
 	assert.IsType(t, PolicyRequirementError(""), err)
 }
+
+func TestPolicyContextSetRejectInsecure(t *testing.T) {
+	pc, err := NewPolicyContext(&Policy{Default: PolicyRequirements{NewPRReject()}})
+	require.NoError(t, err)
+	defer func() {
+		err := pc.Destroy()
+		require.NoError(t, err)
+	}()
+
+	// Test default value is false
+	assert.False(t, pc.rejectInsecure)
+
+	// Test setting to true
+	pc.SetRejectInsecure(true)
+	assert.True(t, pc.rejectInsecure)
+
+	// Test setting back to false
+	pc.SetRejectInsecure(false)
+	assert.False(t, pc.rejectInsecure)
+}
+
+func TestPolicyContextIsRunningImageAllowedWithRejectInsecure(t *testing.T) {
+	pc, err := NewPolicyContext(&Policy{
+		Default: PolicyRequirements{NewPRReject()},
+		Transports: map[string]PolicyTransportScopes{
+			"docker": {
+				"docker.io/testing/manifest:insecureOnly": {
+					NewPRInsecureAcceptAnything(),
+				},
+				"docker.io/testing/manifest:insecureWithOther": {
+					NewPRInsecureAcceptAnything(),
+					xNewPRSignedByKeyPath(SBKeyTypeGPGKeys, "fixtures/public-key.gpg", NewPRMMatchRepository()),
+				},
+				"docker.io/testing/manifest:signedOnly": {
+					xNewPRSignedByKeyPath(SBKeyTypeGPGKeys, "fixtures/public-key.gpg", NewPRMMatchRepository()),
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	defer func() {
+		err := pc.Destroy()
+		require.NoError(t, err)
+	}()
+
+	// Test with rejectInsecure=false (default behavior)
+	// insecureAcceptAnything should be accepted
+	img := pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:insecureOnly")
+	res, err := pc.IsRunningImageAllowed(context.Background(), img)
+	assertRunningAllowed(t, res, err)
+
+	// Test with rejectInsecure=true
+	pc.SetRejectInsecure(true)
+
+	// insecureAcceptAnything only: should be rejected (empty requirements)
+	img = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:insecureOnly")
+	res, err = pc.IsRunningImageAllowed(context.Background(), img)
+	assertRunningRejectedPolicyRequirement(t, res, err)
+
+	// insecureAcceptAnything + signed requirement: should use signed requirement
+	img = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:insecureWithOther")
+	res, err = pc.IsRunningImageAllowed(context.Background(), img)
+	assertRunningAllowed(t, res, err)
+
+	// signed requirement only: should work normally
+	img = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:signedOnly")
+	res, err = pc.IsRunningImageAllowed(context.Background(), img)
+	assertRunningAllowed(t, res, err)
+
+	// Test with unsigned image and insecureAcceptAnything + signed requirement
+	img = pcImageMock(t, "fixtures/dir-img-unsigned", "testing/manifest:insecureWithOther")
+	res, err = pc.IsRunningImageAllowed(context.Background(), img)
+	assertRunningRejectedPolicyRequirement(t, res, err)
+}
+
+func TestPolicyContextRejectInsecureFilteringLogic(t *testing.T) {
+	pc, err := NewPolicyContext(&Policy{
+		Default: PolicyRequirements{NewPRReject()},
+		Transports: map[string]PolicyTransportScopes{
+			"docker": {
+				"docker.io/testing/manifest:multipleInsecure": {
+					NewPRInsecureAcceptAnything(),
+					NewPRInsecureAcceptAnything(),
+					NewPRReject(),
+				},
+				"docker.io/testing/manifest:allInsecure": {
+					NewPRInsecureAcceptAnything(),
+					NewPRInsecureAcceptAnything(),
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	defer func() {
+		err := pc.Destroy()
+		require.NoError(t, err)
+	}()
+
+	pc.SetRejectInsecure(true)
+
+	// Test filtering multiple insecureAcceptAnything requirements but keeping other requirements
+	img := pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:multipleInsecure")
+	res, err := pc.IsRunningImageAllowed(context.Background(), img)
+	assertRunningRejectedPolicyRequirement(t, res, err) // Should fail because only prReject remains
+
+	// Test filtering all requirements results in empty requirements error
+	img = pcImageMock(t, "fixtures/dir-img-valid", "testing/manifest:allInsecure")
+	res, err = pc.IsRunningImageAllowed(context.Background(), img)
+	assertRunningRejectedPolicyRequirement(t, res, err)
+}


### PR DESCRIPTION
In bootc, we want the ability to assert that signature verification is enforced, but there are no mechanisms for this in the library.

Add a new `SetRejectInsecure` method on the `PolicyContext` object which would allow this.

Since this only changes the behaviour of the `insecureAcceptAnything` policy requirement, rather than extending the policy requirement interface, I went with a filtering approach directly in `IsRunningImageAllowed()`.

Test generation was `Assisted-by: Claude Code v1.0.120`.

Part of https://github.com/containers/skopeo/issues/1829.

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
