### PR TITLE
Support multiple static IPs and validate subnets

### DIFF
--- a/common/libnetwork/internal/util/validate.go
+++ b/common/libnetwork/internal/util/validate.go
@@ -68,14 +68,29 @@ func ValidateSubnet(s *types.Subnet, addGateway bool, usedNetworks []*net.IPNet)
 }
 
 // ValidateSubnets will validate the subnets for this network.
+// Will check that no subnets are overlapping or duplicated.
 // It also sets the gateway if the gateway is empty and addGateway is set to true
 // IPv6Enabled to true if at least one subnet is ipv6.
 func ValidateSubnets(network *types.Network, addGateway bool, usedNetworks []*net.IPNet) error {
 	for i := range network.Subnets {
+		for j := i + 1; j < len(network.Subnets); j++ {
+			subnetA := network.Subnets[i].Subnet
+			subnetB := network.Subnets[j].Subnet
+
+			if subnetA.String() == subnetB.String() {
+				return fmt.Errorf("duplicate subnets detected: %s", subnetA.String())
+			}
+
+			if networkIntersect(&subnetA.IPNet, &subnetB.IPNet) {
+				return fmt.Errorf("overlapping subnets detected: %s and %s", subnetA.String(), subnetB.String())
+			}
+		}
+
 		err := ValidateSubnet(&network.Subnets[i], addGateway, usedNetworks)
 		if err != nil {
 			return err
 		}
+
 		if util.IsIPv6(network.Subnets[i].Subnet.IP) {
 			network.IPv6Enabled = true
 		}

--- a/common/libnetwork/netavark/config_test.go
+++ b/common/libnetwork/netavark/config_test.go
@@ -563,6 +563,37 @@ var _ = Describe("Config", func() {
 			Expect(err.Error()).To(ContainSubstring("subnet ip is nil"))
 		})
 
+		DescribeTable("Subnet validation",
+			func(subnets []string, errContains string) {
+				ns := make([]types.Subnet, 0, len(subnets))
+				for _, s := range subnets {
+					sn, _ := types.ParseCIDR(s)
+					ns = append(ns, types.Subnet{Subnet: sn})
+				}
+
+				network := types.Network{Driver: "bridge", Subnets: ns}
+				_, err := libpodNet.NetworkCreate(network, nil)
+				if errContains != "" {
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring(errContains))
+					return
+				}
+				Expect(err).ToNot(HaveOccurred())
+			},
+			// Config file defines overlapping subnets:
+			// - 10.1.2.0/23 covers 10.1.2.0-10.1.3.255
+			// - 10.1.3.248/30 covers 10.1.3.248-10.1.3.251 (subset of the /23)
+			Entry("overlapping ipv4 subnets", []string{"10.1.2.0/23", "10.1.3.248/30"}, "overlapping subnets detected"),
+			// Config file defines overlapping subnets:
+			// - fd00:1:2::/48 covers fd00:1:2:0:0:0:0:0 - fd00:1:2:ffff:ffff:ffff:ffff:ffff
+			// - fd00:1:2:3:f8::/124 covers fd00:1:2:3:f8:0:0:0 - fd00:1:2:3:f8:0:0:f (subset of the /48)
+			Entry("overlapping ipv6 subnets", []string{"fd00:1:2::/48", "fd00:1:2:3:f8::/124"}, "overlapping subnets detected"),
+			Entry("duplicate ipv4 subnets", []string{"10.89.0.0/16", "10.89.0.0/16"}, "duplicate subnets detected"),
+			Entry("duplicate ipv6 subnets", []string{"fd11::/64", "fd11::/64"}, "duplicate subnets detected"),
+			Entry("two non-overlapping ipv4 subnets", []string{"10.12.0.0/16", "10.13.0.0/16"}, ""),
+			Entry("two non-overlapping ipv6 subnets", []string{"fd12::/64", "fd13::/64"}, ""),
+		)
+
 		It("create network with name", func() {
 			name := "myname"
 			network := types.Network{

--- a/common/libnetwork/netavark/ipam_test.go
+++ b/common/libnetwork/netavark/ipam_test.go
@@ -558,4 +558,70 @@ var _ = Describe("IPAM", func() {
 		Expect(opts.Networks[netName].StaticIPs).To(HaveLen(1))
 		Expect(opts.Networks[netName].StaticIPs[0]).To(Equal(net.ParseIP("10.0.0.10").To4()))
 	})
+
+	DescribeTable("ipam alloc and dealloc multiple static IPs",
+		func(subnetStrs []string, staticStrs []string, expectedTotal int) {
+			subnets := make([]types.Subnet, 0, len(subnetStrs))
+			for _, s := range subnetStrs {
+				sn, _ := types.ParseCIDR(s)
+				subnets = append(subnets, types.Subnet{Subnet: sn})
+			}
+
+			network, err := networkInterface.NetworkCreate(
+				types.Network{Subnets: subnets},
+				nil,
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			netName := network.Name
+
+			staticIPs := make([]net.IP, 0, len(staticStrs))
+			for _, ip := range staticStrs {
+				staticIPs = append(staticIPs, net.ParseIP(ip))
+			}
+
+			opts := &types.NetworkOptions{
+				ContainerID: "someContainerID",
+				Networks: map[string]types.PerNetworkOptions{
+					netName: {StaticIPs: staticIPs},
+				},
+			}
+
+			err = networkInterface.allocIPs(opts)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(opts.Networks).To(HaveKey(netName))
+			Expect(opts.Networks[netName].StaticIPs).To(HaveLen(expectedTotal))
+			for _, ip := range staticIPs {
+				Expect(opts.Networks[netName].StaticIPs).To(ContainElement(WithTransform(func(i net.IP) string { return i.String() }, Equal(ip.String()))))
+			}
+
+			err = networkInterface.deallocIPs(opts)
+			Expect(err).ToNot(HaveOccurred())
+		},
+		Entry("ipv4 single subnet",
+			[]string{"10.89.0.0/16"},
+			[]string{"10.89.0.5", "10.89.0.10", "10.89.0.15"},
+			3,
+		),
+		Entry("ipv4 two subnets",
+			[]string{"10.89.0.0/16", "10.90.0.0/16"},
+			[]string{"10.89.0.5", "10.90.0.10", "10.89.0.15"},
+			3,
+		),
+		Entry("ipv6 single subnet",
+			[]string{"fd80::/64"},
+			[]string{"fd80::5", "fd80::10", "fd80::15"},
+			3,
+		),
+		Entry("ipv6 two subnets",
+			[]string{"fd80::/64", "fd81::/64"},
+			[]string{"fd80::5", "fd81::10", "fd80::15"},
+			3,
+		),
+		Entry("mixed ipv6 static and automatic ipv4",
+			[]string{"10.200.0.0/24", "fd82::/64"},
+			[]string{"fd82::5", "fd82::15"},
+			3,
+		),
+	)
 })


### PR DESCRIPTION
Fixes allocation logic to support containers with multiple static IPs from different subnets, while preventing invalid subnet configurations.

Fixes: https://issues.redhat.com/browse/RHEL-98277

Related: https://github.com/containers/netavark/pull/1379


<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
