### PR TITLE
image: add copyright notice to sequoia wrappers

### DIFF
--- a/image/signature/internal/sequoia/gosequoia.c
+++ b/image/signature/internal/sequoia/gosequoia.c
@@ -1,8 +1,12 @@
 /*
- * Copying and distribution of this file, with or without modification,
- * are permitted in any medium without royalty provided the copyright
- * notice and this notice are preserved.  This file is offered as-is,
- * without any warranty.
+ * SPDX-License-Identifier: Apache-2.0 OR FSFAP
+ * SPDX-FileCopyrightText: 2025 Daiki Ueno
+ *
+ * You can redistribute and/or modify this file under the terms of either
+ * Apache License 2.0 (https://www.apache.org/licenses/LICENSE-2.0.html), or
+ * FSF All Permissive License
+ * (https://www.gnu.org/prep/maintain/html_node/License-Notices-for-Other-Files.html),
+ * or both in parallel, as here.
  */
 
 #ifdef HAVE_CONFIG_H

--- a/image/signature/internal/sequoia/gosequoia.h
+++ b/image/signature/internal/sequoia/gosequoia.h
@@ -1,8 +1,12 @@
 /*
- * Copying and distribution of this file, with or without modification,
- * are permitted in any medium without royalty provided the copyright
- * notice and this notice are preserved.  This file is offered as-is,
- * without any warranty.
+ * SPDX-License-Identifier: Apache-2.0 OR FSFAP
+ * SPDX-FileCopyrightText: 2025 Daiki Ueno
+ *
+ * You can redistribute and/or modify this file under the terms of either
+ * Apache License 2.0 (https://www.apache.org/licenses/LICENSE-2.0.html), or
+ * FSF All Permissive License
+ * (https://www.gnu.org/prep/maintain/html_node/License-Notices-for-Other-Files.html),
+ * or both in parallel, as here.
  */
 
 #ifndef GO_SEQUOIA_H_


### PR DESCRIPTION
These wrapper files are generated using dlwrap, licensed under "Apache-2.0 OR FSFAP". Given myself is the sole author of the tool, and the generated files do not include any information derived from the original C headers, I'm adding copyright notice of myself.

Fixes: #472 
<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
