### PR TITLE
Deprecate reference.ParseAnyReference

### DIFF
--- a/image/docker/daemon/daemon_transport_test.go
+++ b/image/docker/daemon/daemon_transport_test.go
@@ -75,7 +75,7 @@ func testParseReference(t *testing.T, fn func(string) (types.ImageReference, err
 			daemonRef, ok := ref.(daemonReference)
 			require.True(t, ok, c.input)
 			// If we don't reject the input, the interpretation must be consistent with reference.ParseAnyReference
-			dockerRef, err := reference.ParseAnyReference(c.input)
+			dockerRef, err := reference.ParseAnyReference(c.input) //nolint:staticcheck // "reference.ParseAnyReference is deprecated" — this is explicitly a check of consistency with that function’s behavior.
 			require.NoError(t, err, c.input)
 
 			if c.expectedRef == "" {

--- a/image/docker/reference/normalize.go
+++ b/image/docker/reference/normalize.go
@@ -169,6 +169,17 @@ func TagNameOnly(ref Named) Named {
 
 // ParseAnyReference parses a reference string as a possible identifier,
 // full digest, or familiar name.
+//
+// Deprecated: This parses inputs with 64 hexadecimal characters as sha256 digests,
+// and that can’t be generalized (a digest algorithm can not be determined purely
+// from the length of the input).
+//
+// In the future, image IDs will either stay 256-bit, but will not be SHA-256 values;
+// or they will support arbitrary algorithms, in which case the hexadecimal-only syntax
+// is not sufficient. Either way, this function will not be fit for purpose.
+//
+// Callers (if any) should redesign their syntax to strictly differentiate between
+// image IDs (with an as-yet-unknown future syntax) and named image references.
 func ParseAnyReference(ref string) (Reference, error) {
 	if ok := anchoredIdentifierRegexp.MatchString(ref); ok {
 		return digestReference("sha256:" + ref), nil


### PR DESCRIPTION
It does not work with, and can not be reasonably generalized for, digest algorithm agility.

Should not change behavior.

Cc: @lsm5 