### PR TITLE
common: safer use of `filepath.EvalSymlinks()` in `findBindir()`

### DIFF
--- a/common/pkg/config/config.go
+++ b/common/pkg/config/config.go
@@ -1078,8 +1078,10 @@ func findBindir() string {
 	}
 	execPath, err := os.Executable()
 	if err == nil {
-		// Resolve symbolic links to find the actual binary file path.
-		execPath, err = filepath.EvalSymlinks(execPath)
+		// Resolve symlinks for the binary path.
+		// On Windows, an additional symlink check is performed;
+		// on other platforms, this is equivalent to filepath.EvalSymlinks.
+		execPath, err = safeEvalSymlinks(execPath)
 	}
 	if err != nil {
 		// If failed to find executable (unlikely to happen), warn about it.

--- a/common/pkg/config/config_unix.go
+++ b/common/pkg/config/config_unix.go
@@ -33,3 +33,7 @@ func userConfigPath() (string, error) {
 func overrideContainersConfigPath() (string, error) {
 	return overrideContainersConfig, nil
 }
+
+func safeEvalSymlinks(filePath string) (string, error) {
+	return filepath.EvalSymlinks(filePath)
+}

--- a/common/pkg/config/config_windows.go
+++ b/common/pkg/config/config_windows.go
@@ -1,6 +1,10 @@
 package config
 
-import "os"
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+)
 
 const (
 	// _configPath is the path to the containers/containers.conf
@@ -34,4 +38,26 @@ var defaultHelperBinariesDir = []string{
 	// FindHelperBinaries(), as a convention, interprets $BINDIR as the
 	// directory where the current process binary (i.e. podman) is located.
 	"$BINDIR",
+}
+
+func safeEvalSymlinks(filePath string) (string, error) {
+	fileInfo, err := os.Lstat(filePath)
+	if err != nil {
+		return "", err
+	}
+	if fileInfo.Mode()&fs.ModeSymlink != 0 {
+		// Only call filepath.EvalSymlinks if it is a symlink.
+		// Starting with v1.23, EvalSymlinks returns an error for mount points.
+		// See https://go-review.googlesource.com/c/go/+/565136 for reference.
+		filePath, err = filepath.EvalSymlinks(filePath)
+		if err != nil {
+			return "", err
+		}
+	} else {
+		// Call filepath.Clean when filePath is not a symlink. That's for
+		// consistency with the symlink case (filepath.EvalSymlinks calls
+		// Clean after evaluating filePath).
+		filePath = filepath.Clean(filePath)
+	}
+	return filePath, nil
 }

--- a/common/pkg/config/config_windows_test.go
+++ b/common/pkg/config/config_windows_test.go
@@ -1,0 +1,149 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/sys/windows"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// shortPathToLongPath converts a Windows short path (C:\PROGRA~1) to its
+// long path equivalent (C:\Program Files). It returns an error if shortPath
+// doesn't exist.
+func shortPathToLongPath(shortPath string) (string, error) {
+	shortPathPtr, err := windows.UTF16PtrFromString(shortPath)
+	if err != nil {
+		return "", err
+	}
+	len, err := windows.GetLongPathName(shortPathPtr, nil, 0)
+	if err != nil {
+		return "", err
+	}
+	if len == 0 {
+		return "", fmt.Errorf("failed to get buffer size for path: %s", shortPath)
+	}
+	longPathPtr := &(make([]uint16, len)[0])
+	_, err = windows.GetLongPathName(shortPathPtr, longPathPtr, len)
+	if err != nil {
+		return "", err
+	}
+	return windows.UTF16PtrToString(longPathPtr), nil
+}
+
+// CreateNewItemWithPowerShell creates a new item using PowerShell.
+// It's an helper to easily create junctions on Windows (as well as other file types).
+// It constructs a PowerShell command to create a new item at the specified path with the given item type.
+// If a target is provided, it includes it in the command.
+//
+// Parameters:
+//   - t: The testing.T instance.
+//   - path: The path where the new item will be created.
+//   - itemType: The type of the item to be created (e.g., "File", "SymbolicLink", "Junction").
+//   - target: The target for the new item, if applicable.
+func CreateNewItemWithPowerShell(t *testing.T, path string, itemType string, target string) {
+	var pwshCmd, pwshPath string
+	// Look for Powershell 7 first as it allow Symlink creation for non-admins too
+	pwshPath, err := exec.LookPath("pwsh.exe")
+	if err != nil {
+		// Use Powershell 5 that is always present
+		pwshPath = "powershell.exe"
+	}
+	pwshCmd = "New-Item -Path " + path + " -ItemType " + itemType
+	if target != "" {
+		pwshCmd += " -Target " + target
+	}
+	cmd := exec.Command(pwshPath, "-Command", pwshCmd)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err = cmd.Run()
+	require.NoError(t, err)
+}
+
+// TestSafeEvalSymlinks tests the safeEvalSymlinks function.
+// In particular it verifies that safeEvalSymlinks behaves as
+// filepath.EvalSymlink before Go 1.23 - with the exception of
+// files under a mount point (juntion) that aren't resolved
+// anymore.
+// The old behavior of filepath.EvalSymlinks can be tested with
+// the directive "//go:debug winsymlink=0" and replacing safeEvalSymlinks()
+// with filepath.EvalSymlink().
+func TestSafeEvalSymlinks(t *testing.T) {
+	// Create a temporary directory to store the normal file
+	normalFileDir, err := shortPathToLongPath(t.TempDir())
+	require.NoError(t, err)
+
+	// Create a temporary directory to store the (hard/sym)link files
+	linkFilesDir, err := shortPathToLongPath(t.TempDir())
+	require.NoError(t, err)
+
+	// Create a temporary directory where the mount point will be created
+	mountPointDir, err := shortPathToLongPath(t.TempDir())
+	require.NoError(t, err)
+
+	// Create a normal file
+	normalFile := filepath.Join(normalFileDir, "testFile")
+	CreateNewItemWithPowerShell(t, normalFile, "File", "")
+
+	// Create a symlink file
+	symlinkFile := filepath.Join(linkFilesDir, "testSymbolicLink")
+	CreateNewItemWithPowerShell(t, symlinkFile, "SymbolicLink", normalFile)
+
+	// Create a hardlink file
+	hardlinkFile := filepath.Join(linkFilesDir, "testHardLink")
+	CreateNewItemWithPowerShell(t, hardlinkFile, "HardLink", normalFile)
+
+	// Create a mount point file
+	mountPoint := filepath.Join(mountPointDir, "testJunction")
+	mountPointFile := filepath.Join(mountPoint, "testFile")
+	CreateNewItemWithPowerShell(t, mountPoint, "Junction", normalFileDir)
+
+	// Replaces the backslashes with forward slashes in the normal file path
+	normalFileWithBadSeparators := filepath.ToSlash(normalFile)
+
+	tests := []struct {
+		name     string
+		filePath string
+		want     string
+	}{
+		{
+			name:     "Normal file",
+			filePath: normalFile,
+			want:     normalFile,
+		},
+		{
+			name:     "File under a mount point (juntion)",
+			filePath: mountPointFile,
+			want:     mountPointFile,
+		},
+		{
+			name:     "Symbolic link",
+			filePath: symlinkFile,
+			want:     normalFile,
+		},
+		{
+			name:     "Hard link",
+			filePath: hardlinkFile,
+			want:     hardlinkFile,
+		},
+		{
+			name:     "Bad separators in path",
+			filePath: normalFileWithBadSeparators,
+			want:     normalFile,
+		},
+	}
+
+	for _, tt := range tests {
+		assert := assert.New(t)
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := safeEvalSymlinks(tt.filePath)
+			require.NoError(t, err)
+			assert.Equal(tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
This patch is directly ported from [[1]] to resolve the exact same issue mentioned in that pull-request.

Why is this patch needed? Because in [[2]], `FindExecutablePeer()` was replaced with `FindHelperBinary()`, making the fix introduced in [[1]] no longer effective, resulting in a regression. To resolve the regression[[3]], `EvalSymlinksOrClean()` is added to `findBindir()`. The function call stack is now:

```
FindHelperBinary() -> findBindir() -> EvalSymlinksOrClean()
```

This should fix https://github.com/containers/podman/issues/27763

/cc @l0rd 

xref: https://github.com/ScoopInstaller/Main/pull/6335#issuecomment-3769785863

[1]: https://github.com/containers/podman/pull/25151
[2]: https://github.com/containers/podman/pull/27612
[3]: https://github.com/containers/podman/issues/27763

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
