### PR TITLE
Link to Podman’s LLM policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,7 @@ However, most of the things here listed are very generic and apply when contribu
 
 ## Topics
 
+* [LLM ("AI") Policy](#llm-ai-policy)
 * [Reporting Issues](#reporting-issues)
 * [Submitting Pull Requests](#submitting-pull-requests)
   * [Describe your Changes in Commit Messages](#describe-your-changes-in-commit-messages)
@@ -37,6 +38,11 @@ However, most of the things here listed are very generic and apply when contribu
   * [Code review](#code-review)
   * [Rebasing](#rebasing)
 * [Find bad changes with git bisect](#find-bad-changes-with-git-bisect)
+
+## LLM ("AI") Policy
+
+If your contribution is aided by LLMs or other AI tools, please read the [LLM Policy in the Podman project](https://github.com/containers/podman/blob/main/LLM_POLICY.md).
+This project also follows this LLM policy, which includes comments, issues, PRs, and any other interactions with the team.
 
 ## Reporting Issues
 


### PR DESCRIPTION
Originally from https://github.com/containers/podman/pull/28141 and discussed there.

@containers/container-libs-maintainers PTAL. Cc: @containers/podman-maintainers 