### PR TITLE
storage: Cleanup manpage formatting

### DIFF
--- a/storage/docs/containers-storage-add-names.md
+++ b/storage/docs/containers-storage-add-names.md
@@ -1,7 +1,7 @@
 # containers-storage-add-names 1 "August 2016"
 
 ## NAME
-containers-storage add-names - Add names to a layer/image/container
+containers-storage-add-names - Add names to a layer/image/container
 
 ## SYNOPSIS
 **containers-storage** **add-names** [*options* [...]] *layerOrImageOrContainerNameOrID*
@@ -19,7 +19,13 @@ is already used by another layer, image, or container, it is removed from that
 other layer, image, or container.
 
 ## EXAMPLE
-**containers-storage add-names -n my-awesome-container -n my-for-realsies-awesome-container f3be6c6134d0d980936b4c894f1613b69a62b79588fdeda744d0be3693bde8ec**
+
+```
+containers-storage add-names \
+ -n my-awesome-container \
+ -n my-for-realsies-awesome-container \
+ f3be6c6134d0d980936b4c894f1613b69a62b79588fdeda744d0be3693bde8ec
+```
 
 ## SEE ALSO
 containers-storage-get-names(1)

--- a/storage/docs/containers-storage-applydiff-using-staging-dir.md
+++ b/storage/docs/containers-storage-applydiff-using-staging-dir.md
@@ -1,7 +1,7 @@
 # containers-storage-applydiff-using-staging-dir 1 "September 2023"
 
 ## NAME
-containers-storage applydiff-using-staging-dir - Apply a layer diff to a layer using a staging directory
+containers-storage-applydiff-using-staging-dir - Apply a layer diff to a layer using a staging directory
 
 ## SYNOPSIS
 **containers-storage** **applydiff-using-staging-dir** *layerNameOrID* *source*
@@ -18,7 +18,9 @@ Differently than **apply-diff**, the command **applydiff-using-staging-dir**
 first creates a staging directory and then moves the final result to the destination.
 
 ## EXAMPLE
-**containers-storage applydiff-using-staging-dir 5891b5b522 /path/to/diff**
+```
+containers-storage applydiff-using-staging-dir 5891b5b522 /path/to/diff
+```
 
 ## SEE ALSO
 containers-storage-apply-diff(1)

--- a/storage/docs/containers-storage-applydiff.md
+++ b/storage/docs/containers-storage-applydiff.md
@@ -1,7 +1,7 @@
 # containers-storage-apply-diff 1 "August 2016"
 
 ## NAME
-containers-storage apply-diff - Apply a layer diff to a layer
+containers-storage-apply-diff - Apply a layer diff to a layer
 
 ## SYNOPSIS
 **containers-storage** **apply-diff** [*options* [...]] *layerNameOrID* [*referenceLayerNameOrID*]
@@ -24,7 +24,8 @@ Specifies the name of a file from which the diff should be read.  If this
 option is not used, the diff is read from standard input.
 
 ## EXAMPLE
-**containers-storage apply-diff -f 71841c97e320d6cde.tar.gz layer1**
+
+    containers-storage apply-diff -f 71841c97e320d6cde.tar.gz layer1
 
 ## SEE ALSO
 containers-storage-changes(1)

--- a/storage/docs/containers-storage-changes.md
+++ b/storage/docs/containers-storage-changes.md
@@ -1,7 +1,7 @@
 # containers-storage-changes 1 "August 2016"
 
 ## NAME
-containers-storage changes - Produce a list of changes in a layer
+containers-storage-changes - Produce a list of changes in a layer
 
 ## SYNOPSIS
 **containers-storage** **changes** *layerNameOrID* [*referenceLayerNameOrID*]
@@ -13,7 +13,8 @@ obtain a summary of which files have been added, deleted, or modified in the
 layer.
 
 ## EXAMPLE
-**containers-storage changes f3be6c6134d0d980936b4c894f1613b69a62b79588fdeda744d0be3693bde8ec**
+
+    containers-storage changes f3be6c6134d0d980936b4c894f1613b69a62b79588fdeda744d0be3693bde8ec
 
 ## SEE ALSO
 containers-storage-applydiff(1)

--- a/storage/docs/containers-storage-check.md
+++ b/storage/docs/containers-storage-check.md
@@ -1,7 +1,7 @@
 # containers-storage-check 1 "September 2022"
 
 ## NAME
-containers-storage check - Check for and remove damaged layers/images/containers
+containers-storage-check - Check for and remove damaged layers/images/containers
 
 ## SYNOPSIS
 **containers-storage** **check** [-q] [-r [-f]]
@@ -28,7 +28,8 @@ currently skips verifying that a layer which was initialized using a diff can
 reproduce that diff if asked to.
 
 ## EXAMPLE
-**containers-storage check -r -f
+
+    containers-storage check -r -f
 
 ## SEE ALSO
 containers-storage(1)

--- a/storage/docs/containers-storage-composefs.md
+++ b/storage/docs/containers-storage-composefs.md
@@ -15,7 +15,8 @@ use_composefs = "true"
 This value must be a "string bool", it cannot be a native TOML boolean.
 
 However at the current time, composefs requires zstd:chunked images, so first
-you must be sure that zstd:chunked is enabled. For more, see [zstd:chunked](containers-storage-zstd-chunked.md).
+you must be sure that zstd:chunked is enabled.
+For more, see [zstd:chunked](containers-storage-zstd-chunked.md).
 
 Additionally, not many images are in zstd:chunked format. In order to bridge this gap,
 `convert_images = "true"` can be specified which does a dynamic conversion; this adds
@@ -37,10 +38,12 @@ is implemented as an "option" for the `overlay` driver. Some file formats
 remain unchanged and are inherited from the overlay driver, even when
 composefs is in use. The primary differences are enumerated below.
 
-The `diff/` directory for each layer is no longer a plain unpacking of the tarball,
-but becomes an "object hash directory", where each filename is the sha256 of its contents. This `diff/`
-directory is the backing store for a `composefs-data/composefs.blob` created for
-each layer which is the composefs "superblock" containing all the non-regular-file content (i.e. metadata) from the tarball.
+The `diff/` directory for each layer is no longer a plain unpacking of the
+tarball, but becomes an "object hash directory", where each filename is the
+sha256 of its contents. This `diff/` directory is the backing store for a
+`composefs-data/composefs.blob` created for each layer which is the composefs
+"superblock" containing all the non-regular-file content (i.e. metadata) from
+the tarball.
 
 As with `zstd:chunked`, existing layers are scanned for matching objects, and reused
 (via hardlink or reflink as configured) if objects with a matching "full sha256" are
@@ -59,7 +62,7 @@ in the "default overlay" (unpacked) format will be reused as is.
 
 ## BUGS
 
-- https://github.com/containers/storage/issues?q=is%3Aissue+is%3Aopen+label%3Aarea%2Fcomposefs
+https://github.com/containers/storage/issues?q=is%3Aissue+is%3Aopen+label%3Aarea%2Fcomposefs
 
 ## FOOTNOTES
 The Containers Storage project is committed to inclusivity, a core value of open source.

--- a/storage/docs/containers-storage-config.md
+++ b/storage/docs/containers-storage-config.md
@@ -1,7 +1,7 @@
 # containers-storage-config 1 "November 2024"
 
 ## NAME
-containers-storage config - Output the configuration for the storage library
+containers-storage-config - Output the configuration for the storage library
 
 ## SYNOPSIS
 **containers-storage** **config** [configurationFile]
@@ -12,7 +12,9 @@ current configuration with the contents of a specified configuration file
 loaded in, in a JSON format.
 
 ## EXAMPLE
-**containers-storage config**
+
+    containers-storage config
+
 
 ## SEE ALSO
 containers-storage-version(1)

--- a/storage/docs/containers-storage-container.md
+++ b/storage/docs/containers-storage-container.md
@@ -1,7 +1,7 @@
 # containers-storage-container 1 "August 2016"
 
 ## NAME
-containers-storage container - Examine a single container
+containers-storage-container - Examine a single container
 
 ## SYNOPSIS
 **containers-storage** **container** *containerNameOrID*
@@ -11,8 +11,9 @@ Retrieve information about a container: any names it has, which image was used
 to create it, any names that image has, and the ID of the container's layer.
 
 ## EXAMPLE
-**containers-storage container f3be6c6134d0d980936b4c894f1613b69a62b79588fdeda744d0be3693bde8ec**
-**containers-storage container my-awesome-container**
+
+    containers-storage container f3be6c6134d0d980936b4c894f1613b69a62b79588fdeda744d0be3693bde8ec
+    containers-storage container my-awesome-container
 
 ## SEE ALSO
 containers-storage-containers(1)

--- a/storage/docs/containers-storage-containers.md
+++ b/storage/docs/containers-storage-containers.md
@@ -1,7 +1,7 @@
 # containers-storage-containers 1 "August 2016"
 
 ## NAME
-containers-storage containers - List known containers
+containers-storage-containers - List known containers
 
 ## SYNOPSIS
 **containers-storage** **containers**
@@ -10,7 +10,8 @@ containers-storage containers - List known containers
 Retrieves information about all known containers and lists their IDs and names.
 
 ## EXAMPLE
-**containers-storage containers**
+
+    containers-storage containers
 
 ## SEE ALSO
 containers-storage-container(1)

--- a/storage/docs/containers-storage-copy.md
+++ b/storage/docs/containers-storage-copy.md
@@ -1,7 +1,7 @@
 # containers-storage-copy 1 "April 2018"
 
 ## NAME
-containers-storage copy - Copy content into a layer
+containers-storage-copy - Copy content into a layer
 
 ## SYNOPSIS
 **containers-storage** **copy** [--chown UID[:GID]] [*sourceLayerNameOrID*:]/path [...] *targetLayerNameOrID*:/path
@@ -17,7 +17,8 @@ specified, the UID is used.  The owner IDs are mapped as appropriate for the
 target layer.
 
 ## EXAMPLE
-**containers-storage copy layer-with-mapping:/root/config.txt layer-with-different-mapping:/root/config.txt**
+
+    containers-storage copy layer-with-mapping:/root/config.txt layer-with-different-mapping:/root/config.txt
 
 ## SEE ALSO
 containers-storage(1)

--- a/storage/docs/containers-storage-create-container.md
+++ b/storage/docs/containers-storage-create-container.md
@@ -1,7 +1,7 @@
 # containers-storage-create-container 1 "August 2016"
 
 ## NAME
-containers-storage create-container - Create a container
+containers-storage-create-container - Create a container
 
 ## SYNOPSIS
 **containers-storage** **create-container** [*options*...] *imageNameOrID*
@@ -29,7 +29,8 @@ Sets the metadata for the container to the specified value.
 Sets the metadata for the container to the contents of the specified file.
 
 ## EXAMPLE
-**containers-storage create-container -f manifest.json -n new-container goodimage**
+
+    containers-storage create-container -f manifest.json -n new-container goodimage
 
 ## SEE ALSO
 containers-storage-create-image(1)

--- a/storage/docs/containers-storage-create-image.md
+++ b/storage/docs/containers-storage-create-image.md
@@ -1,7 +1,7 @@
 # containers-storage-create-image 1 "August 2016"
 
 ## NAME
-containers-storage create-image - Create an image
+containers-storage-create-image - Create an image
 
 ## SYNOPSIS
 **containers-storage** **create-image** [*options*...] *topLayerNameOrID*
@@ -29,7 +29,8 @@ Sets the metadata for the image to the specified value.
 Sets the metadata for the image to the contents of the specified file.
 
 ## EXAMPLE
-**containers-storage create-image -f manifest.json -n new-image somelayer**
+
+    containers-storage create-image -f manifest.json -n new-image somelayer
 
 ## SEE ALSO
 containers-storage-create-container(1)

--- a/storage/docs/containers-storage-create-layer.md
+++ b/storage/docs/containers-storage-create-layer.md
@@ -1,7 +1,7 @@
 # containers-storage-create-layer 1 "August 2016"
 
 ## NAME
-containers-storage create-layer - Create a layer
+containers-storage-create-layer - Create a layer
 
 ## SYNOPSIS
 **containers-storage** **create-layer** [*options* [...]] [*parentLayerNameOrID*]
@@ -26,7 +26,8 @@ Sets the label which should be assigned as an SELinux context when mounting the
 layer.
 
 ## EXAMPLE
-**containers-storage create-layer -f manifest.json -n new-layer somelayer**
+
+    containers-storage create-layer -f manifest.json -n new-layer somelayer
 
 ## SEE ALSO
 containers-storage-create-container(1)

--- a/storage/docs/containers-storage-create-storage-layer.md
+++ b/storage/docs/containers-storage-create-storage-layer.md
@@ -1,7 +1,7 @@
 # containers-storage-create-storage-layer 1 "September 2022"
 
 ## NAME
-containers-storage create-storage-layer - Create a layer in a lower-level storage driver
+containers-storage-create-storage-layer - Create a layer in a lower-level storage driver
 
 ## SYNOPSIS
 **containers-storage** **create-storage-layer** [*options* [...]] [*parentLayerNameOrID*]
@@ -21,7 +21,8 @@ Sets the label which should be assigned as an SELinux context when mounting the
 layer.
 
 ## EXAMPLE
-**containers-storage create-storage-layer somelayer**
+
+    containers-storage create-storage-layer somelayer
 
 ## SEE ALSO
 containers-storage-create-container(1)

--- a/storage/docs/containers-storage-dedup.md
+++ b/storage/docs/containers-storage-dedup.md
@@ -1,7 +1,7 @@
 # containers-storage-dedup 1 "November 2024"
 
 ## NAME
-containers-storage dedup - Deduplicate similar files in the images
+containers-storage-dedup - Deduplicate similar files in the images
 
 ## SYNOPSIS
 **containers-storage** **dedup**
@@ -15,4 +15,5 @@ Find similar files in the images and deduplicate them.  It requires reflink supp
 Specify the function to use to calculate the hash for a file.  It can be one of: *size*, *crc*, *sha256sum*.
 
 ## EXAMPLE
-**containers-storage dedup**
+
+    containers-storage dedup

--- a/storage/docs/containers-storage-delete-container.md
+++ b/storage/docs/containers-storage-delete-container.md
@@ -1,7 +1,7 @@
 # containers-storage-delete-container 1 "August 2016"
 
 ## NAME
-containers-storage delete-container - Delete a container
+containers-storage-delete-container - Delete a container
 
 ## SYNOPSIS
 **containers-storage** **delete-container** *containerNameOrID*
@@ -10,7 +10,8 @@ containers-storage delete-container - Delete a container
 Deletes a container and its layer.
 
 ## EXAMPLE
-**containers-storage delete-container my-awesome-container**
+
+    containers-storage delete-container my-awesome-container
 
 ## SEE ALSO
 containers-storage-create-container(1)

--- a/storage/docs/containers-storage-delete-image.md
+++ b/storage/docs/containers-storage-delete-image.md
@@ -1,7 +1,7 @@
 # containers-storage-delete-image 1 "August 2016"
 
 ## NAME
-containers-storage delete-image - Delete an image
+containers-storage-delete-image - Delete an image
 
 ## SYNOPSIS
 **containers-storage** **delete-image** *imageNameOrID*
@@ -13,7 +13,8 @@ If that image's parent is then not being used by other images, it, too, will be
 removed, and this will be repeated for each parent's parent.
 
 ## EXAMPLE
-**containers-storage delete-image my-base-image**
+
+    containers-storage delete-image my-base-image
 
 ## SEE ALSO
 containers-storage-create-image(1)

--- a/storage/docs/containers-storage-delete-layer.md
+++ b/storage/docs/containers-storage-delete-layer.md
@@ -1,7 +1,7 @@
 # containers-storage-delete-layer 1 "August 2016"
 
 ## NAME
-containers-storage delete-layer - Delete a layer
+containers-storage-delete-layer - Delete a layer
 
 ## SYNOPSIS
 **containers-storage** **delete-layer** *layerNameOrID*
@@ -11,7 +11,8 @@ Deletes a layer if it is not currently being used by any images or containers,
 and is not the parent of any other layers.
 
 ## EXAMPLE
-**containers-storage delete-layer my-base-layer**
+
+    containers-storage delete-layer my-base-layer
 
 ## SEE ALSO
 containers-storage-create-layer(1)

--- a/storage/docs/containers-storage-delete.md
+++ b/storage/docs/containers-storage-delete.md
@@ -1,7 +1,7 @@
 # containers-storage-delete 1 "August 2016"
 
 ## NAME
-containers-storage delete - Force deletion of a layer, image, or container
+containers-storage-delete - Force deletion of a layer, image, or container
 
 ## SYNOPSIS
 **containers-storage** **delete** *layerOrImageOrContainerNameOrID*
@@ -11,7 +11,8 @@ Deletes a specified layer, image, or container, with no safety checking.  This
 can corrupt data, and may be removed.
 
 ## EXAMPLE
-**containers-storage delete my-base-layer**
+
+    containers-storage delete my-base-layer
 
 ## SEE ALSO
 containers-storage-delete-container(1)

--- a/storage/docs/containers-storage-diff.md
+++ b/storage/docs/containers-storage-diff.md
@@ -1,7 +1,7 @@
 # containers-storage-diff 1 "August 2016"
 
 ## NAME
-containers-storage diff - Generate a layer diff
+containers-storage-diff - Generate a layer diff
 
 ## SYNOPSIS
 **containers-storage** **diff** [*options* [...]] *layerNameOrID*
@@ -29,7 +29,8 @@ Force the diff to be uncompressed.  If the layer was populated by a layer diff,
 and that layer diff was compressed, it will be decompressed for output.
 
 ## EXAMPLE
-**containers-storage diff my-base-layer**
+
+    containers-storage diff my-base-layer
 
 ## SEE ALSO
 containers-storage-applydiff(1)

--- a/storage/docs/containers-storage-diffsize.md
+++ b/storage/docs/containers-storage-diffsize.md
@@ -1,7 +1,7 @@
 # containers-storage-diffsize 1 "August 2016"
 
 ## NAME
-containers-storage diffsize - Compute the size of a layer diff
+containers-storage-diffsize - Compute the size of a layer diff
 
 ## SYNOPSIS
 **containers-storage** **diffsize** *layerNameOrID*
@@ -11,7 +11,8 @@ Computes the expected size of the layer diff which would be generated for the
 specified layer.
 
 ## EXAMPLE
-**containers-storage diffsize my-base-layer**
+
+    containers-storage diffsize my-base-layer
 
 ## SEE ALSO
 containers-storage-applydiff(1)

--- a/storage/docs/containers-storage-exists.md
+++ b/storage/docs/containers-storage-exists.md
@@ -1,7 +1,7 @@
 # containers-storage-exists 1 "August 2016"
 
 ## NAME
-containers-storage exists - Check if a layer, image, or container exists
+containers-storage-exists - Check if a layer, image, or container exists
 
 ## SYNOPSIS
 **containers-storage** **exists** [*options* [...]] *layerOrImageOrContainerNameOrID* [...]
@@ -28,4 +28,5 @@ Only succeed if the names or IDs are that of layers.
 Suppress output.
 
 ## EXAMPLE
-**containers-storage exists my-base-layer**
+
+    containers-storage exists my-base-layer

--- a/storage/docs/containers-storage-gc.md
+++ b/storage/docs/containers-storage-gc.md
@@ -1,7 +1,7 @@
 # containers-storage-gc 1 "January 2023"
 
 ## NAME
-containers-storage gc - Garbage collect leftovers from partial layers/images/containers
+containers-storage-gc - Garbage collect leftovers from partial layers/images/containers
 
 ## SYNOPSIS
 **containers-storage** **gc**
@@ -13,4 +13,5 @@ which may have been left on the filesystem after canceled attempts to create
 those layers, images, or containers.
 
 ## EXAMPLE
-**containers-storage gc**
+
+    containers-storage gc

--- a/storage/docs/containers-storage-get-container-data-digest.md
+++ b/storage/docs/containers-storage-get-container-data-digest.md
@@ -1,7 +1,7 @@
 # containers-storage-get-container-data-digest 1 "August 2017"
 
 ## NAME
-containers-storage get-container-data-digest - Retrieve the digest of a lookaside data item
+containers-storage-get-container-data-digest - Retrieve the digest of a lookaside data item
 
 ## SYNOPSIS
 **containers-storage** **get-container-data-digest** *containerNameOrID* *dataName*
@@ -11,7 +11,8 @@ Prints the digest of the named data item which is associated with the specified
 container.
 
 ## EXAMPLE
-**containers-storage get-container-data-digest my-container manifest.json**
+
+    containers-storage get-container-data-digest my-container manifest.json
 
 ## SEE ALSO
 containers-storage-get-container-data(1)

--- a/storage/docs/containers-storage-get-container-data-size.md
+++ b/storage/docs/containers-storage-get-container-data-size.md
@@ -1,7 +1,7 @@
 # containers-storage-get-container-data-size 1 "August 2017"
 
 ## NAME
-containers-storage get-container-data-size - Retrieve the size of a lookaside data item
+containers-storage-get-container-data-size - Retrieve the size of a lookaside data item
 
 ## SYNOPSIS
 **containers-storage** **get-container-data-size** *containerNameOrID* *dataName*
@@ -11,7 +11,8 @@ Prints the size of the named data item which is associated with the specified
 container.
 
 ## EXAMPLE
-**containers-storage get-container-data-size my-container blah.foo**
+
+    containers-storage get-container-data-size my-container blah.foo
 
 ## SEE ALSO
 containers-storage-get-container-data(1)

--- a/storage/docs/containers-storage-get-container-data.md
+++ b/storage/docs/containers-storage-get-container-data.md
@@ -1,7 +1,7 @@
 # containers-storage-get-container-data 1 "August 2016"
 
 ## NAME
-containers-storage get-container-data - Retrieve lookaside data for a container
+containers-storage-get-container-data - Retrieve lookaside data for a container
 
 ## SYNOPSIS
 **containers-storage** **get-container-data** [*options* [...]] *containerNameOrID* *dataName*
@@ -15,7 +15,8 @@ Retrieves a piece of named data which is associated with a container.
 Write the data to a file instead of stdout.
 
 ## EXAMPLE
-**containers-storage get-container-data -f config.json my-container configuration**
+
+    containers-storage get-container-data -f config.json my-container configuration
 
 ## SEE ALSO
 containers-storage-list-container-data(1)

--- a/storage/docs/containers-storage-get-container-dir.md
+++ b/storage/docs/containers-storage-get-container-dir.md
@@ -1,7 +1,7 @@
 # containers-storage-get-container-dir 1 "September 2016"
 
 ## NAME
-containers-storage get-container-dir - Find lookaside directory for a container
+containers-storage-get-container-dir - Find lookaside directory for a container
 
 ## SYNOPSIS
 **containers-storage** **get-container-dir** [*options* [...]] *containerNameOrID*
@@ -11,7 +11,8 @@ Prints the location of a directory which the caller can use to store lookaside
 information which should be cleaned up when the container is deleted.
 
 ## EXAMPLE
-**containers-storage get-container-dir my-container**
+
+    containers-storage get-container-dir my-container
 
 ## SEE ALSO
 containers-storage-get-container-run-dir(1)

--- a/storage/docs/containers-storage-get-container-run-dir.md
+++ b/storage/docs/containers-storage-get-container-run-dir.md
@@ -1,7 +1,7 @@
 # containers-storage-get-container-run-dir 1 "September 2016"
 
 ## NAME
-containers-storage get-container-run-dir - Find runtime lookaside directory for a container
+containers-storage-get-container-run-dir - Find runtime lookaside directory for a container
 
 ## SYNOPSIS
 **containers-storage** **get-container-run-dir** [*options* [...]] *containerNameOrID*
@@ -11,7 +11,8 @@ Prints the location of a directory which the caller can use to store lookaside
 information which should be cleaned up when the host is rebooted.
 
 ## EXAMPLE
-**containers-storage get-container-run-dir my-container**
+
+    containers-storage get-container-run-dir my-container
 
 ## SEE ALSO
 containers-storage-get-container-dir(1)

--- a/storage/docs/containers-storage-get-image-data-digest.md
+++ b/storage/docs/containers-storage-get-image-data-digest.md
@@ -1,7 +1,7 @@
 # containers-storage-get-image-data-digest 1 "August 2017"
 
 ## NAME
-containers-storage get-image-data-digest - Retrieve the digest of a lookaside data item
+containers-storage-get-image-data-digest - Retrieve the digest of a lookaside data item
 
 ## SYNOPSIS
 **containers-storage** **get-image-data-digest** *imageNameOrID* *dataName*
@@ -11,7 +11,8 @@ Prints the digest of the named data item which is associated with the specified
 image.
 
 ## EXAMPLE
-**containers-storage get-image-data-digest my-image manifest.json**
+
+    containers-storage get-image-data-digest my-image manifest.json
 
 ## SEE ALSO
 containers-storage-get-image-data(1)

--- a/storage/docs/containers-storage-get-image-data-size.md
+++ b/storage/docs/containers-storage-get-image-data-size.md
@@ -1,7 +1,7 @@
 # containers-storage-get-image-data-size 1 "August 2017"
 
 ## NAME
-containers-storage get-image-data-size - Retrieve the size of a lookaside data item
+containers-storage-get-image-data-size - Retrieve the size of a lookaside data item
 
 ## SYNOPSIS
 **containers-storage** **get-image-data-size** *imageNameOrID* *dataName*
@@ -11,7 +11,8 @@ Prints the size of the named data item which is associated with the specified
 image.
 
 ## EXAMPLE
-**containers-storage get-image-data-size my-image manifest.json**
+
+    containers-storage get-image-data-size my-image manifest.json
 
 ## SEE ALSO
 containers-storage-get-image-data(1)

--- a/storage/docs/containers-storage-get-image-data.md
+++ b/storage/docs/containers-storage-get-image-data.md
@@ -1,7 +1,7 @@
 # containers-storage-get-image-data 1 "August 2016"
 
 ## NAME
-containers-storage get-image-data - Retrieve lookaside data for an image
+containers-storage-get-image-data - Retrieve lookaside data for an image
 
 ## SYNOPSIS
 **containers-storage** **get-image-data** [*options* [...]] *imageNameOrID* *dataName*
@@ -15,7 +15,8 @@ Retrieves a piece of named data which is associated with an image.
 Write the data to a file instead of stdout.
 
 ## EXAMPLE
-**containers-storage get-image-data -f manifest.json my-image manifest**
+
+    containers-storage get-image-data -f manifest.json my-image manifest
 
 ## SEE ALSO
 containers-storage-list-image-data(1)

--- a/storage/docs/containers-storage-get-image-dir.md
+++ b/storage/docs/containers-storage-get-image-dir.md
@@ -1,7 +1,7 @@
 # containers-storage-get-image-dir 1 "January 2024"
 
 ## NAME
-containers-storage get-image-dir - Find lookaside directory for an image
+containers-storage-get-image-dir - Find lookaside directory for an image
 
 ## SYNOPSIS
 **containers-storage** **get-image-dir** [*options* [...]] *imageNameOrID*
@@ -11,7 +11,8 @@ Prints the location of a directory which the caller can use to store lookaside
 information which should be cleaned up when the image is deleted.
 
 ## EXAMPLE
-**containers-storage get-image-dir my-image**
+
+    containers-storage get-image-dir my-image
 
 ## SEE ALSO
 containers-storage-get-image-run-dir(1)

--- a/storage/docs/containers-storage-get-image-run-dir.md
+++ b/storage/docs/containers-storage-get-image-run-dir.md
@@ -1,7 +1,7 @@
 # containers-storage-get-image-run-dir 1 "January 2024"
 
 ## NAME
-containers-storage get-image-run-dir - Find runtime lookaside directory for an image
+containers-storage-get-image-run-dir - Find runtime lookaside directory for an image
 
 ## SYNOPSIS
 **containers-storage** **get-image-run-dir** [*options* [...]] *imageNameOrID*
@@ -11,7 +11,8 @@ Prints the location of a directory which the caller can use to store lookaside
 information which should be cleaned up when the host is rebooted.
 
 ## EXAMPLE
-**containers-storage get-image-run-dir my-image**
+
+    containers-storage get-image-run-dir my-image
 
 ## SEE ALSO
 containers-storage-get-image-dir(1)

--- a/storage/docs/containers-storage-get-layer-data.md
+++ b/storage/docs/containers-storage-get-layer-data.md
@@ -1,7 +1,7 @@
 # containers-storage-get-layer-data 1 "December 2020"
 
 ## NAME
-containers-storage get-layer-data - Retrieve lookaside data for a layer
+containers-storage-get-layer-data - Retrieve lookaside data for a layer
 
 ## SYNOPSIS
 **containers-storage** **get-layer-data** [*options* [...]] *layerID* *dataName*
@@ -15,7 +15,12 @@ Retrieves a piece of named data which is associated with a layer.
 Write the data to a file instead of stdout.
 
 ## EXAMPLE
-**containers-storage get-layer-data -f config.json 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824 configuration**
+
+```
+containers-storage get-layer-data -f config.json \
+ 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824 \
+ configuration
+```
 
 ## SEE ALSO
 containers-storage-set-layer-data(1)

--- a/storage/docs/containers-storage-get-names.md
+++ b/storage/docs/containers-storage-get-names.md
@@ -1,7 +1,7 @@
 # containers-storage-get-names 1 "September 2017"
 
 ## NAME
-containers-storage get-names - Get names of a layer/image/container
+containers-storage-get-names - Get names of a layer/image/container
 
 ## SYNOPSIS
 **containers-storage** **get-names** *layerOrImageOrContainerNameOrID*
@@ -14,7 +14,11 @@ command can be used to read the list of names for any of them.
 ## OPTIONS
 
 ## EXAMPLE
-**containers-storage get-names f3be6c6134d0d980936b4c894f1613b69a62b79588fdeda744d0be3693bde8ec**
+
+```
+containers-storage get-names \
+ f3be6c6134d0d980936b4c894f1613b69a62b79588fdeda744d0be3693bde8ec
+```
 
 ## SEE ALSO
 containers-storage-add-names(1)

--- a/storage/docs/containers-storage-image.md
+++ b/storage/docs/containers-storage-image.md
@@ -1,7 +1,7 @@
 # containers-storage-image 1 "August 2016"
 
 ## NAME
-containers-storage image - Examine a single image
+containers-storage-image - Examine a single image
 
 ## SYNOPSIS
 **containers-storage** **image** *imageNameOrID*
@@ -11,8 +11,10 @@ Retrieve information about an image: its ID, any names it has, and the ID of
 its top layer.
 
 ## EXAMPLE
-**containers-storage image 49bff34e4baf9378c01733d02276a731a4c4771ebeab305020c5303679f88bb8**
-**containers-storage image my-favorite-image**
+
+    containers-storage image 49bff34e4baf9378c01733d02276a731a4c4771ebeab305020c5303679f88bb8
+
+    containers-storage image my-favorite-image
 
 ## SEE ALSO
 containers-storage-images(1)

--- a/storage/docs/containers-storage-images-by-digest.md
+++ b/storage/docs/containers-storage-images-by-digest.md
@@ -1,7 +1,7 @@
 # containers-storage-images-by-digest 1 "February 2019"
 
 ## NAME
-containers-storage images-by-digest - List known images by digest
+containers-storage-images-by-digest - List known images by digest
 
 ## SYNOPSIS
 **containers-storage** **images-by-digest** *digest*
@@ -10,7 +10,8 @@ containers-storage images-by-digest - List known images by digest
 Retrieves information about images which match a specified digest
 
 ## EXAMPLE
-**containers-storage images-by-digest sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855**
+
+    containers-storage images-by-digest sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 
 ## SEE ALSO
 containers-storage-image(1)

--- a/storage/docs/containers-storage-images.md
+++ b/storage/docs/containers-storage-images.md
@@ -1,7 +1,7 @@
 # containers-storage-images 1 "August 2016"
 
 ## NAME
-containers-storage images - List known images
+containers-storage-images - List known images
 
 ## SYNOPSIS
 **containers-storage** **images**
@@ -10,7 +10,8 @@ containers-storage images - List known images
 Retrieves information about all known images and lists their IDs and names.
 
 ## EXAMPLE
-**containers-storage images**
+
+    containers-storage images
 
 ## SEE ALSO
 containers-storage-image(1)

--- a/storage/docs/containers-storage-import-layer.md
+++ b/storage/docs/containers-storage-import-layer.md
@@ -1,7 +1,7 @@
 # containers-storage-import-layer 1 "April 2019"
 
 ## NAME
-containers-storage import-layer - Import files to a new layer
+containers-storage-import-layer - Import files to a new layer
 
 ## SYNOPSIS
 **containers-storage** **import-layer** [*options* [...]] [*parentLayerNameOrID*]
@@ -69,7 +69,8 @@ Create UID map for username using the data from /etc/subuid. It cannot be specif
 Create GID map for group-name using the data from /etc/subgid. It cannot be specified simultaneously with *--hostuidmap*.
 
 ## EXAMPLE
-**containers-storage import-layer -f 71841c97e320d6cde.tar.gz -n new-layer somelayer**
+
+    containers-storage import-layer -f 71841c97e320d6cde.tar.gz -n new-layer somelayer
 
 ## SEE ALSO
 containers-storage-create-layer(1)

--- a/storage/docs/containers-storage-layer.md
+++ b/storage/docs/containers-storage-layer.md
@@ -1,7 +1,7 @@
 # containers-storage-layer 1 "September 2017"
 
 ## NAME
-containers-storage layer - Examine a single layer
+containers-storage-layer - Examine a single layer
 
 ## SYNOPSIS
 **containers-storage** **layer** *layerNameOrID*
@@ -11,8 +11,9 @@ Retrieve information about a layer: its ID, any names it has, and the ID of
 its parent, if it has one.
 
 ## EXAMPLE
-**containers-storage layer 49bff34e4baf9378c01733d02276a731a4c4771ebeab305020c5303679f88bb8**
-**containers-storage layer my-favorite-layer**
+
+    containers-storage layer 49bff34e4baf9378c01733d02276a731a4c4771ebeab305020c5303679f88bb8
+    containers-storage layer my-favorite-layer
 
 ## SEE ALSO
 containers-storage-image(1)

--- a/storage/docs/containers-storage-layers.md
+++ b/storage/docs/containers-storage-layers.md
@@ -1,7 +1,7 @@
 # containers-storage-layers 1 "August 2016"
 
 ## NAME
-containers-storage layers - List known layers
+containers-storage-layers - List known layers
 
 ## SYNOPSIS
 **containers-storage** [*options* [...]] **layers**
@@ -19,5 +19,6 @@ Display results using a tree to show the hierarchy of parent-child
 relationships between layers.
 
 ## EXAMPLE
-**containers-storage layers**
-**containers-storage layers -t**
+
+    containers-storage layers
+    containers-storage layers -t

--- a/storage/docs/containers-storage-list-container-data.md
+++ b/storage/docs/containers-storage-list-container-data.md
@@ -1,7 +1,7 @@
 # containers-storage-list-container-data 1 "August 2016"
 
 ## NAME
-containers-storage list-container-data - List lookaside data for a container
+containers-storage-list-container-data - List lookaside data for a container
 
 ## SYNOPSIS
 **containers-storage** **list-container-data** *containerNameOrID*
@@ -10,7 +10,8 @@ containers-storage list-container-data - List lookaside data for a container
 List the pieces of named data which are associated with a container.
 
 ## EXAMPLE
-**containers-storage list-container-data my-container**
+
+    containers-storage list-container-data my-container
 
 ## SEE ALSO
 containers-storage-get-container-data(1)

--- a/storage/docs/containers-storage-list-image-data.md
+++ b/storage/docs/containers-storage-list-image-data.md
@@ -1,7 +1,7 @@
 # containers-storage-list-image-data 1 "August 2016"
 
 ## NAME
-containers-storage list-image-data - List lookaside data for an image
+containers-storage-list-image-data - List lookaside data for an image
 
 ## SYNOPSIS
 **containers-storage** **list-image-data** *imageNameOrID*
@@ -10,7 +10,8 @@ containers-storage list-image-data - List lookaside data for an image
 List the pieces of named data which are associated with an image.
 
 ## EXAMPLE
-**containers-storage list-image-data my-image**
+
+    containers-storage list-image-data my-image
 
 ## SEE ALSO
 containers-storage-get-image-data(1)

--- a/storage/docs/containers-storage-list-layer-data.md
+++ b/storage/docs/containers-storage-list-layer-data.md
@@ -1,7 +1,7 @@
 # containers-storage-list-layer-data 1 "December 2020"
 
 ## NAME
-containers-storage list-layer-data - List lookaside data for a layer
+containers-storage-list-layer-data - List lookaside data for a layer
 
 ## SYNOPSIS
 **containers-storage** **list-layer-data** *layerID*
@@ -10,7 +10,8 @@ containers-storage list-layer-data - List lookaside data for a layer
 List the pieces of named data which are associated with a layer.
 
 ## EXAMPLE
-**containers-storage list-layer-data 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824**
+
+    containers-storage list-layer-data 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
 
 ## SEE ALSO
 containers-storage-get-layer-data(1)

--- a/storage/docs/containers-storage-metadata.md
+++ b/storage/docs/containers-storage-metadata.md
@@ -1,7 +1,7 @@
 # containers-storage-metadata 1 "August 2016"
 
 ## NAME
-containers-storage metadata - Retrieve metadata for a layer, image, or container
+containers-storage-metadata - Retrieve metadata for a layer, image, or container
 
 ## SYNOPSIS
 **containers-storage** **metadata** [*options* [...]] *layerOrImageOrContainerNameOrID*
@@ -16,7 +16,8 @@ intended to be small, and is expected to be cached in memory.
 Don't print the ID or name of the item with which the metadata is associated.
 
 ## EXAMPLE
-**containers-storage metadata -q my-image > my-image.txt**
+
+    containers-storage metadata -q my-image > my-image.txt
 
 ## SEE ALSO
 containers-storage-set-metadata(1)

--- a/storage/docs/containers-storage-mount.md
+++ b/storage/docs/containers-storage-mount.md
@@ -1,7 +1,7 @@
 # containers-storage-mount 1 "August 2016"
 
 ## NAME
-containers-storage mount - Mount a layer or a container's layer for manipulation
+containers-storage-mount - Mount a layer or a container's layer for manipulation
 
 ## SYNOPSIS
 **containers-storage** **mount** [*options* [...]] *layerOrContainerNameOrID*
@@ -16,7 +16,8 @@ mountpoint.
 Specify an SELinux context for the mounted layer.
 
 ## EXAMPLE
-**containers-storage mount my-container**
+
+    containers-storage mount my-container
 
 ## SEE ALSO
 containers-storage-mounted(1)

--- a/storage/docs/containers-storage-mounted.md
+++ b/storage/docs/containers-storage-mounted.md
@@ -1,7 +1,7 @@
 # containers-storage-mounted 1 "November 2018"
 
 ## NAME
-containers-storage mounted - Check if a file system is mounted
+containers-storage-mounted - Check if a file system is mounted
 
 ## SYNOPSIS
 **containers-storage** **mounted** *LayerOrContainerNameOrID*
@@ -10,7 +10,8 @@ containers-storage mounted - Check if a file system is mounted
 Check if a filesystem is mounted
 
 ## EXAMPLE
-**containers-storage mounted my-container**
+
+    containers-storage mounted my-container
 
 ## SEE ALSO
 containers-storage-mount(1)

--- a/storage/docs/containers-storage-remove-names.md
+++ b/storage/docs/containers-storage-remove-names.md
@@ -1,7 +1,7 @@
 # containers-storage-remove-names 1 "January 2023"
 
 ## NAME
-containers-storage remove-names - Remove names from a layer/image/container
+containers-storage-remove-names - Remove names from a layer/image/container
 
 ## SYNOPSIS
 **containers-storage** **remove-names** [*options* [...]] *layerOrImageOrContainerNameOrID*
@@ -17,7 +17,8 @@ command can be used to remove one or more names from them.
 Specifies a name to remove from the layer, image, or container.
 
 ## EXAMPLE
-**containers-storage remove-names -n my-for-realsies-awesome-container f3be6c6134d0d980936b4c894f1613b69a62b79588fdeda744d0be3693bde8ec**
+
+    containers-storage remove-names -n my-for-realsies-awesome-container f3be6c6134d0d980936b4c894f1613b69a62b79588fdeda744d0be3693bde8ec
 
 ## SEE ALSO
 containers-storage-add-names(1)

--- a/storage/docs/containers-storage-set-container-data.md
+++ b/storage/docs/containers-storage-set-container-data.md
@@ -1,7 +1,7 @@
 # containers-storage-set-container-data 1 "August 2016"
 
 ## NAME
-containers-storage set-container-data - Set lookaside data for a container
+containers-storage-set-container-data - Set lookaside data for a container
 
 ## SYNOPSIS
 **containers-storage** **set-container-data** [*options* [...]] *containerNameOrID* *dataName*
@@ -15,7 +15,8 @@ Sets a piece of named data which is associated with a container.
 Read the data contents from a file instead of stdin.
 
 ## EXAMPLE
-**containers-storage set-container-data -f ./config.json my-container configuration**
+
+    containers-storage set-container-data -f ./config.json my-container configuration
 
 ## SEE ALSO
 containers-storage-list-container-data(1)

--- a/storage/docs/containers-storage-set-image-data.md
+++ b/storage/docs/containers-storage-set-image-data.md
@@ -1,7 +1,7 @@
 # containers-storage-set-image-data 1 "August 2016"
 
 ## NAME
-containers-storage set-image-data - Set lookaside data for an image
+containers-storage-set-image-data - Set lookaside data for an image
 
 ## SYNOPSIS
 **containers-storage** **set-image-data** [*options* [...]] *imageNameOrID* *dataName*
@@ -15,7 +15,8 @@ Sets a piece of named data which is associated with an image.
 Read the data contents from a file instead of stdin.
 
 ## EXAMPLE
-**containers-storage set-image-data -f ./manifest.json my-image manifest**
+
+    containers-storage set-image-data -f ./manifest.json my-image manifest
 
 ## SEE ALSO
 containers-storage-list-image-data(1)

--- a/storage/docs/containers-storage-set-layer-data.md
+++ b/storage/docs/containers-storage-set-layer-data.md
@@ -1,7 +1,7 @@
 # containers-storage-set-layer-data 1 "December 2020"
 
 ## NAME
-containers-storage set-layer-data - Set lookaside data for a layer
+containers-storage-set-layer-data - Set lookaside data for a layer
 
 ## SYNOPSIS
 **containers-storage** **set-layer-data** [*options* [...]] *layerID* *dataName*
@@ -15,7 +15,11 @@ Sets a piece of named data which is associated with a layer.
 Read the data contents from a file instead of stdin.
 
 ## EXAMPLE
-**containers-storage set-layer-data -f ./config.json 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824 configuration**
+
+    containers-storage set-layer-data \
+     -f ./config.json \
+     2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824 \
+     configuration
 
 ## SEE ALSO
 containers-storage-get-layer-data(1)

--- a/storage/docs/containers-storage-set-metadata.md
+++ b/storage/docs/containers-storage-set-metadata.md
@@ -1,7 +1,7 @@
 # containers-storage-set-metadata 1 "August 2016"
 
 ## NAME
-containers-storage set-metadata - Set metadata for a layer, image, or container
+containers-storage-set-metadata - Set metadata for a layer, image, or container
 
 ## SYNOPSIS
 **containers-storage** **set-metadata** [*options* [...]] *layerOrImageOrContainerNameOrID*
@@ -20,7 +20,8 @@ Use the contents of the specified file as the metadata.
 Use the specified value as the metadata.
 
 ## EXAMPLE
-**containers-storage set-metadata -m "compression: gzip" my-layer**
+
+    containers-storage set-metadata -m "compression: gzip" my-layer
 
 ## SEE ALSO
 containers-storage-metadata(1)

--- a/storage/docs/containers-storage-set-names.md
+++ b/storage/docs/containers-storage-set-names.md
@@ -1,7 +1,7 @@
 # containers-storage-set-names 1 "August 2016"
 
 ## NAME
-containers-storage set-names - Set names for a layer/image/container
+containers-storage-set-names - Set names for a layer/image/container
 
 ## SYNOPSIS
 **containers-storage** **set-names** [**-n** *name* [...]] *layerOrImageOrContainerNameOrID*
@@ -21,7 +21,10 @@ this layer, image, or container, and which are not specified using this option,
 will be removed from the layer, image, or container.
 
 ## EXAMPLE
-**containers-storage set-names -n my-one-and-only-name f3be6c6134d0d980936b4c894f1613b69a62b79588fdeda744d0be3693bde8ec**
+
+    containers-storage set-names \
+     -n my-one-and-only-name \
+     f3be6c6134d0d980936b4c894f1613b69a62b79588fdeda744d0be3693bde8ec
 
 ## SEE ALSO
 containers-storage-add-names(1)

--- a/storage/docs/containers-storage-shutdown.md
+++ b/storage/docs/containers-storage-shutdown.md
@@ -1,7 +1,7 @@
 # containers-storage-shutdown 1 "October 2016"
 
 ## NAME
-containers-storage shutdown - Shut down layer storage
+containers-storage-shutdown - Shut down layer storage
 
 ## SYNOPSIS
 **containers-storage** **shutdown** [*options* [...]]
@@ -17,4 +17,5 @@ driver.  If this option is not specified, if any layers are mounted, shutdown
 will not be attempted.
 
 ## EXAMPLE
-**containers-storage shutdown**
+
+    containers-storage shutdown

--- a/storage/docs/containers-storage-status.md
+++ b/storage/docs/containers-storage-status.md
@@ -1,7 +1,7 @@
 # containers-storage-status 1 "August 2016"
 
 ## NAME
-containers-storage status - Output status information from the storage library's driver
+containers-storage-status - Output status information from the storage library's driver
 
 ## SYNOPSIS
 **containers-storage** **status**
@@ -10,7 +10,8 @@ containers-storage status - Output status information from the storage library's
 Queries the storage library's driver for status information.
 
 ## EXAMPLE
-**containers-storage status**
+
+    containers-storage status
 
 ## SEE ALSO
 containers-storage-version(1)

--- a/storage/docs/containers-storage-unmount.md
+++ b/storage/docs/containers-storage-unmount.md
@@ -1,7 +1,7 @@
 # containers-storage-unmount 1 "August 2016"
 
 ## NAME
-containers-storage unmount - Unmount a layer or a container's layer
+containers-storage-unmount - Unmount a layer or a container's layer
 
 ## SYNOPSIS
 **containers-storage** **unmount** *layerOrContainerMountpointOrNameOrID*
@@ -10,9 +10,10 @@ containers-storage unmount - Unmount a layer or a container's layer
 Unmounts a layer or a container's layer from the host's filesystem.
 
 ## EXAMPLE
-**containers-storage unmount my-container**
 
-**containers-storage unmount /var/lib/containers/storage/mounts/my-container**
+    containers-storage unmount my-container
+
+    containers-storage unmount /var/lib/containers/storage/mounts/my-container
 
 ## SEE ALSO
 containers-storage-mount(1)

--- a/storage/docs/containers-storage-unshare.md
+++ b/storage/docs/containers-storage-unshare.md
@@ -1,7 +1,7 @@
 # containers-storage-unshare 1 "September 2022"
 
 ## NAME
-containers-storage unshare - Run a command in a user namespace
+containers-storage-unshare - Run a command in a user namespace
 
 ## SYNOPSIS
 **containers-storage** **unshare** [command [...]]
@@ -11,7 +11,8 @@ Sets up a user namespace using mappings configured for the current user and runs
 either a specified command or the current user's shell.
 
 ## EXAMPLE
-**containers-storage unshare id**
+
+    containers-storage unshare id
 
 ## SEE ALSO
 containers-storage-status(1)

--- a/storage/docs/containers-storage-version.md
+++ b/storage/docs/containers-storage-version.md
@@ -1,7 +1,7 @@
 # containers-storage-version 1 "August 2016"
 
 ## NAME
-containers-storage version - Output version information about the storage library
+containers-storage-version - Output version information about the storage library
 
 ## SYNOPSIS
 **containers-storage** **version**
@@ -10,7 +10,8 @@ containers-storage version - Output version information about the storage librar
 Outputs version information about the storage library and *containers-storage*.
 
 ## EXAMPLE
-**containers-storage version**
+
+    containers-storage version
 
 ## SEE ALSO
 containers-storage-status(1)

--- a/storage/docs/containers-storage-wipe.md
+++ b/storage/docs/containers-storage-wipe.md
@@ -1,7 +1,7 @@
 # containers-storage-wipe 1 "August 2016"
 
 ## NAME
-containers-storage wipe - Delete all containers, images, and layers
+containers-storage-wipe - Delete all containers, images, and layers
 
 ## SYNOPSIS
 **containers-storage** **wipe**
@@ -11,4 +11,5 @@ Deletes all known containers, images, and layers.  Depending on your use case,
 use with caution or abandon.
 
 ## EXAMPLE
-**containers-storage wipe**
+
+    containers-storage wipe

--- a/storage/docs/containers-storage-zstd-chunked.md
+++ b/storage/docs/containers-storage-zstd-chunked.md
@@ -3,7 +3,6 @@
 ## NAME
 containers-storage-zstd-chunked - Information about zstd:chunked
 
-
 ## DESCRIPTION
 
 The traditional format for container image layers is [application/vnd.oci.image.layer.v1.tar+gzip](https://github.com/opencontainers/image-spec/blob/main/layer.md#gzip-media-types).

--- a/storage/docs/containers-storage.md
+++ b/storage/docs/containers-storage.md
@@ -172,8 +172,10 @@ using the system's default ID mappings for the non-root user.
 **CONTAINERS_STORAGE_CONF** 
 
 If set will use the configuration file path provided in *$CONTAINERS_STORAGE_CONF* instead of the default `/etc/containers/storage.conf`.
+
 ## EXAMPLES
-**containers-storage layers -t**
+
+    containers-storage layers -t
 
 ## BUGS
 This is still a work in progress, so some functionality may not yet be


### PR DESCRIPTION
Also address most troff issues. Not all of them are easy, in particular those manpages with long urls and examples that include digests are difficult to render in traditional manpages.

Add troff renderering to the Manpage to surface those troff issues more easily

Signed-off-by: Reinhard Tartler <siretart@tauware.de>

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
