### PR TITLE
.gitignore: vendor dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /go.work.sum
+/vendor/


### PR DESCRIPTION
Ensure vendor dir is ignored to prevent someone from mistakenly committing it.

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
