### PR TITLE
[podman-5.8] github: run validation workflow also on release branches

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - podman-*
   pull_request:
     branches:
       - main
+      - podman-*
 
 permissions: read-all
 


### PR DESCRIPTION
We call our release branches podman-x.y now so make sure we cover them as well.


(cherry picked from commit c028ad0b024ff1c822eb754a6ee34ba6e3a9595e)

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
