### PR TITLE
storage: fix formatting of container manual pages

### DIFF
--- a/storage/docs/containers-storage-add-names.md
+++ b/storage/docs/containers-storage-add-names.md
@@ -1,4 +1,4 @@
-## containers-storage-add-names 1 "August 2016"
+# containers-storage-add-names 1 "August 2016"
 
 ## NAME
 containers-storage add-names - Add names to a layer/image/container

--- a/storage/docs/containers-storage-applydiff-using-staging-dir.md
+++ b/storage/docs/containers-storage-applydiff-using-staging-dir.md
@@ -1,4 +1,4 @@
-## containers-storage-applydiff-using-staging-dir 1 "September 2023"
+# containers-storage-applydiff-using-staging-dir 1 "September 2023"
 
 ## NAME
 containers-storage applydiff-using-staging-dir - Apply a layer diff to a layer using a staging directory

--- a/storage/docs/containers-storage-applydiff.md
+++ b/storage/docs/containers-storage-applydiff.md
@@ -1,4 +1,4 @@
-## containers-storage-apply-diff 1 "August 2016"
+# containers-storage-apply-diff 1 "August 2016"
 
 ## NAME
 containers-storage apply-diff - Apply a layer diff to a layer

--- a/storage/docs/containers-storage-changes.md
+++ b/storage/docs/containers-storage-changes.md
@@ -1,4 +1,4 @@
-## containers-storage-changes 1 "August 2016"
+# containers-storage-changes 1 "August 2016"
 
 ## NAME
 containers-storage changes - Produce a list of changes in a layer

--- a/storage/docs/containers-storage-check.md
+++ b/storage/docs/containers-storage-check.md
@@ -1,4 +1,4 @@
-## containers-storage-check 1 "September 2022"
+# containers-storage-check 1 "September 2022"
 
 ## NAME
 containers-storage check - Check for and remove damaged layers/images/containers

--- a/storage/docs/containers-storage-composefs.md
+++ b/storage/docs/containers-storage-composefs.md
@@ -1,4 +1,4 @@
-## containers-storage 1 "August 2024"
+# containers-storage 1 "August 2024"
 
 ## NAME
 containers-storage-composefs - Information about composefs and containers/storage

--- a/storage/docs/containers-storage-config.md
+++ b/storage/docs/containers-storage-config.md
@@ -1,4 +1,4 @@
-## containers-storage-config 1 "November 2024"
+# containers-storage-config 1 "November 2024"
 
 ## NAME
 containers-storage config - Output the configuration for the storage library

--- a/storage/docs/containers-storage-container.md
+++ b/storage/docs/containers-storage-container.md
@@ -1,4 +1,4 @@
-## containers-storage-container 1 "August 2016"
+# containers-storage-container 1 "August 2016"
 
 ## NAME
 containers-storage container - Examine a single container

--- a/storage/docs/containers-storage-containers.md
+++ b/storage/docs/containers-storage-containers.md
@@ -1,4 +1,4 @@
-## containers-storage-containers 1 "August 2016"
+# containers-storage-containers 1 "August 2016"
 
 ## NAME
 containers-storage containers - List known containers

--- a/storage/docs/containers-storage-copy.md
+++ b/storage/docs/containers-storage-copy.md
@@ -1,4 +1,4 @@
-## containers-storage-copy 1 "April 2018"
+# containers-storage-copy 1 "April 2018"
 
 ## NAME
 containers-storage copy - Copy content into a layer

--- a/storage/docs/containers-storage-create-container.md
+++ b/storage/docs/containers-storage-create-container.md
@@ -1,4 +1,4 @@
-## containers-storage-create-container 1 "August 2016"
+# containers-storage-create-container 1 "August 2016"
 
 ## NAME
 containers-storage create-container - Create a container

--- a/storage/docs/containers-storage-create-image.md
+++ b/storage/docs/containers-storage-create-image.md
@@ -1,4 +1,4 @@
-## containers-storage-create-image 1 "August 2016"
+# containers-storage-create-image 1 "August 2016"
 
 ## NAME
 containers-storage create-image - Create an image

--- a/storage/docs/containers-storage-create-layer.md
+++ b/storage/docs/containers-storage-create-layer.md
@@ -1,4 +1,4 @@
-## containers-storage-create-layer 1 "August 2016"
+# containers-storage-create-layer 1 "August 2016"
 
 ## NAME
 containers-storage create-layer - Create a layer

--- a/storage/docs/containers-storage-create-storage-layer.md
+++ b/storage/docs/containers-storage-create-storage-layer.md
@@ -1,4 +1,4 @@
-## containers-storage-create-storage-layer 1 "September 2022"
+# containers-storage-create-storage-layer 1 "September 2022"
 
 ## NAME
 containers-storage create-storage-layer - Create a layer in a lower-level storage driver

--- a/storage/docs/containers-storage-dedup.md
+++ b/storage/docs/containers-storage-dedup.md
@@ -1,4 +1,4 @@
-## containers-storage-dedup 1 "November 2024"
+# containers-storage-dedup 1 "November 2024"
 
 ## NAME
 containers-storage dedup - Deduplicate similar files in the images

--- a/storage/docs/containers-storage-delete-container.md
+++ b/storage/docs/containers-storage-delete-container.md
@@ -1,4 +1,4 @@
-## containers-storage-delete-container 1 "August 2016"
+# containers-storage-delete-container 1 "August 2016"
 
 ## NAME
 containers-storage delete-container - Delete a container

--- a/storage/docs/containers-storage-delete-image.md
+++ b/storage/docs/containers-storage-delete-image.md
@@ -1,4 +1,4 @@
-## containers-storage-delete-image 1 "August 2016"
+# containers-storage-delete-image 1 "August 2016"
 
 ## NAME
 containers-storage delete-image - Delete an image

--- a/storage/docs/containers-storage-delete-layer.md
+++ b/storage/docs/containers-storage-delete-layer.md
@@ -1,4 +1,4 @@
-## containers-storage-delete-layer 1 "August 2016"
+# containers-storage-delete-layer 1 "August 2016"
 
 ## NAME
 containers-storage delete-layer - Delete a layer

--- a/storage/docs/containers-storage-delete.md
+++ b/storage/docs/containers-storage-delete.md
@@ -1,4 +1,4 @@
-## containers-storage-delete 1 "August 2016"
+# containers-storage-delete 1 "August 2016"
 
 ## NAME
 containers-storage delete - Force deletion of a layer, image, or container

--- a/storage/docs/containers-storage-diff.md
+++ b/storage/docs/containers-storage-diff.md
@@ -1,4 +1,4 @@
-## containers-storage-diff 1 "August 2016"
+# containers-storage-diff 1 "August 2016"
 
 ## NAME
 containers-storage diff - Generate a layer diff

--- a/storage/docs/containers-storage-diffsize.md
+++ b/storage/docs/containers-storage-diffsize.md
@@ -1,4 +1,4 @@
-## containers-storage-diffsize 1 "August 2016"
+# containers-storage-diffsize 1 "August 2016"
 
 ## NAME
 containers-storage diffsize - Compute the size of a layer diff

--- a/storage/docs/containers-storage-exists.md
+++ b/storage/docs/containers-storage-exists.md
@@ -1,4 +1,4 @@
-## containers-storage-exists 1 "August 2016"
+# containers-storage-exists 1 "August 2016"
 
 ## NAME
 containers-storage exists - Check if a layer, image, or container exists

--- a/storage/docs/containers-storage-gc.md
+++ b/storage/docs/containers-storage-gc.md
@@ -1,4 +1,4 @@
-## containers-storage-gc 1 "January 2023"
+# containers-storage-gc 1 "January 2023"
 
 ## NAME
 containers-storage gc - Garbage collect leftovers from partial layers/images/containers

--- a/storage/docs/containers-storage-get-container-data-digest.md
+++ b/storage/docs/containers-storage-get-container-data-digest.md
@@ -1,4 +1,4 @@
-## containers-storage-get-container-data-digest 1 "August 2017"
+# containers-storage-get-container-data-digest 1 "August 2017"
 
 ## NAME
 containers-storage get-container-data-digest - Retrieve the digest of a lookaside data item

--- a/storage/docs/containers-storage-get-container-data-size.md
+++ b/storage/docs/containers-storage-get-container-data-size.md
@@ -1,4 +1,4 @@
-## containers-storage-get-container-data-size 1 "August 2017"
+# containers-storage-get-container-data-size 1 "August 2017"
 
 ## NAME
 containers-storage get-container-data-size - Retrieve the size of a lookaside data item

--- a/storage/docs/containers-storage-get-container-data.md
+++ b/storage/docs/containers-storage-get-container-data.md
@@ -1,4 +1,4 @@
-## containers-storage-get-container-data 1 "August 2016"
+# containers-storage-get-container-data 1 "August 2016"
 
 ## NAME
 containers-storage get-container-data - Retrieve lookaside data for a container

--- a/storage/docs/containers-storage-get-container-dir.md
+++ b/storage/docs/containers-storage-get-container-dir.md
@@ -1,4 +1,4 @@
-## containers-storage-get-container-dir 1 "September 2016"
+# containers-storage-get-container-dir 1 "September 2016"
 
 ## NAME
 containers-storage get-container-dir - Find lookaside directory for a container

--- a/storage/docs/containers-storage-get-container-run-dir.md
+++ b/storage/docs/containers-storage-get-container-run-dir.md
@@ -1,4 +1,4 @@
-## containers-storage-get-container-run-dir 1 "September 2016"
+# containers-storage-get-container-run-dir 1 "September 2016"
 
 ## NAME
 containers-storage get-container-run-dir - Find runtime lookaside directory for a container

--- a/storage/docs/containers-storage-get-image-data-digest.md
+++ b/storage/docs/containers-storage-get-image-data-digest.md
@@ -1,4 +1,4 @@
-## containers-storage-get-image-data-digest 1 "August 2017"
+# containers-storage-get-image-data-digest 1 "August 2017"
 
 ## NAME
 containers-storage get-image-data-digest - Retrieve the digest of a lookaside data item

--- a/storage/docs/containers-storage-get-image-data-size.md
+++ b/storage/docs/containers-storage-get-image-data-size.md
@@ -1,4 +1,4 @@
-## containers-storage-get-image-data-size 1 "August 2017"
+# containers-storage-get-image-data-size 1 "August 2017"
 
 ## NAME
 containers-storage get-image-data-size - Retrieve the size of a lookaside data item

--- a/storage/docs/containers-storage-get-image-data.md
+++ b/storage/docs/containers-storage-get-image-data.md
@@ -1,4 +1,4 @@
-## containers-storage-get-image-data 1 "August 2016"
+# containers-storage-get-image-data 1 "August 2016"
 
 ## NAME
 containers-storage get-image-data - Retrieve lookaside data for an image

--- a/storage/docs/containers-storage-get-image-dir.md
+++ b/storage/docs/containers-storage-get-image-dir.md
@@ -1,4 +1,4 @@
-## containers-storage-get-image-dir 1 "January 2024"
+# containers-storage-get-image-dir 1 "January 2024"
 
 ## NAME
 containers-storage get-image-dir - Find lookaside directory for an image

--- a/storage/docs/containers-storage-get-image-run-dir.md
+++ b/storage/docs/containers-storage-get-image-run-dir.md
@@ -1,4 +1,4 @@
-## containers-storage-get-image-run-dir 1 "January 2024"
+# containers-storage-get-image-run-dir 1 "January 2024"
 
 ## NAME
 containers-storage get-image-run-dir - Find runtime lookaside directory for an image

--- a/storage/docs/containers-storage-get-layer-data.md
+++ b/storage/docs/containers-storage-get-layer-data.md
@@ -1,4 +1,4 @@
-## containers-storage-get-layer-data 1 "December 2020"
+# containers-storage-get-layer-data 1 "December 2020"
 
 ## NAME
 containers-storage get-layer-data - Retrieve lookaside data for a layer

--- a/storage/docs/containers-storage-get-names.md
+++ b/storage/docs/containers-storage-get-names.md
@@ -1,4 +1,4 @@
-## containers-storage-get-names 1 "September 2017"
+# containers-storage-get-names 1 "September 2017"
 
 ## NAME
 containers-storage get-names - Get names of a layer/image/container

--- a/storage/docs/containers-storage-image.md
+++ b/storage/docs/containers-storage-image.md
@@ -1,4 +1,4 @@
-## containers-storage-image 1 "August 2016"
+# containers-storage-image 1 "August 2016"
 
 ## NAME
 containers-storage image - Examine a single image

--- a/storage/docs/containers-storage-images-by-digest.md
+++ b/storage/docs/containers-storage-images-by-digest.md
@@ -1,4 +1,4 @@
-## containers-storage-images-by-digest 1 "February 2019"
+# containers-storage-images-by-digest 1 "February 2019"
 
 ## NAME
 containers-storage images-by-digest - List known images by digest

--- a/storage/docs/containers-storage-images.md
+++ b/storage/docs/containers-storage-images.md
@@ -1,4 +1,4 @@
-## containers-storage-images 1 "August 2016"
+# containers-storage-images 1 "August 2016"
 
 ## NAME
 containers-storage images - List known images

--- a/storage/docs/containers-storage-import-layer.md
+++ b/storage/docs/containers-storage-import-layer.md
@@ -1,4 +1,4 @@
-## containers-storage-import-layer 1 "April 2019"
+# containers-storage-import-layer 1 "April 2019"
 
 ## NAME
 containers-storage import-layer - Import files to a new layer

--- a/storage/docs/containers-storage-layer.md
+++ b/storage/docs/containers-storage-layer.md
@@ -1,4 +1,4 @@
-## containers-storage-layer 1 "September 2017"
+# containers-storage-layer 1 "September 2017"
 
 ## NAME
 containers-storage layer - Examine a single layer

--- a/storage/docs/containers-storage-layers.md
+++ b/storage/docs/containers-storage-layers.md
@@ -1,4 +1,4 @@
-## containers-storage-layers 1 "August 2016"
+# containers-storage-layers 1 "August 2016"
 
 ## NAME
 containers-storage layers - List known layers

--- a/storage/docs/containers-storage-list-container-data.md
+++ b/storage/docs/containers-storage-list-container-data.md
@@ -1,4 +1,4 @@
-## containers-storage-list-container-data 1 "August 2016"
+# containers-storage-list-container-data 1 "August 2016"
 
 ## NAME
 containers-storage list-container-data - List lookaside data for a container

--- a/storage/docs/containers-storage-list-image-data.md
+++ b/storage/docs/containers-storage-list-image-data.md
@@ -1,4 +1,4 @@
-## containers-storage-list-image-data 1 "August 2016"
+# containers-storage-list-image-data 1 "August 2016"
 
 ## NAME
 containers-storage list-image-data - List lookaside data for an image

--- a/storage/docs/containers-storage-list-layer-data.md
+++ b/storage/docs/containers-storage-list-layer-data.md
@@ -1,4 +1,4 @@
-## containers-storage-list-layer-data 1 "December 2020"
+# containers-storage-list-layer-data 1 "December 2020"
 
 ## NAME
 containers-storage list-layer-data - List lookaside data for a layer

--- a/storage/docs/containers-storage-metadata.md
+++ b/storage/docs/containers-storage-metadata.md
@@ -1,4 +1,4 @@
-## containers-storage-metadata 1 "August 2016"
+# containers-storage-metadata 1 "August 2016"
 
 ## NAME
 containers-storage metadata - Retrieve metadata for a layer, image, or container

--- a/storage/docs/containers-storage-mount.md
+++ b/storage/docs/containers-storage-mount.md
@@ -1,4 +1,4 @@
-## containers-storage-mount 1 "August 2016"
+# containers-storage-mount 1 "August 2016"
 
 ## NAME
 containers-storage mount - Mount a layer or a container's layer for manipulation

--- a/storage/docs/containers-storage-mounted.md
+++ b/storage/docs/containers-storage-mounted.md
@@ -1,4 +1,4 @@
-## containers-storage-mounted 1 "November 2018"
+# containers-storage-mounted 1 "November 2018"
 
 ## NAME
 containers-storage mounted - Check if a file system is mounted

--- a/storage/docs/containers-storage-remove-names.md
+++ b/storage/docs/containers-storage-remove-names.md
@@ -1,4 +1,4 @@
-## containers-storage-remove-names 1 "January 2023"
+# containers-storage-remove-names 1 "January 2023"
 
 ## NAME
 containers-storage remove-names - Remove names from a layer/image/container

--- a/storage/docs/containers-storage-set-container-data.md
+++ b/storage/docs/containers-storage-set-container-data.md
@@ -1,4 +1,4 @@
-## containers-storage-set-container-data 1 "August 2016"
+# containers-storage-set-container-data 1 "August 2016"
 
 ## NAME
 containers-storage set-container-data - Set lookaside data for a container

--- a/storage/docs/containers-storage-set-image-data.md
+++ b/storage/docs/containers-storage-set-image-data.md
@@ -1,4 +1,4 @@
-## containers-storage-set-image-data 1 "August 2016"
+# containers-storage-set-image-data 1 "August 2016"
 
 ## NAME
 containers-storage set-image-data - Set lookaside data for an image

--- a/storage/docs/containers-storage-set-layer-data.md
+++ b/storage/docs/containers-storage-set-layer-data.md
@@ -1,4 +1,4 @@
-## containers-storage-set-layer-data 1 "December 2020"
+# containers-storage-set-layer-data 1 "December 2020"
 
 ## NAME
 containers-storage set-layer-data - Set lookaside data for a layer

--- a/storage/docs/containers-storage-set-metadata.md
+++ b/storage/docs/containers-storage-set-metadata.md
@@ -1,4 +1,4 @@
-## containers-storage-set-metadata 1 "August 2016"
+# containers-storage-set-metadata 1 "August 2016"
 
 ## NAME
 containers-storage set-metadata - Set metadata for a layer, image, or container

--- a/storage/docs/containers-storage-set-names.md
+++ b/storage/docs/containers-storage-set-names.md
@@ -1,4 +1,4 @@
-## containers-storage-set-names 1 "August 2016"
+# containers-storage-set-names 1 "August 2016"
 
 ## NAME
 containers-storage set-names - Set names for a layer/image/container

--- a/storage/docs/containers-storage-shutdown.md
+++ b/storage/docs/containers-storage-shutdown.md
@@ -1,4 +1,4 @@
-## containers-storage-shutdown 1 "October 2016"
+# containers-storage-shutdown 1 "October 2016"
 
 ## NAME
 containers-storage shutdown - Shut down layer storage

--- a/storage/docs/containers-storage-status.md
+++ b/storage/docs/containers-storage-status.md
@@ -1,4 +1,4 @@
-## containers-storage-status 1 "August 2016"
+# containers-storage-status 1 "August 2016"
 
 ## NAME
 containers-storage status - Output status information from the storage library's driver

--- a/storage/docs/containers-storage-unmount.md
+++ b/storage/docs/containers-storage-unmount.md
@@ -1,4 +1,4 @@
-## containers-storage-unmount 1 "August 2016"
+# containers-storage-unmount 1 "August 2016"
 
 ## NAME
 containers-storage unmount - Unmount a layer or a container's layer

--- a/storage/docs/containers-storage-unshare.md
+++ b/storage/docs/containers-storage-unshare.md
@@ -1,4 +1,4 @@
-## containers-storage-unshare 1 "September 2022"
+# containers-storage-unshare 1 "September 2022"
 
 ## NAME
 containers-storage unshare - Run a command in a user namespace

--- a/storage/docs/containers-storage-version.md
+++ b/storage/docs/containers-storage-version.md
@@ -1,4 +1,4 @@
-## containers-storage-version 1 "August 2016"
+# containers-storage-version 1 "August 2016"
 
 ## NAME
 containers-storage version - Output version information about the storage library

--- a/storage/docs/containers-storage-wipe.md
+++ b/storage/docs/containers-storage-wipe.md
@@ -1,4 +1,4 @@
-## containers-storage-wipe 1 "August 2016"
+# containers-storage-wipe 1 "August 2016"
 
 ## NAME
 containers-storage wipe - Delete all containers, images, and layers

--- a/storage/docs/containers-storage-zstd-chunked.md
+++ b/storage/docs/containers-storage-zstd-chunked.md
@@ -1,4 +1,4 @@
-## containers-storage 1 "August 2024"
+# containers-storage 1 "August 2024"
 
 ## NAME
 containers-storage-zstd-chunked - Information about zstd:chunked

--- a/storage/docs/containers-storage.conf.5.md
+++ b/storage/docs/containers-storage.conf.5.md
@@ -1,9 +1,7 @@
-% containers-storage.conf(5) Container Storage Configuration File
-% Dan Walsh
-% May 2017
+# containers-storage.conf 5 "May 2017"
 
-# NAME
-storage.conf - Syntax of Container Storage configuration file
+## NAME
+containers-storage.conf - Syntax of Container Storage configuration file
 
 ## DESCRIPTION
 The STORAGE configuration file specifies all of the available container storage options for tools using shared container storage, but in a TOML format that can be more easily modified and versioned.

--- a/storage/docs/containers-storage.md
+++ b/storage/docs/containers-storage.md
@@ -1,4 +1,4 @@
-## containers-storage 1 "August 2016"
+# containers-storage 1 "August 2016"
 
 ## NAME
 containers-storage - Manage layer/image/container storage


### PR DESCRIPTION
The containers-storage(1) and many other manual pages were unreadable. These files only have section headings (`##` in Markdown, `.SH` in roff) and lack a title heading (`#`, `.TH`). Fix all of these instances with:

    sed -re '1s/^## (.+)/# \1/' storage/docs/containers-storage*.md -i

containers-storage.conf.5.md was somewhat readable, but was also fixed up for consistency. Remove author info, already present in footer. A similar problem in the common and image docs was ignored.

These manual pages still have some formatting issues, but this resolves the main one. No idea whether this documentation is still up-to-date.

Fixes: https://github.com/containers/container-libs/issues/103
