### PR TITLE
Possible lint fix for platform.go

### DIFF
--- a/common/libimage/platform.go
+++ b/common/libimage/platform.go
@@ -8,14 +8,17 @@ import (
 )
 
 // PlatformPolicy controls the behavior of image-platform matching.
+//
 // Deprecated: new code should use define.PlatformPolicy directly.
 type PlatformPolicy = define.PlatformPolicy
 
 const (
 	// Only debug log if an image does not match the expected platform.
+	//
 	// Deprecated: new code should reference define.PlatformPolicyDefault directly.
 	PlatformPolicyDefault = define.PlatformPolicyDefault
 	// Warn if an image does not match the expected platform.
+	//
 	// Deprecated: new code should reference define.PlatformPolicyWarn directly.
 	PlatformPolicyWarn = define.PlatformPolicyWarn
 )


### PR DESCRIPTION
This PR: https://github.com/containers/container-libs/pull/425 was barking about deprecation notices not being properly setup.  I think this cures it.  I just made the "Deprecation" comment be the leading line of the comment.

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
