### PR TITLE
common: add support for `default_host_ips` in containers.conf

### DIFF
--- a/common/docs/containers.conf.5.md
+++ b/common/docs/containers.conf.5.md
@@ -525,6 +525,17 @@ run on the machine.
 A list of default pasta options that should be used running pasta.
 It accepts the pasta cli options, see pasta(1) for the full list of options.
 
+**default_host_ips**=[]
+
+The default host IPs to bind published container ports to when no host IP
+is explicitly specified in the `-p` flag (e.g., `-p 8000:8000`). If empty, the default
+behavior is to bind to all network interfaces (`0.0.0.0` for IPv4 and `::` for IPv6). If multiple IPs are specified,
+separate port mapping for each of the specified IP would be created. For instance, setting
+this to `["127.0.0.1", "::1"]` and port specified as `-p 8080:80` will result into two
+port mappings in podman, `127.0.0.1:8080:80` and `[::1]:8080:80`.
+Note that explicitly specifying a host IP in the `-p` flag (e.g., `-p 192.168.1.10:8000:8000`)
+will always override this default.
+
 ## ENGINE TABLE
 The `engine` table contains configuration options used to set up container engines such as Podman and Buildah.
 

--- a/common/pkg/config/config.go
+++ b/common/pkg/config/config.go
@@ -631,6 +631,13 @@ type NetworkConfig struct {
 	// PastaOptions contains a default list of pasta(1) options that should
 	// be used when running pasta.
 	PastaOptions attributedstring.Slice `toml:"pasta_options,omitempty"`
+
+	// DefaultHostIPs is the default host IPs to bind published container ports
+	// to when no host IP is explicitly specified in the -p flag (e.g., -p 80:80).
+	// If empty, the default behavior is to bind to all interfaces (0.0.0.0).
+	// If multiple IPs are specified, separate port mapping for each of the specified
+	// IP would be created.
+	DefaultHostIPs attributedstring.Slice `toml:"default_host_ips,omitempty"`
 }
 
 type SubnetPool struct {

--- a/common/pkg/config/config_local_test.go
+++ b/common/pkg/config/config_local_test.go
@@ -142,6 +142,18 @@ var _ = Describe("Config Local", func() {
 		gomega.Expect(config2.Network.PastaOptions.Get()).To(gomega.Equal([]string{"-t", "auto"}))
 	})
 
+	It("parse default_host_ips", func() {
+		// Given
+		config, err := newLocked(&Options{}, testConfigPath(""))
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		gomega.Expect(config.Network.DefaultHostIPs.Get()).To(gomega.BeEmpty())
+		// When
+		config2, err := newLocked(&Options{}, testConfigPath("testdata/containers_default.conf"))
+		// Then
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		gomega.Expect(config2.Network.DefaultHostIPs.Get()).To(gomega.Equal([]string{"127.0.0.1", "::1"}))
+	})
+
 	It("parse default_rootless_network_cmd", func() {
 		// Given
 		config, err := newLocked(&Options{}, testConfigPath(""))

--- a/common/pkg/config/containers.conf
+++ b/common/pkg/config/containers.conf
@@ -445,6 +445,16 @@ default_sysctls = [
 #
 #pasta_options = []
 
+# The default host IPs to bind published container ports to when no host IP
+# is explicitly specified in the -p flag (e.g., -p 8000:8000). If empty, the default
+# behavior is to bind to all network interfaces (0.0.0.0). If multiple IPs are specified,
+# separate port mapping for each of the specified IP would be created. For instance, setting
+# this to ["127.0.0.1", "::1"] and port specified as -p 8080:80 will result into two
+# port mappings in podman--127.0.0.1:8080:80 and [::1]:8080:80.
+# Note that explicitly specifying a host IP via -p will always override this.
+#
+#default_host_ips = []
+
 [engine]
 # Index to the active service
 #

--- a/common/pkg/config/containers.conf-freebsd
+++ b/common/pkg/config/containers.conf-freebsd
@@ -335,6 +335,16 @@ default_sysctls = [
 #
 #network_config_dir = "/usr/local/etc/cni/net.d/"
 
+# The default host IPs to bind published container ports to when no host IP
+# is explicitly specified in the -p flag (e.g., -p 8000:8000). If empty, the default
+# behavior is to bind to all network interfaces (0.0.0.0). If multiple IPs are specified,
+# separate port mapping for each of the specified IP would be created. For instance, setting
+# this to ["127.0.0.1", "::1"] and port specified as -p 8080:80 will result into two
+# port mappings in podman--127.0.0.1:8080:80 and [::1]:8080:80.
+# Note that explicitly specifying a host IP via -p will always override this.
+#
+#default_host_ips = []
+
 [engine]
 # Index to the active service
 #

--- a/common/pkg/config/testdata/containers_default.conf
+++ b/common/pkg/config/testdata/containers_default.conf
@@ -140,6 +140,8 @@ netavark_plugin_dirs = [
 
 pasta_options = ["-t", "auto"]
 
+default_host_ips = ["127.0.0.1", "::1"]
+
 [engine]
 
 add_compression = ["zstd", "zstd:chunked"]


### PR DESCRIPTION
This adds support for configuring a default host IP via containers.conf to bind published container ports to when no host IP is explicitly specified (e.g. -p 8000:8000). Note that explicit host IP still overrides the default option set in containers.conf.

Refers https://github.com/containers/podman/issues/27186

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
