### PR TITLE
storage: add new pkg/configfile package

### DIFF
--- a/storage/pkg/configfile/doc.go
+++ b/storage/pkg/configfile/doc.go
@@ -1,0 +1,7 @@
+// Package configfile provides the utilities for our config file parsing.
+//
+// Note the API here is not considered stable and can and will change and we see fit.
+// The purpose is to use this only for our own config file parsing such as
+// containers.conf, storage.conf and registries.conf. We will not consider use cases
+// for external consumers.
+package configfile

--- a/storage/pkg/configfile/parse.go
+++ b/storage/pkg/configfile/parse.go
@@ -1,0 +1,365 @@
+package configfile
+
+import (
+	"errors"
+	"io"
+	"io/fs"
+	"iter"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+	"github.com/sirupsen/logrus"
+)
+
+const _configPathName = "containers"
+
+var (
+	// systemConfigPath is the location for the default config files shipped by the distro/vendor.
+	//
+	// This can be overridden at build time with the following go linker flag:
+	// -ldflags '-X go.podman.io/storage/pkg/configfile.systemConfigPath=$your_path'
+	systemConfigPath = builtinSystemConfigPath
+
+	// adminOverrideConfigPath is the location for admin local override config files.
+	//
+	// This can be overridden at build time with the following go linker flag:
+	// -ldflags '-X go.podman.io/storage/pkg/configfile.adminOverrideConfigPath=$your_path'
+	adminOverrideConfigPath = getAdminOverrideConfigPath()
+)
+
+type File struct {
+	// The name of the config file WITHOUT the extension (i.e. no .conf).
+	// Must not be empty and must not contain the path separator.
+	Name string
+
+	// Extension is the file extension of the config file, i.e. "conf" or "yaml".
+	// Must not be empty and must not contain the path separator.
+	Extension string
+
+	// EnvironmentName is the name of environment variable that can be set to specify the override.
+	// Optional.
+	EnvironmentName string
+
+	// RootForImplicitAbsolutePaths is the path to an alternate root
+	// If not "", prefixed to any absolute paths used by default in the package.
+	// NOTE: This does NOT affect paths starting by $HOME or environment variables paths.
+	RootForImplicitAbsolutePaths string
+
+	// DoNotLoadMainFiles should be set if only the Drop In files should be loaded.
+	DoNotLoadMainFiles bool
+
+	// DoNotLoadDropInFiles should be set if only the main files should be loaded.
+	DoNotLoadDropInFiles bool
+
+	// DoNotUseExtensionForConfigName makes it so that the extension is only consulted for the drop in
+	// file names but not the main config file name search path.
+	DoNotUseExtensionForConfigName bool
+
+	// UserId is the id of the user running this. Used to know where to search in the
+	// different "rootful" and "rootless" drop in lookup paths.
+	UserId int
+
+	// Modules is a list of names of full paths which are loaded after all the other files.
+	// Note the modules concept exists only for containers.conf.
+	// For compatibility reasons this field is written to with the fully resolved paths
+	// of each module as this is what podman expects today.
+	Modules []string
+}
+
+// Item is a single config file that is being read once at a time and returned by the iterator from [Read].
+type Item struct {
+	// Reader is the reader from the file content. The Reader is only valid during
+	Reader io.Reader
+	// Name is the full filepath to the filename being read.
+	Name string
+}
+
+func getConfName(name, extension string, noExtension bool) string {
+	if noExtension {
+		return name
+	}
+	return name + "." + extension
+}
+
+// Read parses all config files with the specified options and returns an iterator which returns all files as Item in the right order.
+// If an error is returned by the iterator then this must be treated as fatal error and must fail the config file parsing.
+// Expected ENOENT errors are already ignored in this function and must not be handled again by callers.
+// The given File options must not be nil and populated with valid options.
+func Read(conf *File) iter.Seq2[*Item, error] {
+	configFileName := getConfName(conf.Name, conf.Extension, conf.DoNotUseExtensionForConfigName)
+
+	// Note this can be empty which is a valid case and should be simply ignored then.
+	defaultConfig := systemConfigPath
+	if defaultConfig != "" {
+		defaultConfig = filepath.Join(defaultConfig, configFileName)
+		if conf.RootForImplicitAbsolutePaths != "" {
+			defaultConfig = filepath.Join(conf.RootForImplicitAbsolutePaths, defaultConfig)
+		}
+	}
+
+	// Same here this can be empty.
+	overrideConfig := adminOverrideConfigPath
+	if overrideConfig != "" {
+		overrideConfig = filepath.Join(overrideConfig, configFileName)
+		if conf.RootForImplicitAbsolutePaths != "" {
+			overrideConfig = filepath.Join(conf.RootForImplicitAbsolutePaths, overrideConfig)
+		}
+	}
+
+	return func(yield func(*Item, error) bool) {
+		shouldLoadMainFile := !conf.DoNotLoadMainFiles
+		shouldLoadDropIns := !conf.DoNotLoadDropInFiles
+
+		yieldAndClose := func(f *os.File) bool {
+			ok := yield(&Item{
+				Reader: f,
+				Name:   f.Name(),
+			}, nil)
+			// Once yield returns always close the file as the consumer should be done with it.
+			if err := f.Close(); err != nil {
+				if ok {
+					// don't yield again if the previous yield returned false
+					yield(nil, err)
+				}
+				return false
+			}
+			return ok
+		}
+
+		if conf.EnvironmentName != "" {
+			if path := os.Getenv(conf.EnvironmentName); path != "" {
+				f, err := os.Open(path)
+				// Do not ignore ErrNotExist here, we want to hard error if users set a wrong path here.
+				if err != nil {
+					yield(nil, err)
+					return
+				}
+				if !yieldAndClose(f) {
+					return
+				}
+				// Also when the env is set skip the loading of the main and drop in files, modules and _OVERRIDE env are still read though.
+				shouldLoadMainFile = false
+				shouldLoadDropIns = false
+			}
+		}
+
+		// userConfig can be empty as well
+		userConfig, err := UserConfigPath()
+		if err != nil {
+			// return error via iterator
+			yield(nil, err)
+			return
+		}
+		if userConfig != "" {
+			userConfig = filepath.Join(userConfig, configFileName)
+		}
+
+		if shouldLoadMainFile {
+			for _, path := range []string{userConfig, overrideConfig, defaultConfig} {
+				if path == "" {
+					continue
+				}
+				f, err := os.Open(path)
+				// only ignore ErrNotExist, all other errors get return to the caller via yield
+				if err != nil {
+					if errors.Is(err, fs.ErrNotExist) {
+						continue
+					}
+					yield(nil, err)
+					return
+				}
+
+				if !yieldAndClose(f) {
+					return
+				}
+				// we only read the first file
+				break
+			}
+		}
+
+		if shouldLoadDropIns {
+			files, err := readDropIns(defaultConfig, overrideConfig, userConfig, conf.Extension, conf.UserId)
+			if err != nil {
+				// return error via iterator
+				yield(nil, err)
+				return
+			}
+			for _, file := range files {
+				f, err := os.Open(file)
+				// only ignore ErrNotExist, all other errors get return to the caller via yield
+				if err != nil {
+					if errors.Is(err, fs.ErrNotExist) {
+						continue
+					}
+					yield(nil, err)
+					return
+				}
+
+				if !yieldAndClose(f) {
+					return
+				}
+			}
+		}
+
+		if len(conf.Modules) > 0 {
+			dirs := moduleDirectories(defaultConfig, overrideConfig, userConfig)
+			resolvedModules := make([]string, 0, len(conf.Modules))
+			for _, module := range conf.Modules {
+				f, err := resolveModule(module, dirs)
+				if err != nil {
+					yield(nil, err)
+					return
+				}
+				resolvedModules = append(resolvedModules, f.Name())
+				if !yieldAndClose(f) {
+					return
+				}
+			}
+			conf.Modules = resolvedModules
+		}
+
+		if conf.EnvironmentName != "" {
+			// The _OVERRIDE env must be appended after loading all files, even modules.
+			if path := os.Getenv(conf.EnvironmentName + "_OVERRIDE"); path != "" {
+				f, err := os.Open(path)
+				// Do not ignore ErrNotExist here, we want to hard error if users set a wrong path here.
+				if err != nil {
+					yield(nil, err)
+					return
+				}
+				if !yieldAndClose(f) {
+					return
+				}
+			}
+		}
+	}
+}
+
+const dropInSuffix = ".d"
+
+func readDropIns(defaultConfig, overrideConfig, userConfig, extension string, uid int) ([]string, error) {
+	dropInMap := make(map[string]string)
+	paths := make([]string, 0, 7)
+
+	suffix := "." + extension
+
+	if defaultConfig != "" {
+		paths = append(paths, getDropInPaths(defaultConfig, suffix, uid)...)
+	}
+	if overrideConfig != "" {
+		paths = append(paths, getDropInPaths(overrideConfig, suffix, uid)...)
+	}
+	if userConfig != "" {
+		// the $HOME config only has one .d path not the rootful/rootless ones.
+		paths = append(paths, userConfig+dropInSuffix)
+	}
+
+	for _, path := range paths {
+		entries, err := os.ReadDir(path)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				continue
+			}
+			return nil, err
+		}
+		for _, entry := range entries {
+			if entry.Type().IsRegular() && strings.HasSuffix(entry.Name(), suffix) {
+				dropInMap[entry.Name()] = filepath.Join(path, entry.Name())
+			}
+		}
+	}
+
+	sortedNames := slices.Sorted(maps.Keys(dropInMap))
+	files := make([]string, 0, len(sortedNames))
+	for _, file := range sortedNames {
+		files = append(files, dropInMap[file])
+	}
+	return files, nil
+}
+
+func getDropInPaths(mainPath, suffix string, uid int) []string {
+	paths := make([]string, 0, 3)
+	paths = append(paths, mainPath+dropInSuffix)
+
+	rootless := uid > 0
+	var specialName string
+	if rootless {
+		specialName = "rootless"
+	} else {
+		specialName = "rootful"
+	}
+	// insert the name after the main config name but before the extension if it has one.
+	mainPath, cut := strings.CutSuffix(mainPath, suffix)
+	specialPath := mainPath + "." + specialName
+	if cut {
+		specialPath += suffix
+	}
+	specialPath += dropInSuffix
+	paths = append(paths, specialPath)
+	if rootless {
+		paths = append(paths, filepath.Join(specialPath, strconv.Itoa(uid)))
+	}
+	return paths
+}
+
+func moduleDirectories(defaultConfig, overrideConfig, userConfig string) []string {
+	const moduleSuffix = ".modules"
+	modules := make([]string, 0, 3)
+	if userConfig != "" {
+		modules = append(modules, userConfig+moduleSuffix)
+	}
+	if overrideConfig != "" {
+		modules = append(modules, overrideConfig+moduleSuffix)
+	}
+	if defaultConfig != "" {
+		modules = append(modules, defaultConfig+moduleSuffix)
+	}
+	return modules
+}
+
+// Resolve the specified path to a module.
+func resolveModule(path string, dirs []string) (*os.File, error) {
+	if filepath.IsAbs(path) {
+		return os.Open(path)
+	}
+
+	// Collect all errors to avoid suppressing important errors (e.g.,
+	// permission errors).
+	var multiErr error
+	for _, d := range dirs {
+		candidate := filepath.Join(d, path)
+
+		f, err := os.Open(candidate)
+		if err == nil {
+			return f, nil
+		}
+		multiErr = errors.Join(multiErr, err)
+	}
+	return nil, multiErr
+}
+
+// ParseTOML parses the given config according to the rules in by [Read].
+// Note the given configStruct must be a pointer to a struct that describes
+// the toml config fields and is modified in place.
+// If an error is returned the struct should not be used.
+func ParseTOML(configStruct any, conf *File) error {
+	for item, err := range Read(conf) {
+		if err != nil {
+			return err
+		}
+		meta, err := toml.NewDecoder(item.Reader).Decode(configStruct)
+		if err != nil {
+			return err
+		}
+		keys := meta.Undecoded()
+		if len(keys) > 0 {
+			logrus.Debugf("Failed to decode the keys %q from %q", keys, item.Name)
+		}
+	}
+	return nil
+}

--- a/storage/pkg/configfile/parse_test.go
+++ b/storage/pkg/configfile/parse_test.go
@@ -1,0 +1,724 @@
+package configfile
+
+import (
+	"io"
+	"io/fs"
+	"iter"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_getDropInPaths(t *testing.T) {
+	tests := []struct {
+		name string
+		// Arguments for this function
+		mainPath string
+		suffix   string
+		uid      int
+		// Expected result
+		want []string
+	}{
+		{
+			name:     "basic rootful",
+			mainPath: "/etc/containers/containers.conf",
+			suffix:   ".conf",
+			uid:      0,
+			want:     []string{"/etc/containers/containers.conf.d", "/etc/containers/containers.rootful.conf.d"},
+		},
+		{
+			name:     "basic rootless uid 500",
+			mainPath: "/etc/containers/containers.conf",
+			suffix:   ".conf",
+			uid:      500,
+			want:     []string{"/etc/containers/containers.conf.d", "/etc/containers/containers.rootless.conf.d", "/etc/containers/containers.rootless.conf.d/500"},
+		},
+		{
+			name:     "basic rootless uid 1234",
+			mainPath: "/etc/containers/containers.conf",
+			suffix:   ".conf",
+			uid:      1234,
+			want:     []string{"/etc/containers/containers.conf.d", "/etc/containers/containers.rootless.conf.d", "/etc/containers/containers.rootless.conf.d/1234"},
+		},
+		{
+			name:     "path with extra dots",
+			mainPath: "/path.with.dots/containers.conf",
+			suffix:   ".conf",
+			uid:      0,
+			want:     []string{"/path.with.dots/containers.conf.d", "/path.with.dots/containers.rootful.conf.d"},
+		},
+		{
+			name:     "/usr rootful",
+			mainPath: "/usr/share/containers/containers.conf",
+			suffix:   ".conf",
+			uid:      0,
+			want:     []string{"/usr/share/containers/containers.conf.d", "/usr/share/containers/containers.rootful.conf.d"},
+		},
+		{
+			name:     "storage.conf",
+			mainPath: "/usr/share/containers/storage.conf",
+			suffix:   ".conf",
+			uid:      0,
+			want:     []string{"/usr/share/containers/storage.conf.d", "/usr/share/containers/storage.rootful.conf.d"},
+		},
+		{
+			name:     "storage.conf",
+			mainPath: "/usr/share/containers/storage.conf",
+			suffix:   ".conf",
+			uid:      0,
+			want:     []string{"/usr/share/containers/storage.conf.d", "/usr/share/containers/storage.rootful.conf.d"},
+		},
+		{
+			name:     "registries.d",
+			mainPath: "/usr/share/containers/registries",
+			suffix:   ".yaml",
+			uid:      0,
+			want:     []string{"/usr/share/containers/registries.d", "/usr/share/containers/registries.rootful.d"},
+		},
+		{
+			name:     "registries.d rootless",
+			mainPath: "/usr/share/containers/registries",
+			suffix:   ".yaml",
+			uid:      99,
+			want:     []string{"/usr/share/containers/registries.d", "/usr/share/containers/registries.rootless.d", "/usr/share/containers/registries.rootless.d/99"},
+		},
+	}
+	t.Parallel()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getDropInPaths(tt.mainPath, tt.suffix, tt.uid)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// File layout of the test files, map key is filename/path and value is the content
+type testfiles struct {
+	usr  map[string]string
+	etc  map[string]string
+	home map[string]string
+}
+
+func Test_Read(t *testing.T) {
+	type testcase struct {
+		name string
+		// Arguments for this function
+		arg File
+		// Layout of the actual files we try to parse
+		files testfiles
+		// setup is extra setup that must be run before the test
+		setup func(t *testing.T, tc *testcase)
+		// Expected result, file content in right order.
+		want []string
+		// wantErr is the error type matched with errors.Is() is the function should error instead
+		wantErr error
+	}
+
+	tests := []testcase{
+		{
+			name: "no files",
+			arg: File{
+				Name:      "containers",
+				Extension: "conf",
+			},
+			want: nil,
+		},
+		{
+			name: "simple main file",
+			arg: File{
+				Name:      "containers",
+				Extension: "conf",
+			},
+			files: testfiles{
+				usr: map[string]string{
+					"containers.conf": "content1",
+					// file with different name should not be read
+					"storage.conf": "content2",
+				},
+			},
+			want: []string{"content1"},
+		},
+		{
+			name: "etc overrides usr file",
+			arg: File{
+				Name:      "containers",
+				Extension: "conf",
+			},
+			files: testfiles{
+				usr: map[string]string{
+					"containers.conf": "content1",
+				},
+				etc: map[string]string{
+					"containers.conf": "file2",
+				},
+			},
+			want: []string{"file2"},
+		},
+		{
+			name: "home overrides etc and usr file",
+			arg: File{
+				Name:      "containers",
+				Extension: "conf",
+			},
+			files: testfiles{
+				usr: map[string]string{
+					"containers.conf": "content1",
+				},
+				etc: map[string]string{
+					"containers.conf": "file2",
+				},
+				home: map[string]string{
+					"containers.conf": "home",
+				},
+			},
+			want: []string{"home"},
+		},
+		{
+			name: "single drop in",
+			arg: File{
+				Name:      "containers",
+				Extension: "conf",
+			},
+			files: testfiles{
+				usr: map[string]string{
+					"containers.conf.d/10-myconf.conf": "content1",
+				},
+			},
+			want: []string{"content1"},
+		},
+		{
+			name: "drop in and main file",
+			arg: File{
+				Name:      "containers",
+				Extension: "conf",
+			},
+
+			files: testfiles{
+				usr: map[string]string{
+					"containers.conf":                  "file1",
+					"containers.conf.d/10-myconf.conf": "file2",
+				},
+			},
+			want: []string{"file1", "file2"},
+		},
+		{
+			name: "drop in and main file on different paths",
+			arg: File{
+				Name:      "containers",
+				Extension: "conf",
+			},
+
+			files: testfiles{
+				usr: map[string]string{
+					"containers.conf.d/10-myconf.conf": "usr",
+				},
+				etc: map[string]string{
+					"containers.conf": "etc",
+				},
+			},
+			want: []string{"etc", "usr"},
+		},
+		{
+			name: "drop in order",
+			arg: File{
+				Name:      "containers",
+				Extension: "conf",
+			},
+
+			files: testfiles{
+				usr: map[string]string{
+					"containers.conf.d/20-conf2.conf": "2",
+					"containers.conf.d/40-conf4.conf": "4",
+				},
+				etc: map[string]string{
+					"containers.conf.d/10-conf1.conf": "1",
+				},
+				home: map[string]string{
+					"containers.conf.d/30-conf3.conf": "3",
+				},
+			},
+			want: []string{"1", "2", "3", "4"},
+		},
+		{
+			name: "drop in override",
+			arg: File{
+				Name:      "containers",
+				Extension: "conf",
+			},
+			files: testfiles{
+				usr: map[string]string{
+					// This should be ignored because etc has the same filename
+					"containers.conf.d/10-settings.conf": "usr-content",
+					"containers.conf.d/20-settings.conf": "usr-content-2",
+				},
+				etc: map[string]string{
+					// This should win
+					"containers.conf.d/10-settings.conf": "etc-override",
+				},
+			},
+			want: []string{"etc-override", "usr-content-2"},
+		},
+		{
+			name: "drop in ignores wrong extensions",
+			arg: File{
+				Name:      "containers",
+				Extension: "conf",
+			},
+			files: testfiles{
+				usr: map[string]string{
+					"containers.conf.d/10-valid.conf": "valid",
+					"containers.conf.d/README.md":     "ignore-me",
+					"containers.conf.d/backup.conf~":  "ignore-me-too",
+				},
+			},
+			want: []string{"valid"},
+		},
+		{
+			name: "policy.json main files only (ignore drop-ins)",
+			arg: File{
+				Name:                 "policy",
+				Extension:            "json",
+				DoNotLoadDropInFiles: true,
+			},
+			files: testfiles{
+				usr: map[string]string{
+					"policy.json":                 "main",
+					"policy.json.d/10-extra.json": "drop-in",
+				},
+			},
+			want: []string{"main"},
+		},
+		{
+			name: "registries.d drop ins only (ignore main)",
+			arg: File{
+				Name:                           "registries",
+				Extension:                      "yaml",
+				DoNotLoadMainFiles:             true,
+				DoNotUseExtensionForConfigName: true,
+			},
+			files: testfiles{
+				usr: map[string]string{
+					"registries.yaml":            "main",
+					"registries.d/10-extra.yaml": "drop-in",
+				},
+			},
+			want: []string{"drop-in"},
+		},
+		{
+			name: "rootless specific drop-ins",
+			arg: File{
+				Name:      "containers",
+				Extension: "conf",
+				UserId:    1000,
+			},
+			files: testfiles{
+				usr: map[string]string{
+					"containers.conf.d/01-global.conf":        "global",
+					"containers.rootless.conf.d/02-user.conf": "rootless-specific",
+					"containers.rootful.conf.d/02-root.conf":  "rootful-ignored",
+				},
+			},
+			want: []string{"global", "rootless-specific"},
+		},
+		{
+			name: "rootless uid specific drop-ins",
+			arg: File{
+				Name:      "containers",
+				Extension: "conf",
+				UserId:    1000,
+			},
+			files: testfiles{
+				usr: map[string]string{
+					"containers.rootless.conf.d/1000/settings.conf": "uid-1000",
+					"containers.rootless.conf.d/99/settings.conf":   "uid-99",
+				},
+			},
+			want: []string{"uid-1000"},
+		},
+		{
+			name: "containers.conf env var not being set",
+			arg: File{
+				Name:            "containers",
+				Extension:       "conf",
+				EnvironmentName: "CONTAINERS_CONF",
+			},
+			files: testfiles{
+				usr: map[string]string{
+					"containers.conf": "content1",
+				},
+			},
+			want: []string{"content1"},
+		},
+		{
+			name: "containers.conf env var must override all files",
+			arg: File{
+				Name:            "containers",
+				Extension:       "conf",
+				EnvironmentName: "CONTAINERS_CONF",
+			},
+			files: testfiles{
+				usr: map[string]string{
+					"containers.conf":           "content1",
+					"containers.conf.d/01.conf": "01",
+				},
+			},
+			setup: func(t *testing.T, tc *testcase) {
+				// filename does not need to end in .conf
+				file := filepath.Join(t.TempDir(), "somepath")
+				err := os.WriteFile(file, []byte("env"), 0o600)
+				require.NoError(t, err)
+				t.Setenv("CONTAINERS_CONF", file)
+			},
+			want: []string{"env"},
+		},
+		{
+			name: "containers.conf override env var should be appended",
+			arg: File{
+				Name:            "containers",
+				Extension:       "conf",
+				EnvironmentName: "CONTAINERS_CONF",
+			},
+			files: testfiles{
+				usr: map[string]string{
+					"containers.conf":           "content1",
+					"containers.conf.d/01.conf": "01",
+				},
+			},
+			setup: func(t *testing.T, tc *testcase) {
+				file := filepath.Join(t.TempDir(), "somepath")
+				err := os.WriteFile(file, []byte("env"), 0o600)
+				require.NoError(t, err)
+				t.Setenv("CONTAINERS_CONF_OVERRIDE", file)
+			},
+			want: []string{"content1", "01", "env"},
+		},
+		{
+			name: "containers.conf both env var should be appended",
+			arg: File{
+				Name:            "containers",
+				Extension:       "conf",
+				EnvironmentName: "CONTAINERS_CONF",
+			},
+			files: testfiles{
+				usr: map[string]string{
+					"containers.conf":           "content1",
+					"containers.conf.d/01.conf": "01",
+				},
+			},
+			setup: func(t *testing.T, tc *testcase) {
+				file1 := filepath.Join(t.TempDir(), "path1")
+				err := os.WriteFile(file1, []byte("env1"), 0o600)
+				require.NoError(t, err)
+				t.Setenv("CONTAINERS_CONF", file1)
+
+				file2 := filepath.Join(t.TempDir(), "path1")
+				err = os.WriteFile(file2, []byte("env2"), 0o600)
+				require.NoError(t, err)
+				t.Setenv("CONTAINERS_CONF_OVERRIDE", file2)
+			},
+			want: []string{"env1", "env2"},
+		},
+		{
+			name: "env var should error on non existing file",
+			arg: File{
+				Name:            "containers",
+				Extension:       "conf",
+				EnvironmentName: "CONTAINERS_CONF",
+			},
+			setup: func(t *testing.T, tc *testcase) {
+				file := filepath.Join(t.TempDir(), "123")
+				t.Setenv("CONTAINERS_CONF", file)
+			},
+			wantErr: fs.ErrNotExist,
+		},
+		{
+			name: "override env var should error on non existing file",
+			arg: File{
+				Name:            "containers",
+				Extension:       "conf",
+				EnvironmentName: "CONTAINERS_CONF",
+			},
+			setup: func(t *testing.T, tc *testcase) {
+				file := filepath.Join(t.TempDir(), "123")
+				t.Setenv("CONTAINERS_CONF_OVERRIDE", file)
+			},
+			wantErr: fs.ErrNotExist,
+		},
+		{
+			name: "containers.conf with modules",
+			arg: File{
+				Name:            "containers",
+				Extension:       "conf",
+				EnvironmentName: "CONTAINERS_CONF",
+				Modules:         []string{"module.abc"},
+			},
+			files: testfiles{
+				usr: map[string]string{
+					"containers.conf": "content1",
+				},
+				home: map[string]string{
+					// file extension should not matter for modules
+					"containers.conf.modules/module.abc": "relative module",
+				},
+			},
+			setup: func(t *testing.T, tc *testcase) {
+				file := filepath.Join(t.TempDir(), "somepath")
+				err := os.WriteFile(file, []byte("absolute module"), 0o600)
+				require.NoError(t, err)
+				tc.arg.Modules = append(tc.arg.Modules, file)
+			},
+			want: []string{"content1", "relative module", "absolute module"},
+		},
+		{
+			name: "containers.conf with module override",
+			arg: File{
+				Name:            "containers",
+				Extension:       "conf",
+				EnvironmentName: "CONTAINERS_CONF",
+				Modules:         []string{"module.conf", "different.conf"},
+			},
+			files: testfiles{
+				usr: map[string]string{
+					"containers.conf.modules/module.conf": "usr",
+				},
+				etc: map[string]string{
+					"containers.conf.modules/different.conf": "etc",
+				},
+				home: map[string]string{
+					"containers.conf.modules/module.conf": "home",
+				},
+			},
+			want: []string{"home", "etc"},
+		},
+		{
+			// same as above except we switch the module order to ensure we read the files in the proper order as given
+			name: "containers.conf with module override inverse module order",
+			arg: File{
+				Name:            "containers",
+				Extension:       "conf",
+				EnvironmentName: "CONTAINERS_CONF",
+				Modules:         []string{"different.conf", "module.conf"},
+			},
+			files: testfiles{
+				usr: map[string]string{
+					"containers.conf.modules/module.conf": "usr",
+				},
+				etc: map[string]string{
+					"containers.conf.modules/different.conf": "etc",
+				},
+				home: map[string]string{
+					"containers.conf.modules/module.conf": "home",
+				},
+			},
+			want: []string{"etc", "home"},
+		},
+		{
+			name: "containers.conf env and modules order",
+			arg: File{
+				Name:            "containers",
+				Extension:       "conf",
+				EnvironmentName: "CONTAINERS_CONF",
+				Modules:         []string{"module.conf"},
+			},
+			files: testfiles{
+				usr: map[string]string{
+					"containers.conf":                     "content1",
+					"containers.conf.d/01.conf":           "01",
+					"containers.conf.modules/module.conf": "mod",
+				},
+			},
+
+			setup: func(t *testing.T, tc *testcase) {
+				file1 := filepath.Join(t.TempDir(), "path1")
+				err := os.WriteFile(file1, []byte("env1"), 0o600)
+				require.NoError(t, err)
+				t.Setenv("CONTAINERS_CONF", file1)
+
+				file2 := filepath.Join(t.TempDir(), "path1")
+				err = os.WriteFile(file2, []byte("env2"), 0o600)
+				require.NoError(t, err)
+				t.Setenv("CONTAINERS_CONF_OVERRIDE", file2)
+			},
+			// CONTAINERS_CONF, then modules, then CONTAINERS_CONF_OVERRIDE
+			want: []string{"env1", "mod", "env2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.arg.RootForImplicitAbsolutePaths = t.TempDir()
+			writeTestFiles(t, tt.arg.RootForImplicitAbsolutePaths, tt.files)
+			if tt.setup != nil {
+				tt.setup(t, &tt)
+			}
+			seq := Read(&tt.arg)
+			if tt.wantErr == nil {
+				confs := collectConfigs(t, seq)
+				assert.Equal(t, tt.want, confs)
+
+				// ensure the modules all get resolves to absolute paths and are valid
+				for _, module := range tt.arg.Modules {
+					assert.FileExists(t, module)
+					assert.True(t, filepath.IsAbs(module))
+				}
+			} else {
+				next, stop := iter.Pull2(seq)
+				defer stop()
+
+				_, err, ok := next()
+				assert.True(t, ok)
+				assert.ErrorIs(t, err, tt.wantErr)
+
+				// end of iterator
+				_, _, ok = next()
+				assert.False(t, ok)
+			}
+		})
+	}
+}
+
+func writeTestFiles(t *testing.T, tmpdir string, files testfiles) {
+	t.Helper()
+	usr := filepath.Join(tmpdir, systemConfigPath)
+	require.NoError(t, os.MkdirAll(usr, 0o755))
+	writeTestFileMap(t, usr, files.usr)
+
+	etc := filepath.Join(tmpdir, adminOverrideConfigPath)
+	require.NoError(t, os.MkdirAll(etc, 0o755))
+	writeTestFileMap(t, etc, files.etc)
+
+	home := filepath.Join(tmpdir, "home")
+	t.Setenv("XDG_CONFIG_HOME", home)
+	homeContainers := filepath.Join(home, "containers")
+	require.NoError(t, os.MkdirAll(homeContainers, 0o755))
+	writeTestFileMap(t, homeContainers, files.home)
+}
+
+func writeTestFileMap(t *testing.T, path string, files map[string]string) {
+	t.Helper()
+	for name, value := range files {
+		fullPath := filepath.Join(path, name)
+		require.NoError(t, os.MkdirAll(filepath.Dir(fullPath), 0o755))
+		err := os.WriteFile(fullPath, []byte(value), 0o600)
+		require.NoError(t, err)
+	}
+}
+
+// collectConfigs consumes the iterator and returns the content of the files read
+func collectConfigs(t *testing.T, seq iter.Seq2[*Item, error]) []string {
+	var contents []string
+	for item, err := range seq {
+		require.NoError(t, err)
+		require.NotNil(t, item)
+		data, err := io.ReadAll(item.Reader)
+		require.NoError(t, err)
+
+		contents = append(contents, string(data))
+	}
+	return contents
+}
+
+func Test_ParseTOML(t *testing.T) {
+	type Config struct {
+		Field1 bool
+		Field2 string
+		Field3 int
+	}
+
+	tests := []struct {
+		name string
+		// Arguments for this function
+		arg File
+		// Layout of the actual files we try to parse
+		files testfiles
+		// Expected result
+		want *Config
+		// wantErr set to the expected error message
+		wantErr string
+	}{
+		{
+			name: "simple parse",
+			arg: File{
+				Name:      "containers",
+				Extension: "conf",
+			},
+			files: testfiles{
+				usr: map[string]string{
+					"containers.conf": "field1 = true\n",
+				},
+			},
+			want: &Config{
+				Field1: true,
+			},
+		},
+		{
+			name: "drop in parse",
+			arg: File{
+				Name:      "containers",
+				Extension: "conf",
+			},
+			files: testfiles{
+				usr: map[string]string{
+					"containers.conf":           "field1 = true\n",
+					"containers.conf.d/10.conf": "field2 = \"abc\"",
+				},
+			},
+			want: &Config{
+				Field1: true,
+				Field2: "abc",
+			},
+		},
+		{
+			name: "main file override",
+			arg: File{
+				Name:      "containers",
+				Extension: "conf",
+			},
+			files: testfiles{
+				usr: map[string]string{
+					"containers.conf":           "field1 = true\n",
+					"containers.conf.d/10.conf": "field2 = \"abc\"",
+				},
+				etc: map[string]string{
+					"containers.conf": "field3 = 1\n",
+				},
+			},
+			want: &Config{
+				Field2: "abc",
+				Field3: 1,
+			},
+		},
+		{
+			name: "invalid toml",
+			arg: File{
+				Name:      "containers",
+				Extension: "conf",
+			},
+			files: testfiles{
+				usr: map[string]string{
+					"containers.conf": "blah\n",
+				},
+			},
+			wantErr: "toml: line 1: expected '.' or '='",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.arg.RootForImplicitAbsolutePaths = t.TempDir()
+			writeTestFiles(t, tt.arg.RootForImplicitAbsolutePaths, tt.files)
+
+			conf := new(Config)
+			err := ParseTOML(conf, &tt.arg)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, conf)
+			} else {
+				assert.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/storage/pkg/configfile/path.go
+++ b/storage/pkg/configfile/path.go
@@ -1,0 +1,15 @@
+//go:build !windows && !freebsd
+
+package configfile
+
+const (
+	// builtinSystemConfigPath is the location for the default config files shipped by the distro/vendor.
+	builtinSystemConfigPath = "/usr/share/containers"
+
+	// builtinAdminOverrideConfigPath is the location for admin local override config files.
+	builtinAdminOverrideConfigPath = "/etc/containers"
+)
+
+func getAdminOverrideConfigPath() string {
+	return builtinAdminOverrideConfigPath
+}

--- a/storage/pkg/configfile/path_freebsd.go
+++ b/storage/pkg/configfile/path_freebsd.go
@@ -1,0 +1,13 @@
+package configfile
+
+const (
+	// builtinSystemConfigPath is the location for the default config files shipped by the distro/vendor.
+	builtinSystemConfigPath = "/usr/local/share/" + _configPathName
+
+	// builtinAdminOverrideConfigPath is the location for admin local override config files.
+	builtinAdminOverrideConfigPath = "/usr/local/etc/" + _configPathName
+)
+
+func getAdminOverrideConfigPath() string {
+	return builtinAdminOverrideConfigPath
+}

--- a/storage/pkg/configfile/path_unix.go
+++ b/storage/pkg/configfile/path_unix.go
@@ -1,0 +1,25 @@
+//go:build !windows
+
+package configfile
+
+import (
+	"os"
+	"path/filepath"
+
+	"go.podman.io/storage/pkg/unshare"
+)
+
+// UserConfigPath returns the path to the users local config that is
+// not shared with other users. It uses $XDG_CONFIG_HOME/containers...
+// if set or $HOME/.config/containers... if not.
+func UserConfigPath() (string, error) {
+	if configHome, ok := os.LookupEnv("XDG_CONFIG_HOME"); ok {
+		return filepath.Join(configHome, _configPathName), nil
+	}
+	home, err := unshare.HomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(home, ".config", _configPathName), nil
+}

--- a/storage/pkg/configfile/path_windows.go
+++ b/storage/pkg/configfile/path_windows.go
@@ -1,0 +1,28 @@
+package configfile
+
+import (
+	"os"
+	"path/filepath"
+)
+
+const (
+	// builtinSystemConfigPath is the location for the default config files shipped by the distro/vendor.
+	// On windows there is no /usr equivalent so leave it empty.
+	builtinSystemConfigPath = ""
+)
+
+func getAdminOverrideConfigPath() string {
+	if env, ok := os.LookupEnv("ProgramData"); ok {
+		return filepath.Join(env, _configPathName)
+	}
+	return ""
+}
+
+// UserConfigPath returns the path to the users local config that is
+// not shared with other users. It uses $APPDATA/containers...
+func UserConfigPath() (string, error) {
+	if env, ok := os.LookupEnv("APPDATA"); ok {
+		return filepath.Join(env, _configPathName), nil
+	}
+	return "", nil
+}


### PR DESCRIPTION
Unify the config file loading logic with this new package. See the full design doc[1] for more information.

[1] https://github.com/containers/podman/blob/1af4caf888924e837e9c6038c30d67bfcc7c0196/contrib/design-docs/config-file-parsing.md

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
