### PR TITLE
common: abort load on ENOSPC and output clear error

### DIFF
--- a/common/libimage/load.go
+++ b/common/libimage/load.go
@@ -16,6 +16,7 @@ import (
 	"go.podman.io/image/v5/transports"
 	"go.podman.io/image/v5/types"
 	"go.podman.io/storage/pkg/fileutils"
+	"go.podman.io/storage/pkg/chrootarchive"
 )
 
 type LoadOptions struct {
@@ -110,6 +111,13 @@ func (r *Runtime) Load(ctx context.Context, path string, options *LoadOptions) (
 			return loadedImages, err
 		}
 		logrus.Debugf("Error loading %s (%s): %v", path, transportName, err)
+
+		var eDetail *chrootarchive.ErrorDetail 
+
+		if errors.As(err, &eDetail) {
+			return nil, fmt.Errorf("%s", eDetail.Message)
+		}
+		
 		loadErrors = append(loadErrors, fmt.Errorf("%s: %v", transportName, err))
 	}
 

--- a/common/libimage/load.go
+++ b/common/libimage/load.go
@@ -16,7 +16,7 @@ import (
 	"go.podman.io/image/v5/transports"
 	"go.podman.io/image/v5/types"
 	"go.podman.io/storage/pkg/fileutils"
-	"golang.org/x/sys/unix"
+	"go.podman.io/common/pkg/config"
 )
 
 type LoadOptions struct {
@@ -112,7 +112,7 @@ func (r *Runtime) Load(ctx context.Context, path string, options *LoadOptions) (
 		}
 		logrus.Debugf("Error loading %s (%s): %v", path, transportName, err)
 
-		if errors.Is(err, unix.ENOSPC) {
+		if errors.Is(err, config.ErrDiskFull) {
 			// %.0w makes e visible to error.Unwrap() without including any text
 			return nil, fmt.Errorf("no space left on device%.0w", err)
 		}

--- a/common/libimage/load.go
+++ b/common/libimage/load.go
@@ -16,7 +16,7 @@ import (
 	"go.podman.io/image/v5/transports"
 	"go.podman.io/image/v5/types"
 	"go.podman.io/storage/pkg/fileutils"
-	"go.podman.io/storage/pkg/chrootarchive"
+	"golang.org/x/sys/unix"
 )
 
 type LoadOptions struct {
@@ -112,12 +112,11 @@ func (r *Runtime) Load(ctx context.Context, path string, options *LoadOptions) (
 		}
 		logrus.Debugf("Error loading %s (%s): %v", path, transportName, err)
 
-		var eDetail *chrootarchive.ErrorDetail 
-
-		if errors.As(err, &eDetail) {
-			return nil, fmt.Errorf("%s", eDetail.Message)
+		if errors.Is(err, unix.ENOSPC) {
+			// %.0w makes e visible to error.Unwrap() without including any text
+			return nil, fmt.Errorf("no space left on device%.0w", err)
 		}
-		
+
 		loadErrors = append(loadErrors, fmt.Errorf("%s: %v", transportName, err))
 	}
 

--- a/common/pkg/config/config_unix.go
+++ b/common/pkg/config/config_unix.go
@@ -4,7 +4,10 @@ package config
 
 import (
 	"path/filepath"
+	"golang.org/x/sys/unix"
 )
+
+var ErrDiskFull = unix.ENOSPC
 
 func safeEvalSymlinks(filePath string) (string, error) {
 	return filepath.EvalSymlinks(filePath)

--- a/common/pkg/config/config_windows.go
+++ b/common/pkg/config/config_windows.go
@@ -3,8 +3,11 @@ package config
 import (
 	"io/fs"
 	"os"
+	"syscall"
 	"path/filepath"
 )
+
+var ErrDiskFull = syscall.Errno(112)
 
 const (
 	// DefaultSignaturePolicyPath is the default value for the

--- a/storage/pkg/chrootarchive/archive_unix.go
+++ b/storage/pkg/chrootarchive/archive_unix.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -82,6 +83,10 @@ func untar() {
 	}
 
 	if err := archive.Unpack(os.Stdin, dst, &options); err != nil {
+		if errors.Is(err, unix.ENOSPC) {
+			fmt.Fprint(os.Stderr, err)
+			os.Exit(int(unix.ENOSPC))
+		}
 		fatal(err)
 	}
 	// fully consume stdin in case it is zero padded
@@ -155,6 +160,20 @@ func invokeUnpack(decompressedArchive io.Reader, dest *unpackDestination, option
 	w.Close()
 
 	if err := cmd.Wait(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			exitCode := exitErr.ExitCode()
+			if exitCode == int(unix.ENOSPC) {
+				procPath := fmt.Sprintf("/proc/self/fd/%d", dest.root.Fd())
+
+				path, err := os.Readlink(procPath)
+
+				if err == nil {
+					fmt.Fprintf(os.Stderr, "no space left on device: %s\n", path)
+					os.Exit(28)
+				}
+			}
+		}
+
 		errorOut := fmt.Errorf("unpacking failed (error: %w; output: %s)", err, output)
 		// when `xz -d -c -q | storage-untar ...` failed on storage-untar side,
 		// we need to exhaust `xz`'s output, otherwise the `xz` side will be

--- a/storage/pkg/chrootarchive/archive_unix.go
+++ b/storage/pkg/chrootarchive/archive_unix.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -24,6 +23,15 @@ import (
 type unpackDestination struct {
 	root *os.File
 	dest string
+}
+
+type ErrorDetail struct {
+	Message string `json:"message"`
+	Errno   int    `json:"errno"`
+}
+
+func (e *ErrorDetail) Error() string {
+	return fmt.Sprintf("errno %d: %s", e.Errno, e.Message)
 }
 
 func (dst *unpackDestination) Close() error {
@@ -84,8 +92,12 @@ func untar() {
 
 	if err := archive.Unpack(os.Stdin, dst, &options); err != nil {
 		if errors.Is(err, unix.ENOSPC) {
-			fmt.Fprint(os.Stderr, err)
-			os.Exit(int(unix.ENOSPC))
+			enospcLog := ErrorDetail{
+				Message: "no space left on device",
+				Errno: int(unix.ENOSPC),
+			}
+			json.NewEncoder(os.Stderr).Encode(enospcLog)
+			os.Exit(1)
 		}
 		fatal(err)
 	}
@@ -160,17 +172,11 @@ func invokeUnpack(decompressedArchive io.Reader, dest *unpackDestination, option
 	w.Close()
 
 	if err := cmd.Wait(); err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			exitCode := exitErr.ExitCode()
-			if exitCode == int(unix.ENOSPC) {
-				procPath := fmt.Sprintf("/proc/self/fd/%d", dest.root.Fd())
+		var eDetail ErrorDetail
 
-				path, err := os.Readlink(procPath)
-
-				if err == nil {
-					fmt.Fprintf(os.Stderr, "no space left on device: %s\n", path)
-					os.Exit(28)
-				}
+		if json.Unmarshal(output.Bytes(), &eDetail) == nil {
+			if eDetail.Errno == int(unix.ENOSPC) {
+				return fmt.Errorf("%w", &eDetail)
 			}
 		}
 

--- a/storage/pkg/chrootarchive/archive_unix.go
+++ b/storage/pkg/chrootarchive/archive_unix.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -23,15 +24,6 @@ import (
 type unpackDestination struct {
 	root *os.File
 	dest string
-}
-
-type ErrorDetail struct {
-	Message string `json:"message"`
-	Errno   int    `json:"errno"`
-}
-
-func (e *ErrorDetail) Error() string {
-	return fmt.Sprintf("errno %d: %s", e.Errno, e.Message)
 }
 
 func (dst *unpackDestination) Close() error {
@@ -92,12 +84,7 @@ func untar() {
 
 	if err := archive.Unpack(os.Stdin, dst, &options); err != nil {
 		if errors.Is(err, unix.ENOSPC) {
-			enospcLog := ErrorDetail{
-				Message: "no space left on device",
-				Errno: int(unix.ENOSPC),
-			}
-			json.NewEncoder(os.Stderr).Encode(enospcLog)
-			os.Exit(1)
+			os.Exit(2)
 		}
 		fatal(err)
 	}
@@ -172,11 +159,10 @@ func invokeUnpack(decompressedArchive io.Reader, dest *unpackDestination, option
 	w.Close()
 
 	if err := cmd.Wait(); err != nil {
-		var eDetail ErrorDetail
-
-		if json.Unmarshal(output.Bytes(), &eDetail) == nil {
-			if eDetail.Errno == int(unix.ENOSPC) {
-				return fmt.Errorf("%w", &eDetail)
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			status := exitErr.ExitCode()
+			if status == 2 {
+				return unix.ENOSPC
 			}
 		}
 


### PR DESCRIPTION
Fix: containers/podman#26197

When loading images, exit archive checks when receiving ENOSPC error, and display a clearer exit message for the user.


tests for podman at: https://github.com/containers/podman/pull/27374
