### PR TITLE
Do not access `uncompressed` reader after close.

### DIFF
--- a/image/docker/docker_image_dest.go
+++ b/image/docker/docker_image_dest.go
@@ -31,11 +31,11 @@ import (
 	"go.podman.io/image/v5/internal/set"
 	"go.podman.io/image/v5/internal/signature"
 	"go.podman.io/image/v5/internal/streamdigest"
-	"go.podman.io/image/v5/internal/uploadreader"
 	"go.podman.io/image/v5/manifest"
 	"go.podman.io/image/v5/pkg/blobinfocache/none"
 	compressiontypes "go.podman.io/image/v5/pkg/compression/types"
 	"go.podman.io/image/v5/types"
+	"go.podman.io/storage/pkg/terminablereader"
 )
 
 type dockerImageDestination struct {
@@ -183,7 +183,7 @@ func (d *dockerImageDestination) PutBlobWithOptions(ctx context.Context, stream 
 	stream = io.TeeReader(stream, sizeCounter)
 
 	uploadLocation, err = func() (*url.URL, error) { // A scope for defer
-		uploadReader := uploadreader.NewUploadReader(stream)
+		uploadReader := terminablereader.NewTerminableReader(stream)
 		// This error text should never be user-visible, we terminate only after makeRequestToResolvedURL
 		// returns, so there isn’t a way for the error text to be provided to any of our callers.
 		defer uploadReader.Terminate(errors.New("Reading data from an already terminated upload"))

--- a/storage/pkg/terminablereader/terminable_reader_test.go
+++ b/storage/pkg/terminablereader/terminable_reader_test.go
@@ -1,4 +1,4 @@
-package uploadreader
+package terminablereader
 
 import (
 	"bytes"
@@ -10,18 +10,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestUploadReader(t *testing.T) {
+func TestTerminableReader(t *testing.T) {
 	// This is a smoke test in a single goroutine, without really testing the locking.
 
 	data := bytes.Repeat([]byte{0x01}, 65535)
 	// No termination
-	ur := NewUploadReader(bytes.NewReader(data))
+	ur := NewTerminableReader(bytes.NewReader(data))
 	read, err := io.ReadAll(ur)
 	require.NoError(t, err)
 	assert.Equal(t, data, read)
 
 	// Terminated
-	ur = NewUploadReader(bytes.NewReader(data))
+	ur = NewTerminableReader(bytes.NewReader(data))
 	readLen := len(data) / 2
 	read, err = io.ReadAll(io.LimitReader(ur, int64(readLen)))
 	require.NoError(t, err)


### PR DESCRIPTION
Before this commit, when the `applyDiff` function returned, the `defer uncompressed.Close()` was executed. This dealocated the resources which might still be used by another goroutine trying to read them.

This commit fixes it by reusing existing `UploadReader` logic from the `image` package. Since the `UploadReader` is now used by both `image` and `storage`, it is now moved to `storage` and renamed to `TerminableReader` (it is no longer used just for "upload").

The `TerminableReader` wraps the `Read` function and if its `Terminate` is called, the `Read` function returns an error. This effectively ensures that the real closed `io.Reader` under the `TerminableReader` is never used after `close()` and the crash is fixed.

Fixes #148.

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
