### PR TITLE
seccomp: block AF_VSOCK sockets

### DIFF
--- a/common/pkg/seccomp/default_linux.go
+++ b/common/pkg/seccomp/default_linux.go
@@ -821,6 +821,21 @@ func DefaultProfile() *Seccomp {
 				"socket",
 			},
 			Action:   ActErrno,
+			Errno:    "EPERM",
+			ErrnoRet: &eperm,
+			Args: []*Arg{
+				{
+					Index: 0,
+					Value: unix.AF_VSOCK,
+					Op:    OpEqualTo,
+				},
+			},
+		},
+		{
+			Names: []string{
+				"socket",
+			},
+			Action:   ActErrno,
 			Errno:    "EINVAL",
 			ErrnoRet: &einval,
 			Args: []*Arg{
@@ -846,6 +861,11 @@ func DefaultProfile() *Seccomp {
 			Action: ActAllow,
 			Args: []*Arg{
 				{
+					Index: 0,
+					Value: unix.AF_NETLINK,
+					Op:    OpEqualTo,
+				},
+				{
 					Index: 2,
 					Value: unix.NETLINK_AUDIT,
 					Op:    OpNotEqual,
@@ -878,20 +898,11 @@ func DefaultProfile() *Seccomp {
 			Action: ActAllow,
 			Args: []*Arg{
 				{
-					Index: 2,
-					Value: unix.NETLINK_AUDIT,
+					Index: 0,
+					Value: unix.AF_VSOCK,
 					Op:    OpNotEqual,
 				},
 			},
-			Excludes: Filter{
-				Caps: []string{"CAP_AUDIT_WRITE"},
-			},
-		},
-		{
-			Names: []string{
-				"socket",
-			},
-			Action: ActAllow,
 			Includes: Filter{
 				Caps: []string{"CAP_AUDIT_WRITE"},
 			},

--- a/common/pkg/seccomp/seccomp.json
+++ b/common/pkg/seccomp/seccomp.json
@@ -965,6 +965,25 @@
 			"args": [
 				{
 					"index": 0,
+					"value": 40,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_EQ"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {},
+			"errnoRet": 1,
+			"errno": "EPERM"
+		},
+		{
+			"names": [
+				"socket"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [
+				{
+					"index": 0,
 					"value": 16,
 					"valueTwo": 0,
 					"op": "SCMP_CMP_EQ"
@@ -992,6 +1011,12 @@
 			],
 			"action": "SCMP_ACT_ALLOW",
 			"args": [
+				{
+					"index": 0,
+					"value": 16,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_EQ"
+				},
 				{
 					"index": 2,
 					"value": 9,
@@ -1035,26 +1060,12 @@
 			"action": "SCMP_ACT_ALLOW",
 			"args": [
 				{
-					"index": 2,
-					"value": 9,
+					"index": 0,
+					"value": 40,
 					"valueTwo": 0,
 					"op": "SCMP_CMP_NE"
 				}
 			],
-			"comment": "",
-			"includes": {},
-			"excludes": {
-				"caps": [
-					"CAP_AUDIT_WRITE"
-				]
-			}
-		},
-		{
-			"names": [
-				"socket"
-			],
-			"action": "SCMP_ACT_ALLOW",
-			"args": null,
 			"comment": "",
 			"includes": {
 				"caps": [


### PR DESCRIPTION
Block the socket() syscall with AF_VSOCK to prevent container escapes via VM sockets.

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
