### PR TITLE
Add a DefaultNetwork field to NetworkInfo

### DIFF
--- a/common/libnetwork/cni/network.go
+++ b/common/libnetwork/cni/network.go
@@ -327,9 +327,10 @@ func (n *cniNetwork) NetworkInfo() types.NetworkInfo {
 	}
 
 	info := types.NetworkInfo{
-		Backend: types.CNI,
-		Package: packageVersion,
-		Path:    path,
+		Backend:        types.CNI,
+		Package:        packageVersion,
+		Path:           path,
+		DefaultNetwork: n.defaultNetwork,
 	}
 
 	dnsPath := filepath.Join(path, "dnsname")

--- a/common/libnetwork/netavark/network.go
+++ b/common/libnetwork/netavark/network.go
@@ -369,10 +369,11 @@ func (n *netavarkNetwork) NetworkInfo() types.NetworkInfo {
 		logrus.Infof("Failed to get the netavark version: %v", err)
 	}
 	info := types.NetworkInfo{
-		Backend: types.Netavark,
-		Version: programVersion,
-		Package: packageVersion,
-		Path:    path,
+		Backend:        types.Netavark,
+		Version:        programVersion,
+		Package:        packageVersion,
+		Path:           path,
+		DefaultNetwork: n.defaultNetwork,
 	}
 
 	dnsPath := n.aardvarkBinary

--- a/common/libnetwork/types/network.go
+++ b/common/libnetwork/types/network.go
@@ -97,11 +97,12 @@ type NetworkUpdateOptions struct {
 
 // NetworkInfo contains the network information.
 type NetworkInfo struct {
-	Backend NetworkBackend `json:"backend"`
-	Version string         `json:"version,omitempty"`
-	Package string         `json:"package,omitempty"`
-	Path    string         `json:"path,omitempty"`
-	DNS     DNSNetworkInfo `json:"dns,omitempty"`
+	Backend        NetworkBackend `json:"backend"`
+	Version        string         `json:"version,omitempty"`
+	Package        string         `json:"package,omitempty"`
+	Path           string         `json:"path,omitempty"`
+	DNS            DNSNetworkInfo `json:"dns,omitempty"`
+	DefaultNetwork string         `json:"default_network,omitempty"`
 }
 
 // DNSNetworkInfo contains the DNS information.


### PR DESCRIPTION
<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->

containers/podman#27580

To address this issue, we added the DefaultNetwork field to the NetworkInfo structure.