### PR TITLE
storage.conf-freebsd: fix typo

### DIFF
--- a/storage/storage.conf-freebsd
+++ b/storage/storage.conf-freebsd
@@ -50,7 +50,7 @@ additionalimagestores = [
 # Auto-userns-min-size is the minimum size for a user namespace created automatically.
 # auto-userns-min-size=1024
 #
-# Auto-userns-max-size is the minimum size for a user namespace created automatically.
+# Auto-userns-max-size is the maximum size for a user namespace created automatically.
 # auto-userns-max-size=65536
 
 [storage.options.overlay]


### PR DESCRIPTION
This fix will match how it's written elsewhere
```
$ git grep  "Auto-userns-max-size is the maximum size" main
main:storage/docs/containers-storage.conf.5.md:  Auto-userns-max-size is the maximum size for a user namespace created automatically.
main:storage/storage.conf:# Auto-userns-max-size is the maximum size for a user namespace created automatically.
```