### PR TITLE
opendownstreamPR: Fix comment about checkout

### DIFF
--- a/.github/workflows/opendownstream-pr.yml
+++ b/.github/workflows/opendownstream-pr.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: 'Checkout Self'
         uses: actions/checkout@v5
-        # This checks out the code from the PR branch itself
+        # Because we use pull_request_target, this checks out the code from the default branch, NOT the PR branch
 
       - name: 'Setup Go'
         uses: actions/setup-go@v6


### PR DESCRIPTION
When using pull_request_target, actions/checkout by default checks out the default branch of the main repo, not the PR branch.
