### PR TITLE
Convert default_network from snake_case to camelCase

### DIFF
--- a/common/libnetwork/types/network.go
+++ b/common/libnetwork/types/network.go
@@ -102,7 +102,7 @@ type NetworkInfo struct {
 	Package        string         `json:"package,omitempty"`
 	Path           string         `json:"path,omitempty"`
 	DNS            DNSNetworkInfo `json:"dns,omitempty"`
-	DefaultNetwork string         `json:"default_network,omitempty"`
+	DefaultNetwork string         `json:"defaultNetwork,omitempty"`
 }
 
 // DNSNetworkInfo contains the DNS information.


### PR DESCRIPTION
<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->

https://github.com/containers/podman/issues/27580 

As discussed in the issue, I’ve updated the default network name from snake_case to camelCase.