### PR TITLE
fix(secrets): allow deletion of tracked secrets which no longer exist

### DIFF
--- a/common/pkg/secrets/secrets.go
+++ b/common/pkg/secrets/secrets.go
@@ -276,7 +276,8 @@ func (s *SecretsManager) Delete(nameOrID string) (string, error) {
 	}
 
 	err = driver.Delete(secretID)
-	if err != nil {
+	// If the driver does not have that secret, it's considered to be deleted
+	if err != nil && !errors.Is(err, define.ErrNoSuchSecret) {
 		return "", fmt.Errorf("deleting secret %s: %w", nameOrID, err)
 	}
 


### PR DESCRIPTION
When deleting a secret, it's possible the underlying driver no longer holds that secret, in which case an ErrNoSuchSecret error is thrown. In previous versions, this would force the secrets manager to keep a reference to that non-existing secret.

Fixes containers/podman#27666

Signed-off-by: Samuel Gunter <sgunter@utexas.edu>

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
