### PR TITLE
image/directory: store manifest and signature with digest algorithm prefix

### DIFF
--- a/image/directory/directory_dest.go
+++ b/image/directory/directory_dest.go
@@ -242,6 +242,9 @@ func (d *dirImageDestination) PutManifest(ctx context.Context, manifest []byte, 
 // (when the primary manifest is a manifest list); this should always be nil if the primary manifest is not a manifest list.
 // MUST be called after PutManifest (signatures may reference manifest contents).
 func (d *dirImageDestination) PutSignaturesWithFormat(ctx context.Context, signatures []signature.Signature, instanceDigest *digest.Digest) error {
+	if instanceDigest != nil && instanceDigest.Algorithm() != digest.Canonical { // compare the special case in signaturePath
+		d.usesNonSHA256Digest = true
+	}
 	for i, sig := range signatures {
 		blob, err := signature.Blob(sig)
 		if err != nil {

--- a/image/directory/directory_dest_test.go
+++ b/image/directory/directory_dest_test.go
@@ -42,6 +42,17 @@ func TestVersionAssignment(t *testing.T) {
 				require.NoError(t, err)
 			},
 		},
+		{
+			name: "signature",
+			put: func(t *testing.T, dest types.ImageDestination, algo digest.Algorithm, i int, cache types.BlobInfoCache) {
+				manifestData := []byte("test-manifest-" + algo.String() + "-" + string(rune(i)))
+				instanceDigest := algo.FromBytes(manifestData)
+				// These signatures are completely invalid; start with 0xA3 just to be minimally plausible to signature.FromBlob.
+				signatures := [][]byte{[]byte("\xA3sig" + algo.String() + "-" + string(rune(i)))}
+				err := dest.PutSignatures(context.Background(), signatures, &instanceDigest)
+				require.NoError(t, err)
+			},
+		},
 	} {
 		for _, c := range []struct {
 			name            string

--- a/image/directory/directory_transport.go
+++ b/image/directory/directory_transport.go
@@ -199,7 +199,13 @@ func (ref dirReference) signaturePath(index int, instanceDigest *digest.Digest) 
 		if err := instanceDigest.Validate(); err != nil { // digest.Digest.Encoded() panics on failure, and could possibly result in a path with ../, so validate explicitly.
 			return "", err
 		}
-		return filepath.Join(ref.path, fmt.Sprintf(instanceDigest.Encoded()+".signature-%d", index+1)), nil
+		var prefix string
+		if instanceDigest.Algorithm() == digest.Canonical {
+			prefix = instanceDigest.Encoded()
+		} else {
+			prefix = instanceDigest.Algorithm().String() + "-" + instanceDigest.Encoded()
+		}
+		return filepath.Join(ref.path, fmt.Sprintf(prefix+".signature-%d", index+1)), nil
 	}
 	return filepath.Join(ref.path, fmt.Sprintf("signature-%d", index+1)), nil
 }

--- a/image/directory/directory_transport_test.go
+++ b/image/directory/directory_transport_test.go
@@ -238,7 +238,8 @@ func TestReferenceLayerPath(t *testing.T) {
 }
 
 func TestReferenceSignaturePath(t *testing.T) {
-	dhex := digest.Digest("sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+	dhex256 := digest.Digest("sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+	dhex512 := digest.Digest("sha512:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
 
 	ref, tmpDir := refToTempDir(t)
 	dirRef, ok := ref.(dirReference)
@@ -249,12 +250,21 @@ func TestReferenceSignaturePath(t *testing.T) {
 	res, err = dirRef.signaturePath(9, nil)
 	require.NoError(t, err)
 	assert.Equal(t, tmpDir+"/signature-10", res)
-	res, err = dirRef.signaturePath(0, &dhex)
+
+	res, err = dirRef.signaturePath(0, &dhex256)
 	require.NoError(t, err)
-	assert.Equal(t, tmpDir+"/"+dhex.Encoded()+".signature-1", res)
-	res, err = dirRef.signaturePath(9, &dhex)
+	assert.Equal(t, tmpDir+"/"+dhex256.Encoded()+".signature-1", res)
+	res, err = dirRef.signaturePath(9, &dhex256)
 	require.NoError(t, err)
-	assert.Equal(t, tmpDir+"/"+dhex.Encoded()+".signature-10", res)
+	assert.Equal(t, tmpDir+"/"+dhex256.Encoded()+".signature-10", res)
+
+	res, err = dirRef.signaturePath(0, &dhex512)
+	require.NoError(t, err)
+	assert.Equal(t, tmpDir+"/sha512-"+dhex512.Encoded()+".signature-1", res)
+	res, err = dirRef.signaturePath(9, &dhex512)
+	require.NoError(t, err)
+	assert.Equal(t, tmpDir+"/sha512-"+dhex512.Encoded()+".signature-10", res)
+
 	invalidDigest := digest.Digest("sha256:../hello")
 	_, err = dirRef.signaturePath(0, &invalidDigest)
 	assert.Error(t, err)


### PR DESCRIPTION
<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->

see individual commits for manifestPath and signaturePath