### PR TITLE
github: run validation workflow also on release branches

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - podman-*
   pull_request:
     branches:
       - main
+      - podman-*
 
 permissions: read-all
 


### PR DESCRIPTION
We call our release branches podman-x.y now so make sure we cover them as well.

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
