### PR TITLE
common: change default macOS machine provider to libkrun

### DIFF
--- a/common/docs/containers.conf.5.md
+++ b/common/docs/containers.conf.5.md
@@ -1031,7 +1031,7 @@ is interpreted as the default provider for the current host OS.
 | -------- | --------------------------------------- | -------- |
 | Linux    | "" (qemu)                               | None     |
 | Windows  | "" ("wsl": Windows Subsystem for Linux) | "hyperv" (Windows Server Virtualization) |
-| Mac      | "" ("applehv": Apple Hypervisor)        | "libkrun" (Launch machine via libkrun platform, optimized for sharing GPU with the machine) |
+| Mac      | "" ("libkrun": Launch machine via libkrun platform, optimized for sharing GPU with the machine) | "applehv" (Apple Hypervisor) |
 
 
 **rosetta**="true"

--- a/common/pkg/config/containers.conf
+++ b/common/pkg/config/containers.conf
@@ -937,9 +937,9 @@ default_sysctls = [
 #    wsl     - Windows Subsystem for Linux (Default)
 #    hyperv  - Windows Server Virtualization
 # Mac: there are currently two options:
-#    applehv - Default Apple Hypervisor (Default)
 #    libkrun - Launch virtual machines using the libkrun platform, optimized
-#              for sharing GPU with the machine.
+#              for sharing GPU with the machine. (Default)
+#    applehv - Launch virtual machines using the vfkit platform.
 #provider = ""
 
 # Rosetta supports running x86_64 Linux binaries on a Podman machine on Apple silicon.


### PR DESCRIPTION
Update the docs and containers.conf comments to identify libkrun as the default macOS machine provider.

Related to: https://github.com/containers/podman/pull/27546

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
