### PR TITLE
Use $BINDIR as the default helper binary directory on Windows

### DIFF
--- a/common/pkg/config/config_windows.go
+++ b/common/pkg/config/config_windows.go
@@ -31,5 +31,7 @@ func overrideContainersConfigPath() (string, error) {
 }
 
 var defaultHelperBinariesDir = []string{
-	"C:\\Program Files\\RedHat\\Podman",
+	// FindHelperBinaries(), as a convention, interprets $BINDIR as the
+	// directory where the current process binary (i.e. podman) is located.
+	"$BINDIR",
 }


### PR DESCRIPTION
The default helper binary directory on Windows was hardcoded. However the new user-scope installer deploys the binaries on a distinct directory. As a consequence `podman machine start` fails because gvproxy/winssh-proxy cannot be found.

This problem affects Hyper-V, not WSL.

In this fix we changed default to `$BINDIR` that is interpreted by `FindHelperBinaries()` as the directory where podman is located.

Fixes https://github.com/containers/podman/issues/27603

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
