### PR TITLE
[WIP] common: Add libexec paths to default helper binary path dirs

### DIFF
--- a/common/docs/containers.conf.5.md
+++ b/common/docs/containers.conf.5.md
@@ -691,6 +691,8 @@ The default paths on Linux are:
 - `/usr/local/lib/podman`
 - `/usr/libexec/podman`
 - `/usr/lib/podman`
+- `/usr/libexec`
+- `/usr/local/libexec'`
 
 The default paths on macOS are:
 

--- a/common/pkg/config/config_linux.go
+++ b/common/pkg/config/config_linux.go
@@ -26,6 +26,8 @@ var defaultHelperBinariesDir = []string{
 	"/usr/local/lib/podman",
 	"/usr/libexec/podman",
 	"/usr/lib/podman",
+	"/usr/libexec",
+	"/usr/local/libexec",
 }
 
 // Capabilities returns the capabilities parses the Add and Drop capability


### PR DESCRIPTION
When searching for helper binaries, also look in the `/usr/libexec` and `/usr/local/libexec` paths.

Related to: https://github.com/containers/podman/pull/27719

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
