### PR TITLE
Fix secretsdb cache consistency and improve memory efficiency

### DIFF
--- a/common/pkg/secrets/secretsdb_test.go
+++ b/common/pkg/secrets/secretsdb_test.go
@@ -1,0 +1,63 @@
+package secrets
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// makeReadOnly is used to simulate IO errors like disk full.
+func makeReadOnly(t *testing.T, path string) func() {
+	t.Helper()
+	err := os.Chmod(path, 0o500)
+	require.NoError(t, err)
+
+	return func() {
+		os.Chmod(path, 0o700)
+	}
+}
+
+func TestDBRollback(t *testing.T) {
+	testSecretName := "testsecret"
+	testSecretData := "secretdata"
+
+	t.Run("delete rollback on write failure", func(t *testing.T) {
+		manager, driverOpts := setup(t)
+		storeOpts := StoreOptions{DriverOpts: driverOpts}
+
+		secretID, err := manager.Store(testSecretName, []byte(testSecretData), drivertype, storeOpts)
+		require.NoError(t, err)
+
+		cleanup := makeReadOnly(t, manager.secretsDBPath)
+		defer cleanup()
+
+		_, err = manager.Delete(testSecretName)
+		require.Error(t, err)
+
+		// Verify rollback: secret should still exist in memory
+		require.Equal(t, secretID, manager.db.NameToID[testSecretName])
+		require.NotEmpty(t, manager.db.Secrets[secretID])
+	})
+
+	t.Run("store rollback on write failure", func(t *testing.T) {
+		manager, driverOpts := setup(t)
+		storeOpts := StoreOptions{DriverOpts: driverOpts}
+
+		// Make the db file
+		_, err := manager.Store("a", []byte("b"), drivertype, storeOpts)
+		require.NoError(t, err)
+		_, err = manager.Delete("a")
+		require.NoError(t, err)
+
+		cleanup := makeReadOnly(t, manager.secretsDBPath)
+		defer cleanup()
+
+		_, err = manager.Store(testSecretName, []byte(testSecretData), drivertype, storeOpts)
+		require.Error(t, err)
+
+		// Verify rollback: secret should not exist in memory
+		require.Empty(t, manager.db.NameToID[testSecretName])
+		require.Empty(t, manager.db.Secrets)
+	})
+}


### PR DESCRIPTION
# Fix secretsdb cache consistency and improve memory efficiency
## Summary

This PR simplifies the secrets database schema by removing the redundant `IDToName` map and fixes a bug where the in-memory cache could become inconsistent with the on-disk database when marshal or write operations fail.

## Changes

### 1. Fix cache/file consistency on errors

**Bug:** When `store()` or `delete()` modified the in-memory cache and then failed during `json.MarshalIndent()` or `os.WriteFile()`, the cache would be left in a modified state while the file retained the old data — causing inconsistency.

**Fix:** Use `defer` with named return values to rollback cache changes on any error:

- **`store()`**: On error, deletes the newly added entries from cache
- **`delete()`**: On error, restores the previously deleted entries to cache

### 2. Remove redundant `IDToName` map

The `db` struct previously maintained three maps:
- `Secrets`: ID → Secret (contains Name)
- `NameToID`: Name → ID
- `IDToName`: ID → Name ← **redundant**

Since `Secrets[id].Name` already provides the ID→Name mapping, `IDToName` was unnecessary duplication. This PR removes it and updates all lookups to use the `Secrets` map directly.

### 3. General code improvements 
- Add newDB() constructor 
- Remove dead code
- Improve error messages (related https://github.com/containers/podman/issues/27635)

## Files Changed
- `common/pkg/secrets/secretsdb.go`
- `common/pkg/secrets/secrets.go`

## Testing

- [x] Existing unit tests pass
- [x] Added failing test on older revision. 

## Checklist

- [x] Code follows project conventions
- [x] No new linter errors introduced
- [x] Backwards compatible (JSON schema change removes unused field)

