### PR TITLE
engine: add platform field to EngineConfig

### DIFF
--- a/common/docs/containers.conf.5.md
+++ b/common/docs/containers.conf.5.md
@@ -809,6 +809,14 @@ Locks are recycled and can be reused after the associated container, pod, or vol
 The default number available is 2048.
 If this is changed, a lock renumbering must be performed, using the `podman system renumber` command.
 
+**platform**=""
+
+Specifies the default platform for image operations such as pull, build, run,
+and create. When set, container engines will use this platform instead of the
+host's native platform. The format is `os/arch` or `os/arch/variant` (e.g.,
+`linux/amd64`, `linux/arm64/v8`). If empty (the default), the host's platform
+is used.
+
 **pod_exit_policy**="continue"
 
 Set the exit policy of the pod when the last container exits.  Supported policies are:

--- a/common/pkg/config/config.go
+++ b/common/pkg/config/config.go
@@ -422,6 +422,12 @@ type EngineConfig struct {
 	// OCIRuntimesFlags are the set of configured OCI runtimes' flags
 	OCIRuntimesFlags map[string][]string `toml:"runtimes_flags,omitempty"`
 
+	// Platform specifies the default platform (os/arch[/variant]) for image
+	// operations such as pull, build, run, and create. If empty, the host's
+	// platform is used. Format: "os/arch" or "os/arch/variant" (e.g.,
+	// "linux/amd64", "linux/arm64/v8").
+	Platform string `toml:"platform,omitempty"`
+
 	// PlatformToOCIRuntime requests specific OCI runtime for a specified platform of image.
 	PlatformToOCIRuntime map[string]string `toml:"platform_to_oci_runtime,omitempty"`
 

--- a/common/pkg/config/config_test.go
+++ b/common/pkg/config/config_test.go
@@ -347,6 +347,7 @@ image_copy_tmp_dir="storage"`
 			gomega.Expect(config.Containers.Privileged).To(gomega.BeTrue())
 			gomega.Expect(config.Containers.ReadOnly).To(gomega.BeTrue())
 			gomega.Expect(config.Engine.ImageParallelCopies).To(gomega.Equal(uint(10)))
+			gomega.Expect(config.Engine.Platform).To(gomega.Equal("linux/amd64"))
 			gomega.Expect(config.Engine.PlatformToOCIRuntime).To(gomega.Equal(PlatformToOCIRuntimeMap))
 			gomega.Expect(config.Engine.ImageDefaultFormat).To(gomega.Equal("v2s2"))
 			gomega.Expect(config.Engine.CompressionFormat).To(gomega.BeEquivalentTo("zstd:chunked"))

--- a/common/pkg/config/containers.conf
+++ b/common/pkg/config/containers.conf
@@ -703,6 +703,11 @@ default_sysctls = [
 #
 #num_locks = 2048
 
+# Default platform (os/arch[/variant]) for image operations such as pull,
+# build, run, and create. If empty, the host's platform is used.
+#
+#platform = ""
+
 # Set the exit policy of the pod when the last container exits.
 #pod_exit_policy = "continue"
 

--- a/common/pkg/config/containers.conf-freebsd
+++ b/common/pkg/config/containers.conf-freebsd
@@ -535,6 +535,11 @@ default_sysctls = [
 #
 #num_locks = 2048
 
+# Default platform (os/arch[/variant]) for image operations such as pull,
+# build, run, and create. If empty, the host's platform is used.
+#
+#platform = ""
+
 # Whether to pull new image before running a container
 #
 #pull_policy = "missing"

--- a/common/pkg/config/testdata/containers_override.conf
+++ b/common/pkg/config/testdata/containers_override.conf
@@ -18,6 +18,7 @@ events_container_create_inspect_data = true
 pod_exit_policy="stop"
 compression_format="zstd:chunked"
 cdi_spec_dirs = [ "/somepath" ]
+platform = "linux/amd64"
 
 [engine.platform_to_oci_runtime]
 hello = "world"


### PR DESCRIPTION
Issue: https://github.com/containers/podman/issues/25641

This PR adds a new `platform` option to the `[engine]` section of `containers.conf`:

```toml
[engine]
platform = "linux/amd64"
```

This allows users to set a default platform (of the form `os/arch` or `os/arch/variant`) for image operations.