### PR TITLE
[sha512] image/manifest: Add `DigestWithAlgorithm` function

### DIFF
--- a/image/internal/manifest/manifest.go
+++ b/image/internal/manifest/manifest.go
@@ -107,9 +107,16 @@ func GuessMIMEType(manifest []byte) string {
 	return ""
 }
 
-// Digest returns the a digest of a docker manifest, with any necessary implied transformations like stripping v1s1 signatures.
+// Digest returns the digest of a docker manifest, with any necessary implied transformations like stripping v1s1 signatures.
 // This is publicly visible as c/image/manifest.Digest.
 func Digest(manifest []byte) (digest.Digest, error) {
+	return DigestWithAlgorithm(manifest, digest.Canonical)
+}
+
+// DigestWithAlgorithm returns the digest of a docker manifest using the specified algorithm,
+// with any necessary implied transformations like stripping v1s1 signatures.
+// This is publicly visible as c/image/manifest.DigestWithAlgorithm.
+func DigestWithAlgorithm(manifest []byte, algo digest.Algorithm) (digest.Digest, error) {
 	if GuessMIMEType(manifest) == DockerV2Schema1SignedMediaType {
 		sig, err := libtrust.ParsePrettySignature(manifest, "signatures")
 		if err != nil {
@@ -122,8 +129,7 @@ func Digest(manifest []byte) (digest.Digest, error) {
 			return "", err
 		}
 	}
-
-	return digest.FromBytes(manifest), nil
+	return algo.FromBytes(manifest), nil
 }
 
 // MatchesDigest returns true iff the manifest matches expectedDigest.

--- a/image/manifest/manifest.go
+++ b/image/manifest/manifest.go
@@ -113,6 +113,12 @@ func Digest(manifestBlob []byte) (digest.Digest, error) {
 	return manifest.Digest(manifestBlob)
 }
 
+// DigestWithAlgorithm returns the digest of a docker manifest using the specified algorithm,
+// with any necessary implied transformations like stripping v1s1 signatures.
+func DigestWithAlgorithm(manifestBlob []byte, algo digest.Algorithm) (digest.Digest, error) {
+	return manifest.DigestWithAlgorithm(manifestBlob, algo)
+}
+
 // MatchesDigest returns true iff the manifest matches expectedDigest.
 // Error may be set if this returns false.
 // Note that this is not doing ConstantTimeCompare; by the time we get here, the cryptographic signature must already have been verified,


### PR DESCRIPTION
Add a new `manifest.DigestWithAlgorithm` function that
allows computing the digest of a manifest using a specified algorithm
(e.g., SHA256, SHA512) while properly handling v2s1 signed manifest
signature stripping.
    
This addresses the need for skopeo's `--manifest-digest` flag to support
different digest algorithms while correctly handling all manifest types,
particularly Docker v2s1 signed manifests that require signature
stripping before digest computation.


<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->

Note: Currently rebased on #475 .