### PR TITLE
Packit: Do not notify on podman-next copr build failure

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -61,9 +61,6 @@ jobs:
   - job: copr_build
     trigger: commit
     packages: [containers-common-fedora]
-    notifications:
-      failure_comment:
-        message: "podman-next COPR build failed. @containers/packit-build please check."
     branch: main
     owner: rhcontainerbot
     project: podman-next


### PR DESCRIPTION
These happen after commit to upstream and don't affect upstream.

These notifications only end up adding unnecessary noise.

Overall build failures can happen for a variety of reasons like copr infra, outdated toolchain on some environments etc.

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->

See also: https://github.com/containers/skopeo/pull/2741