### PR TITLE
allow lookup of artifact by digest

### DIFF
--- a/common/pkg/libartifact/artifact.go
+++ b/common/pkg/libartifact/artifact.go
@@ -1,18 +1,21 @@
 package libartifact
 
 import (
-	"encoding/json"
-
 	"github.com/opencontainers/go-digest"
 	"go.podman.io/common/pkg/libartifact/types"
 	"go.podman.io/image/v5/manifest"
 )
 
 type Artifact struct {
+	// Digest is the Digest of the artifact
+	Digest digest.Digest
+	Name   string
 	// Manifest is the OCI manifest for the artifact with the name.
 	// In a valid artifact the Manifest is guaranteed to not be nil.
 	Manifest *manifest.OCI1
-	Name     string
+	// rawManifest is the manifest as it was originally read off disk
+	// and has never been marshalled. i.e. the "blob"
+	rawManifest []byte
 }
 
 // TotalSizeBytes returns the total bytes of the all the artifact layers.
@@ -40,15 +43,6 @@ func (a *Artifact) GetName() (string, error) {
 // called Name.
 func (a *Artifact) SetName(name string) {
 	a.Name = name
-}
-
-func (a *Artifact) GetDigest() (*digest.Digest, error) {
-	b, err := json.Marshal(a.Manifest)
-	if err != nil {
-		return nil, err
-	}
-	artifactDigest := digest.FromBytes(b)
-	return &artifactDigest, nil
 }
 
 type ArtifactList []*Artifact

--- a/common/pkg/libartifact/reference.go
+++ b/common/pkg/libartifact/reference.go
@@ -1,4 +1,4 @@
-package store
+package libartifact
 
 import (
 	"go.podman.io/common/pkg/libartifact/types"

--- a/common/pkg/libartifact/reference_test.go
+++ b/common/pkg/libartifact/reference_test.go
@@ -1,4 +1,4 @@
-package store
+package libartifact
 
 import (
 	"testing"

--- a/common/pkg/libartifact/store_reference.go
+++ b/common/pkg/libartifact/store_reference.go
@@ -1,4 +1,4 @@
-package store
+package libartifact
 
 import (
 	"errors"

--- a/common/pkg/libartifact/store_reference_test.go
+++ b/common/pkg/libartifact/store_reference_test.go
@@ -1,4 +1,4 @@
-package store
+package libartifact
 
 import (
 	"testing"

--- a/common/pkg/libartifact/unparsed.go
+++ b/common/pkg/libartifact/unparsed.go
@@ -1,6 +1,6 @@
 //go:build !remote
 
-package store
+package libartifact
 
 import (
 	"context"

--- a/go.work.sum
+++ b/go.work.sum
@@ -163,6 +163,7 @@ golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/sys v0.39.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/telemetry v0.0.0-20251008203120-078029d740a8/go.mod h1:Pi4ztBfryZoJEkyFTI5/Ocsu2jXyDr6iSdgJiYE/uwE=
 golang.org/x/telemetry v0.0.0-20251111182119-bc8e575c7b54/go.mod h1:hKdjCMrbv9skySur+Nek8Hd0uJ0GuxJIoIX2payrIdQ=
+golang.org/x/telemetry v0.0.0-20251203150158-8fff8a5912fc/go.mod h1:hKdjCMrbv9skySur+Nek8Hd0uJ0GuxJIoIX2payrIdQ=
 golang.org/x/term v0.38.0/go.mod h1:bSEAKrOT1W+VSu9TSCMtoGEOUcKxOKgl3LE5QEF/xVg=
 golang.org/x/tools v0.32.0/go.mod h1:ZxrU41P/wAbZD8EDa6dDCa6XfpkhJ7HFMjHJXfBDu8s=
 golang.org/x/tools v0.38.0/go.mod h1:yEsQ/d/YK8cjh0L6rZlY8tgtlKiBNTL14pGDJPJpYQs=


### PR DESCRIPTION
Issue #408 describes libartifact not working for use cases where consumers want to look up an artifact by it's digest. This allows, among other things, for inspect to be done by digest.

Fixes #408

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
