### PR TITLE
zfs: add idmapped mount support for rootless containers

### DIFF
--- a/storage/drivers/zfs/zfs.go
+++ b/storage/drivers/zfs/zfs.go
@@ -19,6 +19,7 @@ import (
 	"go.podman.io/storage/internal/driver"
 	"go.podman.io/storage/internal/tempdir"
 	"go.podman.io/storage/pkg/directory"
+	"go.podman.io/storage/pkg/idmap"
 	"go.podman.io/storage/pkg/idtools"
 	"go.podman.io/storage/pkg/mount"
 	"golang.org/x/sys/unix"
@@ -481,6 +482,19 @@ func (d *Driver) Get(id string, options graphdriver.MountOpts) (_ string, retErr
 		}
 	}
 
+	// Apply idmapped mount if UID/GID mappings are explicitly provided
+	// This enables rootless container support by translating UIDs/GIDs
+	if len(options.UidMaps) > 0 || len(options.GidMaps) > 0 {
+		logrus.WithField("storage-driver", "zfs").Debugf("applying idmapped mount to %s with %d uid maps, %d gid maps", mountpoint, len(options.UidMaps), len(options.GidMaps))
+		if err := applyIDMappedMount(mountpoint, options.UidMaps, options.GidMaps); err != nil {
+			logrus.WithField("storage-driver", "zfs").Warnf("failed to apply idmapped mount to %s: %v", mountpoint, err)
+			if unmountErr := detachUnmount(mountpoint); unmountErr != nil {
+				logrus.WithField("storage-driver", "zfs").Warnf("failed to unmount %s after idmap failure: %v", mountpoint, unmountErr)
+			}
+			return "", fmt.Errorf("applying idmapped mount for zfs: %w", err)
+		}
+	}
+
 	return mountpoint, nil
 }
 
@@ -502,6 +516,24 @@ func (d *Driver) Put(id string) error {
 		logger.Debugf("Failed to remove %s mount point %s: %v", id, mountpoint, err)
 	}
 
+	return nil
+}
+
+// applyIDMappedMount creates an idmapped mount over the ZFS mount to translate UIDs/GIDs
+// for rootless container support. This uses the Linux mount_setattr() syscall with
+// MOUNT_ATTR_IDMAP to create a view of the filesystem with translated ownership.
+func applyIDMappedMount(mountpoint string, uidMaps, gidMaps []idtools.IDMap) error {
+	// Create a user namespace process with the desired UID/GID mappings
+	pid, cleanupFunc, err := idmap.CreateUsernsProcess(uidMaps, gidMaps)
+	if err != nil {
+		return fmt.Errorf("creating user namespace process for idmap: %w", err)
+	}
+	defer cleanupFunc()
+
+	// Apply the idmapped mount using the user namespace
+	if err := idmap.CreateIDMappedMount(mountpoint, mountpoint, pid); err != nil {
+		return fmt.Errorf("creating idmapped mount at %s: %w", mountpoint, err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
  Apply idmapped mounts to ZFS storage layers when UID/GID mappings are
  provided. This translates file ownership through the user namespace
  mapping, allowing containers to perform chown operations that appear
  as root inside the container but map to unprivileged UIDs on the host.

  The overlay and btrfs drivers already support idmapped mounts; this
  brings ZFS to feature parity for rootless container support.

  This works in conjunction with ZFS's zoned_uid property [proposed
  separately to OpenZFS](https://github.com/openzfs/zfs/pull/18167) which delegates dataset operations to user
  namespaces, enabling full rootless podman/docker with native ZFS
  storage.

  Signed-off-by: Colin K. Williams colin@li-nk.org

Resolves https://github.com/containers/container-libs/issues/147

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->

