### PR TITLE
Add DockerAdditionalTrustedBundle for custom CAs

### DIFF
--- a/image/docker/docker_client.go
+++ b/image/docker/docker_client.go
@@ -262,6 +262,11 @@ func newDockerClient(sys *types.SystemContext, registry, reference string) (*doc
 		return nil, err
 	}
 
+	// If the non-host-specific trust bundle is given add it to the RootCAs pool
+	if sys.DockerAdditionalTrustedBundle != "" {
+		tlsClientConfig.RootCAs.AppendCertsFromPEM([]byte(sys.DockerAdditionalTrustedBundle))
+	}
+
 	// Check if TLS verification shall be skipped (default=false) which can
 	// be specified in the sysregistriesv2 configuration.
 	skipVerify := false

--- a/image/types/types.go
+++ b/image/types/types.go
@@ -640,6 +640,8 @@ type SystemContext struct {
 	// If not "", overrides the system’s default path for a directory containing host[:port] subdirectories with the same structure as DockerCertPath above.
 	// Ignored if DockerCertPath is non-empty.
 	DockerPerHostCertDirPath string
+	// If not "", a string containing PEM-encoded certificates to add to the trusted root CAs.
+	DockerAdditionalTrustedBundle string
 	// Allow contacting container registries over HTTP, or HTTPS with failed TLS verification. Note that this does not affect other TLS connections.
 	DockerInsecureSkipTLSVerify OptionalBool
 	// if nil, the library tries to parse ~/.docker/config.json to retrieve credentials


### PR DESCRIPTION
## Summary

Adds `DockerAdditionalTrustedBundle` field to `SystemContext` for providing additional PEM-encoded CA certificates when connecting to Docker registries.

## Use case

Useful when host-specific certificates are configured but a common CA is needed across all registry connections.

## Changes

  - Added `DockerAdditionalTrustedBundle` field to `SystemContext`
  - Appends provided certificates to TLS `RootCAs` pool in `newDockerClient()`
