### PR TITLE
[podman-5.7] Use $BINDIR as the default helper binary directory on Windows

### DIFF
--- a/common/pkg/config/config_windows.go
+++ b/common/pkg/config/config_windows.go
@@ -31,5 +31,7 @@ func overrideContainersConfigPath() (string, error) {
 }
 
 var defaultHelperBinariesDir = []string{
-	"C:\\Program Files\\RedHat\\Podman",
+	// FindHelperBinaries(), as a convention, interprets $BINDIR as the
+	// directory where the current process binary (i.e. podman) is located.
+	"$BINDIR",
 }


### PR DESCRIPTION
cherry-pick 4877783c373caf006a6d031db4d39ef4c6f3cf55

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
