### PR TITLE
docs: Clarify that container signatures expect a single signature packet

### DIFF
--- a/image/docs/containers-signature.5.md
+++ b/image/docs/containers-signature.5.md
@@ -67,10 +67,11 @@ When verifying a cryptographic signature in the OpenPGP format,
 the consumer MUST verify at least the following aspects of the signature
 (like the `go.podman.io/image/v5/signature` package does):
 
-- The blob MUST be a “Signed Message” as defined RFC 4880 section 11.3.
+- The blob MUST be a “Signed Message” as defined in RFC 4880 section 11.3.
   (e.g. it MUST NOT be an unsigned “Literal Message”,
   a “Cleartext Signature” as defined in RFC 4880 section 7,
   or any other non-signature format).
+- The blob MUST NOT contain more than one "Signature Packet" as defined in RFC 4880 section 5.2.
 - The signature MUST have been made by an expected key trusted for the purpose (and the specific container image).
 - The signature MUST be correctly formed and pass the cryptographic validation.
 - The signature MUST correctly authenticate the included JSON payload


### PR DESCRIPTION
Clarify that OpenPGP container signatures are expected to contain a single signature packet.

This clarification is necessary because, according to RFC 4880, a "Signed Message" may contain a sequence of signature packets. This case might not be correctly handled by the existing verification software.

More info on this on this PR in #423
