### PR TITLE
common/libimage/manifests.list.Add(): add from lists without images

### DIFF
--- a/common/libimage/manifest_list.go
+++ b/common/libimage/manifest_list.go
@@ -508,7 +508,7 @@ func (m *ManifestList) Add(ctx context.Context, name string, options *ManifestLi
 		}
 	}
 
-	ref, err := m.parseNameToExtantReference(ctx, systemContext, name, false, "image to add to manifest list")
+	ref, err := m.parseNameToExtantReference(ctx, systemContext, name, options.All, "image to add to manifest list")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
When adding the contents of a list to another list, keep track of the MediaType that described the list elements, so that we can handle cases where the entry being referred to is unreadable.

When adding a non-list manifest to a list, default to reusing the MediaType of the non-list for its entry in the list to which it's being added.

If we can't read a manifest or configuration blob from an item that we're adding to a list, don't fail if we already have the information that we would try to read from the configuration blob.

Fixes https://github.com/containers/podman/issues/27228.