### PR TITLE
fix: Use octal literal syntax for file mode in tar header

### DIFF
--- a/common/pkg/libartifact/store/store.go
+++ b/common/pkg/libartifact/store/store.go
@@ -742,7 +742,7 @@ func copyTrustedImageBlobToTarStream(ctx context.Context, imgSrc types.ImageSour
 	now := time.Now()
 	header := tar.Header{
 		Name:       filename,
-		Mode:       600,
+		Mode:       0o600,
 		Size:       srcSize,
 		ModTime:    now,
 		ChangeTime: now,


### PR DESCRIPTION
<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->

This PR changes the file mode to octet literal.