### PR TITLE
secrets: enhance logging for shell driver and store operations

### DIFF
--- a/common/pkg/secrets/secrets.go
+++ b/common/pkg/secrets/secrets.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"go.podman.io/common/pkg/secrets/define"
 	"go.podman.io/common/pkg/secrets/filedriver"
 	"go.podman.io/common/pkg/secrets/passdriver"
@@ -58,7 +59,7 @@ var secretsFile = "secrets.json"
 //
 // revive does not like the name because the package is already called secrets
 //
-//nolint:revive
+// revive does not like the name because the package is already called secrets
 type SecretsManager struct {
 	// secretsPath is the path to the db file where secrets are stored
 	secretsDBPath string
@@ -95,7 +96,7 @@ type Secret struct {
 //
 // revive does not like the name because the package is already called secrets
 //
-//nolint:revive
+// revive does not like the name because the package is already called secrets
 type SecretsDriver interface {
 	// List lists all secret ids in the secrets data store
 	List() ([]string, error)
@@ -245,14 +246,16 @@ func (s *SecretsManager) Store(name string, data []byte, driverType string, opti
 		return "", err
 	}
 
+	logrus.Tracef("Storing secret %s data using driver %s", name, driverType)
 	err = driver.Store(secr.ID, data)
 	if err != nil {
-		return "", fmt.Errorf("creating secret %s: %w", name, err)
+		return "", fmt.Errorf("driver failed to store secret %s data: %w", name, err)
 	}
 
+	logrus.Tracef("Storing secret %s metadata", name)
 	err = s.store(secr)
 	if err != nil {
-		return "", fmt.Errorf("creating secret %s: %w", name, err)
+		return "", fmt.Errorf("manager failed to store secret %s metadata: %w", name, err)
 	}
 
 	return secr.ID, nil

--- a/common/pkg/secrets/shelldriver/shelldriver.go
+++ b/common/pkg/secrets/shelldriver/shelldriver.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/sirupsen/logrus"
 	"go.podman.io/common/pkg/secrets/define"
 )
 
@@ -79,6 +80,7 @@ func NewDriver(opts map[string]string) (*Driver, error) {
 func (d *Driver) List() (secrets []string, err error) {
 	cmd := exec.CommandContext(context.TODO(), "/bin/sh", "-c", d.ListCommand)
 	cmd.Env = os.Environ()
+	logrus.Debugf("Shell Driver: executing command %q with env %v", cmd.String(), cmd.Env)
 	cmd.Stderr = os.Stderr
 
 	buf := &bytes.Buffer{}
@@ -109,6 +111,7 @@ func (d *Driver) Lookup(id string) ([]byte, error) {
 	cmd := exec.CommandContext(context.TODO(), "/bin/sh", "-c", d.LookupCommand)
 	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env, "SECRET_ID="+id)
+	logrus.Debugf("Shell Driver: executing command %q with env %v", cmd.String(), cmd.Env)
 	cmd.Stderr = os.Stderr
 
 	buf := &bytes.Buffer{}
@@ -130,6 +133,7 @@ func (d *Driver) Store(id string, data []byte) error {
 	cmd := exec.CommandContext(context.TODO(), "/bin/sh", "-c", d.StoreCommand)
 	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env, "SECRET_ID="+id)
+	logrus.Debugf("Shell Driver: executing command %q with env %v", cmd.String(), cmd.Env)
 
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
@@ -147,6 +151,7 @@ func (d *Driver) Delete(id string) error {
 	cmd := exec.CommandContext(context.TODO(), "/bin/sh", "-c", d.DeleteCommand)
 	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env, "SECRET_ID="+id)
+	logrus.Debugf("Shell Driver: executing command %q with env %v", cmd.String(), cmd.Env)
 
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
This patch adds DEBUG logging to the shell driver to print the exact command and environment variables being executed. It also adds TRACE logging to the SecretsManager.Store method and improves error wrapping to distinguish between driver errors and metadata storage errors.

Fixes containers/podman#27635

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
