### PR TITLE
storage_linux: simplify map to slice conversion when collecting IDs

### DIFF
--- a/storage/pkg/chunked/storage_linux.go
+++ b/storage/pkg/chunked/storage_linux.go
@@ -9,9 +9,11 @@ import (
 	"hash"
 	"io"
 	"io/fs"
+	"maps"
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -606,11 +608,7 @@ func maybeDoIDRemap(manifest []fileMetadata, options *archive.TarOptions) error 
 }
 
 func mapToSlice(inputMap map[uint32]struct{}) []uint32 {
-	var out []uint32
-	for value := range inputMap {
-		out = append(out, value)
-	}
-	return out
+	return slices.Collect(maps.Keys(inputMap))
 }
 
 func collectIDs(entries []fileMetadata) ([]uint32, []uint32) {


### PR DESCRIPTION
- Simplify `mapToSlice` function using new convenience functions available in Go 1.23+
- Pre-allocate `uids` and `gids` in `collectIDs` function with expected capacity to reduce re-allocations as entries are added