### PR TITLE
netavark: prefer slices.Equal over reflect.DeepEqual for network update

### DIFF
--- a/common/libnetwork/netavark/config.go
+++ b/common/libnetwork/netavark/config.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"reflect"
 	"slices"
 	"strconv"
 	"time"
@@ -81,7 +80,7 @@ func (n *netavarkNetwork) NetworkUpdate(name string, options types.NetworkUpdate
 	networkDNSServersAfter = append(networkDNSServersAfter, options.AddDNSServers...)
 	networkDNSServersAfter = sliceRemoveDuplicates(networkDNSServersAfter)
 	network.NetworkDNSServers = networkDNSServersAfter
-	if reflect.DeepEqual(networkDNSServersBefore, networkDNSServersAfter) {
+	if slices.Equal(networkDNSServersBefore, networkDNSServersAfter) {
 		return nil
 	}
 	err = n.commitNetwork(network)


### PR DESCRIPTION
<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
`slices.Equal()` is available in Go 1.21+ when comparing slices with a type that satisfies `comparable` (including `string`), and is generally more performant than `reflect.DeepEqual`.