### PR TITLE
validate: refactor git-validate

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -71,7 +71,8 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     env:
-      GIT_CHECK_EXCLUDE: "./vendor"
+      # Base commit sha that we use the lint the commit from
+      EPOCH_TEST_COMMIT: "${{ github.event.pull_request.base.sha }}"
     steps:
     - uses: actions/checkout@v6
       with:
@@ -85,10 +86,7 @@ jobs:
         # See comment on lint task
         cache-dependency-path: "**/go.sum"
     - name: run git-validation
-
-      # We validate all commits as we only fetched the number of commits in the PR above,
-      # by default git-validation has some special github action handling but that seems broken.
-      run: make .install.gitvalidation && git-validation -no-github
+      run: make .install.gitvalidation && make git-validation
 
   go-vendor:
     runs-on: ubuntu-24.04

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,10 @@ install.tools: .install.gitvalidation .install.golangci-lint .install.md2man
 
 .PHONY: git-validation
 git-validation: .install.gitvalidation
-	GIT_CHECK_EXCLUDE="./vendor" git-validation -q -run DCO,short-subject,dangling-whitespace -range "$(EPOCH_TEST_COMMIT)..HEAD"
+ifndef EPOCH_TEST_COMMIT
+	$(error EPOCH_TEST_COMMIT is empty)
+endif
+	GIT_CHECK_EXCLUDE="./vendor" git-validation $(if $(CI),,-q) -run DCO,short-subject,dangling-whitespace -range "$(EPOCH_TEST_COMMIT)..HEAD"
 
 .PHONY: lint
 lint: .install.golangci-lint


### PR DESCRIPTION
Do not define GIT_CHECK_EXCLUDE in two places and just define it once and make the action use the Makefile.
In addtion we don't want to lint the full set of commits, this seems to cause side effects with merge commits as it lints commits that may no actual be in the PR and thus it can fail.

Using "github.event.pull_request.base.sha" is the right base commit we care about and makes the validation work. Thanks to Miloslav for finding that value.

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
