### PR TITLE
storage: update store-locks.bt to figure out code path

### DIFF
--- a/storage/contrib/scripts/store-locks.bt
+++ b/storage/contrib/scripts/store-locks.bt
@@ -44,6 +44,15 @@ kretfunc:fcntl_setlk
       printf("blocked %s time: %lld msec\n", $lockname, $lock_duration);
     }
 
+    // When observing long lock durations but not knowing what code paths do that
+    // uncomment the lines below and adjust the threshold in order to send SIGABRT
+    // to the process holding the lock. The go runtime should then create a stack
+    // trace which points to the code path holding the lock.
+    // When doing this add --unsafe as argument to bpftrace as it fails otherwise.
+    /*if ($lock_duration > 1000) {
+      signal("SIGABRT");
+    }*/
+
     // store max and create histogram that get printed on bpftrace exit (CTRL-C)
     @block_max[$lockname] = max($lock_duration);
     @block_duration[$lockname] = hist($lock_duration);


### PR DESCRIPTION
This adds a comment to show how we can figure out which code path is holding the lock for to long. This works by sending SIGABRT to the go process which then exits and dumps the go runtime stack traces.

The nice thing is we can do this without instrumenting the actual code base so it can be used without having to compile podman, buildah, etc...

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
