### PR TITLE
Add DockerProxy field for dynamic proxy configuration

### DIFF
--- a/image/docker/docker_client.go
+++ b/image/docker/docker_client.go
@@ -972,6 +972,11 @@ func (c *dockerClient) detectPropertiesHelper(ctx context.Context) error {
 	if c.sys != nil && c.sys.DockerProxyURL != nil {
 		tr.Proxy = http.ProxyURL(c.sys.DockerProxyURL)
 	}
+	if c.sys != nil && c.sys.DockerProxy != nil {
+		tr.Proxy = func(request *http.Request) (*url.URL, error) {
+			return c.sys.DockerProxy(request.URL)
+		}
+	}
 	c.client = &http.Client{Transport: tr}
 
 	ping := func(scheme string) error {

--- a/image/types/types.go
+++ b/image/types/types.go
@@ -668,6 +668,10 @@ type SystemContext struct {
 	DockerRegistryPushPrecomputeDigests bool
 	// DockerProxyURL specifies proxy configuration schema (like socks5://username:password@ip:port)
 	DockerProxyURL *url.URL
+	// DockerProxy is a function that determines the proxy URL for a given request URL.
+	// If set, this takes precedence over DockerProxyURL. The function should return the proxy URL to use,
+	// or nil if no proxy should be used for the given request.
+	DockerProxy func(reqURL *url.URL) (*url.URL, error)
 
 	// === docker/daemon.Transport overrides ===
 	// A directory containing a CA certificate (ending with ".crt"),


### PR DESCRIPTION
Add a new DockerProxy field to SystemContext that accepts a function for determining proxy URLs dynamically per request. This provides more flexibility than the static DockerProxyURL field, allowing for advanced proxy configurations such as those from httpproxy.Config.ProxyFunc().

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
