### PR TITLE
idtools: avoid direct use of C.stderr to fix musl cgo build failures

### DIFF
--- a/storage/pkg/idtools/idtools_supported.go
+++ b/storage/pkg/idtools/idtools_supported.go
@@ -20,6 +20,12 @@ struct subid_range get_range(struct subid_range *ranges, int i)
     return ranges[i];
 }
 
+// helper for stderr to avoid referencing C.stderr from Go code,
+// which breaks cgo on musl due to stderr being declared as FILE *const
+static FILE *subid_stderr(void) {
+    return stderr;
+}
+
 #if !defined(SUBID_ABI_MAJOR) || (SUBID_ABI_MAJOR < 4)
 # define subid_init libsubid_init
 # define subid_get_uid_ranges get_subuid_ranges
@@ -44,7 +50,7 @@ func readSubid(username string, isUser bool) (ranges, error) {
 	}
 
 	onceInit.Do(func() {
-		C.subid_init(C.CString("storage"), C.stderr)
+		C.subid_init(C.CString("storage"), C.subid_stderr())
 	})
 
 	cUsername := C.CString(username)


### PR DESCRIPTION
On musl-based systems, stderr is declared as FILE *const.

Referencing stderr directly from Go code (via C.stderr) causes cgo to generate assignment code for a const-qualified pointer, which is invalid C and fails to compile.

Both gcc and clang reject the generated code with error messages below:

clang:
> cgo-gcc-prolog:85:9: error: cannot assign to variable '_cgo_r' with const-qualified type 'typeof (_cgo_a->r)' (aka 'struct _IO_FILE *const')
> cgo-gcc-prolog:83:24: note: variable '_cgo_r' declared const here
> cgo-gcc-prolog:88:12: error: cannot assign to non-static data member 'r' with const-qualified type 'FILE *const' (aka 'struct _IO_FILE *const')
> cgo-gcc-prolog:80:15: note: non-static data member 'r' declared const here

gcc:
> cgo-gcc-prolog:85:9: error: assignment of read-only variable '_cgo_r'
> cgo-gcc-prolog:88:12: error: assignment of read-only member 'r'

This patch avoids referencing C.stderr from Go code and instead returns stderr from a small C helper function. This keeps the usage entirely in C and avoids cgo’s broken handling for const-qualified global objects.

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
