### PR TITLE
Fix typo in error variable name: ErrArtifactUnamed -> ErrArtifactUnnamed

### DIFF
--- a/common/pkg/libartifact/artifact.go
+++ b/common/pkg/libartifact/artifact.go
@@ -31,7 +31,7 @@ func (a *Artifact) GetName() (string, error) {
 	}
 	// We don't have a concept of None for artifacts yet, but if we do,
 	// then we should probably not error but return `None`
-	return "", types.ErrArtifactUnamed
+	return "", types.ErrArtifactUnnamed
 }
 
 // SetName is a accessor for setting the artifact name

--- a/common/pkg/libartifact/types/errors.go
+++ b/common/pkg/libartifact/types/errors.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	ErrArtifactUnamed           = errors.New("artifact is unnamed")
+	ErrArtifactUnnamed          = errors.New("artifact is unnamed")
 	ErrArtifactNotExist         = errors.New("artifact does not exist")
 	ErrArtifactAlreadyExists    = errors.New("artifact already exists")
 	ErrArtifactFileExists       = errors.New("file already exists in artifact")


### PR DESCRIPTION
<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->

This PR fixes a typo.