### PR TITLE
Fix race between lock() and AssertLocked()

### DIFF
--- a/storage/pkg/lockfile/lockfile.go
+++ b/storage/pkg/lockfile/lockfile.go
@@ -399,9 +399,9 @@ func (l *LockFile) lock(lType rawfilelock.LockType) {
 		if err := rawfilelock.LockFile(l.fd, lType); err != nil {
 			panic(err)
 		}
+		l.lockType = lType
+		l.locked = true
 	}
-	l.lockType = lType
-	l.locked = true
 	l.counter++
 }
 
@@ -442,9 +442,9 @@ func (l *LockFile) tryLock(lType rawfilelock.LockType) error {
 			rwMutexUnlocker()
 			return err
 		}
+		l.lockType = lType
+		l.locked = true
 	}
-	l.lockType = lType
-	l.locked = true
 	l.counter++
 	return nil
 }


### PR DESCRIPTION
Only write `l.locked` and `l.lockType` when `counter == 0` to prevent race with unsynchronized reads in `AssertLocked()`.

I'm not sure how this should be tested. I wrote a test that tries to hit the unsynchronized R+W, but hitting the exact timing is pretty hard. With enough iterations and goroutines, the chance is better.

Test:
```
func TestAssertLockedRaceForRLock(t *testing.T) {
	lock, err := getTempLockfile()
	require.NoError(t, err, "creating lock")

	const numGoroutines = 20000
	const numIterations = 500000
	start := make(chan struct{})
	var wg sync.WaitGroup
	wg.Add(numGoroutines)

	for i := 0; i < numGoroutines; i++ {
		go func(id int) {
			defer wg.Done()
			<-start

			lock.RLock()
			defer lock.Unlock()

			for j := 0; j < numIterations; j++ {
				lock.AssertLocked()
				//time.Sleep(time.Nanosecond * 10)
			}
		}(i)
	}

	close(start)
	wg.Wait()
}
```

Run command: `go test -race -v -run TestAssertLockedRaceForRLock`


Fixes: https://github.com/containers/podman/issues/27924

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
