### PR TITLE
Do not block try lock on state mutex

### DIFF
--- a/storage/pkg/lockfile/lockfile.go
+++ b/storage/pkg/lockfile/lockfile.go
@@ -420,7 +420,10 @@ func (l *LockFile) tryLock(lType rawfilelock.LockType) error {
 	if !success {
 		return fmt.Errorf("resource temporarily unavailable")
 	}
-	l.stateMutex.Lock()
+	if !l.stateMutex.TryLock() {
+		rwMutexUnlocker()
+		return fmt.Errorf("resource temporarily unavailable")
+	}
 	defer l.stateMutex.Unlock()
 	if l.counter == 0 {
 		// If we're the first reference on the lock, we need to open the file again.


### PR DESCRIPTION
TryLock should not block when file lock is held by other process and
state lock is held by other coroutine which waits for file lock.

Signed-off-by: Konstantin Khlebnikov <koct9i@gmail.com>
