### PR TITLE
Introduce a sentinel layer variant for zstd:chunked pulls

### DIFF
--- a/image/copy/copy.go
+++ b/image/copy/copy.go
@@ -385,6 +385,18 @@ func Image(ctx context.Context, policyContext *signature.PolicyContext, destRef,
 			return nil, err
 		}
 		copiedManifest = single.manifest
+		// If the copied single image has zstd:chunked layers and the destination
+		// supports manifest lists, wrap it in an OCI index with a sentinel variant.
+		// Skip when digests must be preserved or destination is a digested reference.
+		if !options.PreserveDigests && supportsMultipleImages(c.dest) {
+			indexManifest, err := c.createSingleImageSentinelIndex(ctx, single)
+			if err != nil {
+				return nil, err
+			}
+			if indexManifest != nil {
+				copiedManifest = indexManifest
+			}
+		}
 	} else {
 		// If we were asked to copy multiple images and can't, that's an error.
 		if !supportsMultipleImages(c.dest) {

--- a/image/copy/multiple.go
+++ b/image/copy/multiple.go
@@ -3,6 +3,7 @@ package copy
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
@@ -16,9 +17,12 @@ import (
 	"go.podman.io/image/v5/docker/reference"
 	"go.podman.io/image/v5/internal/image"
 	internalManifest "go.podman.io/image/v5/internal/manifest"
+	"go.podman.io/image/v5/internal/private"
 	"go.podman.io/image/v5/internal/set"
 	"go.podman.io/image/v5/manifest"
 	"go.podman.io/image/v5/pkg/compression"
+	"go.podman.io/image/v5/types"
+	chunkedToc "go.podman.io/storage/pkg/chunked/toc"
 )
 
 type instanceOpKind int
@@ -28,6 +32,14 @@ const (
 	instanceOpClone
 	instanceOpDelete
 )
+
+// copiedInstanceData stores info about a successfully copied instance,
+// used for creating sentinel variants.
+type copiedInstanceData struct {
+	sourceDigest digest.Digest
+	result       copySingleImageResult
+	platform     *imgspecv1.Platform
+}
 
 type instanceOp struct {
 	op           instanceOpKind
@@ -311,6 +323,8 @@ func (c *copier) copyMultipleImages(ctx context.Context) (copiedManifest []byte,
 	if err != nil {
 		return nil, fmt.Errorf("preparing instances for copy: %w", err)
 	}
+	var copiedInstances []copiedInstanceData
+
 	c.Printf("Copying %d images generated from %d images in list\n", copyLen, len(instanceDigests))
 	copyCount := 0 // Track copy/clone operations separately from delete operations
 	for i, instance := range instanceOpList {
@@ -335,6 +349,15 @@ func (c *copier) copyMultipleImages(ctx context.Context) (copiedManifest []byte,
 				UpdateCompressionAlgorithms: updated.compressionAlgorithms,
 				UpdateMediaType:             updated.manifestMIMEType,
 			})
+			// Capture instance data for sentinel variant creation
+			instanceDetails, detailsErr := updatedList.Instance(instance.sourceDigest)
+			if detailsErr == nil {
+				copiedInstances = append(copiedInstances, copiedInstanceData{
+					sourceDigest: instance.sourceDigest,
+					result:       updated,
+					platform:     instanceDetails.ReadOnly.Platform,
+				})
+			}
 		case instanceOpClone:
 			copyCount++
 			logrus.Debugf("Replicating instance %s (%d/%d)", instance.sourceDigest, copyCount, copyLen)
@@ -367,6 +390,15 @@ func (c *copier) copyMultipleImages(ctx context.Context) (copiedManifest []byte,
 		default:
 			return nil, fmt.Errorf("copying image: invalid copy operation %d", instance.op)
 		}
+	}
+
+	// Create zstd:chunked sentinel variants for instances where any layer uses zstd:chunked.
+	if cannotModifyManifestListReason == "" {
+		sentinelEdits, err := c.createZstdChunkedSentinelVariants(ctx, copiedInstances, updatedList)
+		if err != nil {
+			return nil, fmt.Errorf("creating zstd:chunked sentinel variants: %w", err)
+		}
+		instanceEdits = append(instanceEdits, sentinelEdits...)
 	}
 
 	// Now reset the digest/size/types of the manifests in the list and remove deleted instances.
@@ -440,4 +472,249 @@ func (c *copier) copyMultipleImages(ctx context.Context) (copiedManifest []byte,
 	}
 
 	return manifestList, nil
+}
+
+// hasZstdChunkedLayers returns true if any non-empty layer in the manifest has
+// zstd:chunked TOC annotations.
+func hasZstdChunkedLayers(ociMan *manifest.OCI1) bool {
+	for _, l := range ociMan.LayerInfos() {
+		if l.EmptyLayer {
+			continue
+		}
+		d, err := chunkedToc.GetTOCDigest(l.Annotations)
+		if err == nil && d != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// pushSentinelVariant creates and pushes a sentinel variant of the given OCI manifest.
+// It prepends a sentinel layer and DiffID, creates a new config, and pushes everything
+// to the destination. Returns the serialized sentinel manifest and its digest.
+func (c *copier) pushSentinelVariant(ctx context.Context, ociMan *manifest.OCI1, ociConfig *imgspecv1.Image) ([]byte, digest.Digest, error) {
+	sentinelContent := chunkedToc.ZstdChunkedSentinelContent
+
+	// Push sentinel blob (content-addressed, so idempotent if already pushed).
+	sentinelBlobInfo := types.BlobInfo{
+		Digest: chunkedToc.ZstdChunkedSentinelDigest,
+		Size:   int64(len(sentinelContent)),
+	}
+	reused, _, err := c.dest.TryReusingBlobWithOptions(ctx, sentinelBlobInfo,
+		private.TryReusingBlobOptions{Cache: c.blobInfoCache})
+	if err != nil {
+		return nil, "", fmt.Errorf("checking sentinel blob: %w", err)
+	}
+	if !reused {
+		_, err = c.dest.PutBlobWithOptions(ctx, bytes.NewReader(sentinelContent),
+			sentinelBlobInfo, private.PutBlobOptions{Cache: c.blobInfoCache})
+		if err != nil {
+			return nil, "", fmt.Errorf("pushing sentinel blob: %w", err)
+		}
+	}
+
+	// Create new config with sentinel DiffID prepended.
+	newDiffIDs := make([]digest.Digest, 0, len(ociConfig.RootFS.DiffIDs)+1)
+	newDiffIDs = append(newDiffIDs, chunkedToc.ZstdChunkedSentinelDigest)
+	newDiffIDs = append(newDiffIDs, ociConfig.RootFS.DiffIDs...)
+	ociConfig.RootFS.DiffIDs = newDiffIDs
+	configBlob, err := json.Marshal(ociConfig)
+	if err != nil {
+		return nil, "", fmt.Errorf("marshaling sentinel config: %w", err)
+	}
+	configDigest := digest.FromBytes(configBlob)
+
+	// Push new config.
+	configBlobInfo := types.BlobInfo{
+		Digest:    configDigest,
+		Size:      int64(len(configBlob)),
+		MediaType: imgspecv1.MediaTypeImageConfig,
+	}
+	reused, _, err = c.dest.TryReusingBlobWithOptions(ctx, configBlobInfo,
+		private.TryReusingBlobOptions{Cache: c.blobInfoCache})
+	if err != nil {
+		return nil, "", fmt.Errorf("checking sentinel config: %w", err)
+	}
+	if !reused {
+		_, err = c.dest.PutBlobWithOptions(ctx, bytes.NewReader(configBlob),
+			configBlobInfo, private.PutBlobOptions{Cache: c.blobInfoCache, IsConfig: true})
+		if err != nil {
+			return nil, "", fmt.Errorf("pushing sentinel config: %w", err)
+		}
+	}
+
+	// Build sentinel manifest: sentinel layer + original layers.
+	newLayers := make([]imgspecv1.Descriptor, 0, len(ociMan.Layers)+1)
+	newLayers = append(newLayers, imgspecv1.Descriptor{
+		MediaType: chunkedToc.ZstdChunkedSentinelMediaType,
+		Digest:    chunkedToc.ZstdChunkedSentinelDigest,
+		Size:      int64(len(sentinelContent)),
+	})
+	newLayers = append(newLayers, ociMan.Layers...)
+
+	sentinelOCI := manifest.OCI1FromComponents(imgspecv1.Descriptor{
+		MediaType: imgspecv1.MediaTypeImageConfig,
+		Digest:    configDigest,
+		Size:      int64(len(configBlob)),
+	}, newLayers)
+	sentinelManifestBlob, err := sentinelOCI.Serialize()
+	if err != nil {
+		return nil, "", fmt.Errorf("serializing sentinel manifest: %w", err)
+	}
+	sentinelManifestDigest := digest.FromBytes(sentinelManifestBlob)
+
+	// Push sentinel manifest.
+	if err := c.dest.PutManifest(ctx, sentinelManifestBlob, &sentinelManifestDigest); err != nil {
+		return nil, "", fmt.Errorf("pushing sentinel manifest: %w", err)
+	}
+
+	return sentinelManifestBlob, sentinelManifestDigest, nil
+}
+
+// createZstdChunkedSentinelVariants creates sentinel variants for instances
+// where any layer uses zstd:chunked. The sentinel variant has a non-tar sentinel
+// layer prepended, signaling aware clients to skip the full-digest mitigation.
+// It returns ListEdit entries to add the sentinel variants to the manifest list.
+func (c *copier) createZstdChunkedSentinelVariants(ctx context.Context, copiedInstances []copiedInstanceData, updatedList internalManifest.List) ([]internalManifest.ListEdit, error) {
+	var edits []internalManifest.ListEdit
+
+	// Check which platforms already have a sentinel variant in the source.
+	platformsWithSentinel := set.New[platformComparable]()
+	for _, d := range updatedList.Instances() {
+		details, err := updatedList.Instance(d)
+		if err != nil {
+			continue
+		}
+		if details.ReadOnly.Annotations[internalManifest.OCI1InstanceAnnotationZstdChunkedSentinel] == internalManifest.OCI1InstanceAnnotationZstdChunkedSentinelValue {
+			platformsWithSentinel.Add(platformV1ToPlatformComparable(details.ReadOnly.Platform))
+		}
+	}
+
+	for _, ci := range copiedInstances {
+		// Only handle OCI manifests (zstd:chunked is OCI-only).
+		if ci.result.manifestMIMEType != imgspecv1.MediaTypeImageManifest {
+			continue
+		}
+
+		// Skip if this platform already has a sentinel variant.
+		if platformsWithSentinel.Contains(platformV1ToPlatformComparable(ci.platform)) {
+			continue
+		}
+
+		ociMan, err := manifest.OCI1FromManifest(ci.result.manifest)
+		if err != nil {
+			logrus.Debugf("Cannot parse manifest for sentinel variant: %v", err)
+			continue
+		}
+
+		if !hasZstdChunkedLayers(ociMan) {
+			continue
+		}
+
+		// Use the config as written to the destination (reflects any edits during copy).
+		var ociConfig imgspecv1.Image
+		if err := json.Unmarshal(ci.result.configBlob, &ociConfig); err != nil {
+			logrus.Debugf("Cannot parse config for sentinel variant: %v", err)
+			continue
+		}
+
+		sentinelManifestBlob, sentinelManifestDigest, err := c.pushSentinelVariant(ctx, ociMan, &ociConfig)
+		if err != nil {
+			return nil, err
+		}
+
+		edits = append(edits, internalManifest.ListEdit{
+			ListOperation: internalManifest.ListOpAdd,
+			AddDigest:     sentinelManifestDigest,
+			AddSize:       int64(len(sentinelManifestBlob)),
+			AddMediaType:  imgspecv1.MediaTypeImageManifest,
+			AddPlatform:   ci.platform,
+			AddAnnotations: map[string]string{
+				internalManifest.OCI1InstanceAnnotationZstdChunkedSentinel: internalManifest.OCI1InstanceAnnotationZstdChunkedSentinelValue,
+				internalManifest.OCI1InstanceAnnotationCompressionZSTD:     internalManifest.OCI1InstanceAnnotationCompressionZSTDValue,
+			},
+			AddCompressionAlgorithms: ci.result.compressionAlgorithms,
+		})
+
+		platformsWithSentinel.Add(platformV1ToPlatformComparable(ci.platform))
+	}
+
+	return edits, nil
+}
+
+// createSingleImageSentinelIndex checks if a single copied image has zstd:chunked
+// layers, and if so, creates a sentinel variant and wraps both in an OCI index.
+// Returns the serialized index manifest, or nil if no sentinel was needed.
+func (c *copier) createSingleImageSentinelIndex(ctx context.Context, single copySingleImageResult) ([]byte, error) {
+	if single.manifestMIMEType != imgspecv1.MediaTypeImageManifest {
+		return nil, nil
+	}
+
+	ociMan, err := manifest.OCI1FromManifest(single.manifest)
+	if err != nil {
+		return nil, nil
+	}
+
+	if !hasZstdChunkedLayers(ociMan) {
+		return nil, nil
+	}
+
+	// Use the config as written to the destination (reflects any edits during copy).
+	var ociConfig imgspecv1.Image
+	if err := json.Unmarshal(single.configBlob, &ociConfig); err != nil {
+		logrus.Debugf("Cannot parse config for single-image sentinel: %v", err)
+		return nil, nil
+	}
+
+	sentinelManifestBlob, sentinelManifestDigest, err := c.pushSentinelVariant(ctx, ociMan, &ociConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	// Extract platform from config.
+	var platform *imgspecv1.Platform
+	if ociConfig.OS != "" || ociConfig.Architecture != "" {
+		platform = &imgspecv1.Platform{
+			OS:           ociConfig.OS,
+			Architecture: ociConfig.Architecture,
+			Variant:      ociConfig.Variant,
+			OSVersion:    ociConfig.OSVersion,
+		}
+	}
+
+	// Build OCI index with: original manifest first, sentinel variant last.
+	// Both entries get the zstd annotation so that old clients (which prefer
+	// zstd over gzip) fall through to position-based selection and pick the
+	// original at position 0 instead of the sentinel.
+	index := manifest.OCI1IndexFromComponents([]imgspecv1.Descriptor{
+		{
+			MediaType: imgspecv1.MediaTypeImageManifest,
+			Digest:    single.manifestDigest,
+			Size:      int64(len(single.manifest)),
+			Platform:  platform,
+			Annotations: map[string]string{
+				internalManifest.OCI1InstanceAnnotationCompressionZSTD: internalManifest.OCI1InstanceAnnotationCompressionZSTDValue,
+			},
+		},
+		{
+			MediaType: imgspecv1.MediaTypeImageManifest,
+			Digest:    sentinelManifestDigest,
+			Size:      int64(len(sentinelManifestBlob)),
+			Platform:  platform,
+			Annotations: map[string]string{
+				internalManifest.OCI1InstanceAnnotationZstdChunkedSentinel: internalManifest.OCI1InstanceAnnotationZstdChunkedSentinelValue,
+				internalManifest.OCI1InstanceAnnotationCompressionZSTD:     internalManifest.OCI1InstanceAnnotationCompressionZSTDValue,
+			},
+		},
+	}, nil)
+	indexBlob, err := index.Serialize()
+	if err != nil {
+		return nil, fmt.Errorf("serializing sentinel index: %w", err)
+	}
+
+	if err := c.dest.PutManifest(ctx, indexBlob, nil); err != nil {
+		return nil, fmt.Errorf("pushing sentinel index: %w", err)
+	}
+
+	return indexBlob, nil
 }

--- a/image/copy/single.go
+++ b/image/copy/single.go
@@ -3,6 +3,7 @@ package copy
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -42,6 +43,7 @@ type imageCopier struct {
 	compressionFormat             *compressiontypes.Algorithm // Compression algorithm to use, if the user explicitly requested one, or nil.
 	compressionLevel              *int
 	requireCompressionFormatMatch bool
+	stripSentinel                 bool // Remove sentinel layer[0] and DiffID[0] from final manifest/config
 }
 
 type copySingleImageOptions struct {
@@ -56,6 +58,7 @@ type copySingleImageResult struct {
 	manifestMIMEType      string
 	manifestDigest        digest.Digest
 	compressionAlgorithms []compressiontypes.Algorithm
+	configBlob            []byte // The config as written to the destination
 }
 
 // copySingleImage copies a single (non-manifest-list) image unparsedImage, using c.policyContext to validate
@@ -241,11 +244,12 @@ func (c *copier) copySingleImage(ctx context.Context, unparsedImage *image.Unpar
 	// without actually trying to upload something and getting a types.ManifestTypeRejectedError.
 	// So, try the preferred manifest MIME type with possibly-updated blob digests, media types, and sizes if
 	// we're altering how they're compressed.  If the process succeeds, fine…
-	manifestBytes, manifestDigest, err := ic.copyUpdatedConfigAndManifest(ctx, targetInstance)
+	manifestBytes, manifestDigest, configBlob, err := ic.copyUpdatedConfigAndManifest(ctx, targetInstance)
 	wipResult := copySingleImageResult{
 		manifest:         manifestBytes,
 		manifestMIMEType: ic.manifestConversionPlan.preferredMIMEType,
 		manifestDigest:   manifestDigest,
+		configBlob:       configBlob,
 	}
 	if err != nil {
 		logrus.Debugf("Writing manifest using preferred type %s failed: %v", ic.manifestConversionPlan.preferredMIMEType, err)
@@ -276,7 +280,7 @@ func (c *copier) copySingleImage(ctx context.Context, unparsedImage *image.Unpar
 		for _, manifestMIMEType := range ic.manifestConversionPlan.otherMIMETypeCandidates {
 			logrus.Debugf("Trying to use manifest type %s…", manifestMIMEType)
 			ic.manifestUpdates.ManifestMIMEType = manifestMIMEType
-			attemptedManifest, attemptedManifestDigest, err := ic.copyUpdatedConfigAndManifest(ctx, targetInstance)
+			attemptedManifest, attemptedManifestDigest, attemptedConfigBlob, err := ic.copyUpdatedConfigAndManifest(ctx, targetInstance)
 			if err != nil {
 				logrus.Debugf("Upload of manifest type %s failed: %v", manifestMIMEType, err)
 				errs = append(errs, fmt.Sprintf("%s(%v)", manifestMIMEType, err))
@@ -288,6 +292,7 @@ func (c *copier) copySingleImage(ctx context.Context, unparsedImage *image.Unpar
 				manifest:         attemptedManifest,
 				manifestMIMEType: manifestMIMEType,
 				manifestDigest:   attemptedManifestDigest,
+				configBlob:       attemptedConfigBlob,
 			}
 			errs = nil // Mark this as a success so that we don't abort below.
 			break
@@ -458,11 +463,43 @@ func (ic *imageCopier) copyLayers(ctx context.Context) ([]compressiontypes.Algor
 	}
 	manifestLayerInfos := man.LayerInfos()
 
+	// Let the destination filter manifest layer infos before copying.
+	// Destinations that support it (e.g., c/storage) may detect storage-specific
+	// markers and return indices of layers that should be skipped.
+	type layerFilter interface {
+		FilterLayers([]manifest.LayerInfo) []int
+	}
+	filteredLayers := set.New[int]()
+	if f, ok := ic.c.dest.(layerFilter); ok {
+		for _, idx := range f.FilterLayers(manifestLayerInfos) {
+			filteredLayers.Add(idx)
+		}
+	}
+
+	// If the destination does not implement FilterLayers (non-storage), strip the
+	// sentinel layer when compression is changing away from zstd:chunked.
+	if filteredLayers.Empty() && len(manifestLayerInfos) > 0 && manifestLayerInfos[0].MediaType == chunkedToc.ZstdChunkedSentinelMediaType {
+		destFormat := ic.compressionFormat
+		if destFormat == nil {
+			destFormat = defaultCompressionFormat
+		}
+		if destFormat.Name() != compressiontypes.ZstdChunkedAlgorithmName {
+			if ic.cannotModifyManifestReason != "" {
+				return nil, fmt.Errorf("copying this image requires stripping the zstd:chunked sentinel layer, which we cannot do: %q", ic.cannotModifyManifestReason)
+			}
+			filteredLayers.Add(0)
+			ic.stripSentinel = true
+		}
+	}
+
 	data := make([]copyLayerData, len(srcInfos))
 	copyLayerHelper := func(index int, srcLayer types.BlobInfo, toEncrypt bool, pool *mpb.Progress, srcRef reference.Named) {
 		defer ic.c.concurrentBlobCopiesSemaphore.Release(1)
 		cld := copyLayerData{}
-		if !ic.c.options.DownloadForeignLayers && ic.c.dest.AcceptsForeignLayerURLs() && len(srcLayer.URLs) != 0 {
+		if filteredLayers.Contains(index) {
+			cld.destInfo = srcLayer
+			logrus.Debugf("Skipping filtered layer %q (e.g., sentinel)", srcLayer.Digest)
+		} else if !ic.c.options.DownloadForeignLayers && ic.c.dest.AcceptsForeignLayerURLs() && len(srcLayer.URLs) != 0 {
 			// DiffIDs are, currently, needed only when converting from schema1.
 			// In which case src.LayerInfos will not have URLs because schema1
 			// does not support them.
@@ -564,11 +601,11 @@ func layerDigestsDiffer(a, b []types.BlobInfo) bool {
 // copyUpdatedConfigAndManifest updates the image per ic.manifestUpdates, if necessary,
 // stores the resulting config and manifest to the destination, and returns the stored manifest
 // and its digest.
-func (ic *imageCopier) copyUpdatedConfigAndManifest(ctx context.Context, instanceDigest *digest.Digest) ([]byte, digest.Digest, error) {
+func (ic *imageCopier) copyUpdatedConfigAndManifest(ctx context.Context, instanceDigest *digest.Digest) ([]byte, digest.Digest, []byte, error) {
 	var pendingImage types.Image = ic.src
 	if !ic.noPendingManifestUpdates() {
 		if ic.cannotModifyManifestReason != "" {
-			return nil, "", fmt.Errorf("Internal error: copy needs an updated manifest but that was known to be forbidden: %q", ic.cannotModifyManifestReason)
+			return nil, "", nil, fmt.Errorf("Internal error: copy needs an updated manifest but that was known to be forbidden: %q", ic.cannotModifyManifestReason)
 		}
 		if !ic.diffIDsAreNeeded && ic.src.UpdatedImageNeedsLayerDiffIDs(*ic.manifestUpdates) {
 			// We have set ic.diffIDsAreNeeded based on the preferred MIME type returned by determineManifestConversion.
@@ -577,36 +614,111 @@ func (ic *imageCopier) copyUpdatedConfigAndManifest(ctx context.Context, instanc
 			// when ic.c.dest.SupportedManifestMIMETypes() includes both s1 and s2, the upload using s1 failed, and we are now trying s2.
 			// Supposedly s2-only registries do not exist or are extremely rare, so failing with this error message is good enough for now.
 			// If handling such registries turns out to be necessary, we could compute ic.diffIDsAreNeeded based on the full list of manifest MIME type candidates.
-			return nil, "", fmt.Errorf("Can not convert image to %s, preparing DiffIDs for this case is not supported", ic.manifestUpdates.ManifestMIMEType)
+			return nil, "", nil, fmt.Errorf("Can not convert image to %s, preparing DiffIDs for this case is not supported", ic.manifestUpdates.ManifestMIMEType)
 		}
 		pi, err := ic.src.UpdatedImage(ctx, *ic.manifestUpdates)
 		if err != nil {
-			return nil, "", fmt.Errorf("creating an updated image manifest: %w", err)
+			return nil, "", nil, fmt.Errorf("creating an updated image manifest: %w", err)
 		}
 		pendingImage = pi
 	}
 	man, _, err := pendingImage.Manifest(ctx)
 	if err != nil {
-		return nil, "", fmt.Errorf("reading manifest: %w", err)
+		return nil, "", nil, fmt.Errorf("reading manifest: %w", err)
 	}
 
-	if err := ic.copyConfig(ctx, pendingImage); err != nil {
-		return nil, "", err
+	configBlob, err := pendingImage.ConfigBlob(ctx)
+	if err != nil {
+		return nil, "", nil, fmt.Errorf("reading config blob: %w", err)
+	}
+
+	if ic.stripSentinel {
+		man, configBlob, err = ic.stripSentinelFromManifestAndConfig(ctx, man, configBlob)
+		if err != nil {
+			return nil, "", nil, err
+		}
+	} else {
+		if err := ic.copyConfig(ctx, pendingImage); err != nil {
+			return nil, "", nil, err
+		}
 	}
 
 	ic.c.Printf("Writing manifest to image destination\n")
 	manifestDigest, err := manifest.Digest(man)
 	if err != nil {
-		return nil, "", err
+		return nil, "", nil, err
 	}
 	if instanceDigest != nil {
 		instanceDigest = &manifestDigest
 	}
 	if err := ic.c.dest.PutManifest(ctx, man, instanceDigest); err != nil {
 		logrus.Debugf("Error %v while writing manifest %q", err, string(man))
-		return nil, "", fmt.Errorf("writing manifest: %w", err)
+		return nil, "", nil, fmt.Errorf("writing manifest: %w", err)
 	}
-	return man, manifestDigest, nil
+	return man, manifestDigest, configBlob, nil
+}
+
+// stripSentinelFromManifestAndConfig removes the sentinel layer (layer[0]) from
+// the OCI manifest and the corresponding DiffID (DiffIDs[0]) from the config.
+// It pushes the new config to the destination and returns the updated manifest
+// and config blobs.
+func (ic *imageCopier) stripSentinelFromManifestAndConfig(ctx context.Context, manBlob []byte, configBlob []byte) ([]byte, []byte, error) {
+	ociMan, err := manifest.OCI1FromManifest(manBlob)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parsing OCI manifest for sentinel stripping: %w", err)
+	}
+	if len(ociMan.Layers) == 0 || ociMan.Layers[0].MediaType != chunkedToc.ZstdChunkedSentinelMediaType {
+		return nil, nil, errors.New("internal error: stripSentinel set but manifest layer[0] is not the sentinel")
+	}
+	ociMan.Layers = ociMan.Layers[1:]
+
+	var ociConfig imgspecv1.Image
+	if err := json.Unmarshal(configBlob, &ociConfig); err != nil {
+		return nil, nil, fmt.Errorf("parsing config for sentinel stripping: %w", err)
+	}
+	if len(ociConfig.RootFS.DiffIDs) == 0 || ociConfig.RootFS.DiffIDs[0] != chunkedToc.ZstdChunkedSentinelDigest {
+		return nil, nil, errors.New("internal error: stripSentinel set but config DiffIDs[0] is not the sentinel")
+	}
+	ociConfig.RootFS.DiffIDs = ociConfig.RootFS.DiffIDs[1:]
+
+	newConfigBlob, err := json.Marshal(ociConfig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshaling config after sentinel stripping: %w", err)
+	}
+	configDigest := digest.FromBytes(newConfigBlob)
+
+	// Push new config to destination.
+	configBlobInfo := types.BlobInfo{
+		Digest:    configDigest,
+		Size:      int64(len(newConfigBlob)),
+		MediaType: imgspecv1.MediaTypeImageConfig,
+	}
+	reused, _, err := ic.c.dest.TryReusingBlobWithOptions(ctx, configBlobInfo,
+		private.TryReusingBlobOptions{Cache: ic.c.blobInfoCache})
+	if err != nil {
+		return nil, nil, fmt.Errorf("checking stripped config blob: %w", err)
+	}
+	if !reused {
+		_, err = ic.c.dest.PutBlobWithOptions(ctx, bytes.NewReader(newConfigBlob),
+			configBlobInfo, private.PutBlobOptions{Cache: ic.c.blobInfoCache, IsConfig: true})
+		if err != nil {
+			return nil, nil, fmt.Errorf("pushing stripped config blob: %w", err)
+		}
+	}
+
+	// Update manifest to point to the new config.
+	ociMan.Config = imgspecv1.Descriptor{
+		MediaType: imgspecv1.MediaTypeImageConfig,
+		Digest:    configDigest,
+		Size:      int64(len(newConfigBlob)),
+	}
+	newManBlob, err := ociMan.Serialize()
+	if err != nil {
+		return nil, nil, fmt.Errorf("serializing manifest after sentinel stripping: %w", err)
+	}
+
+	logrus.Debugf("Stripped zstd:chunked sentinel layer from manifest and config")
+	return newManBlob, newConfigBlob, nil
 }
 
 // copyConfig copies config.json, if any, from src to dest.

--- a/image/copy/single_test.go
+++ b/image/copy/single_test.go
@@ -2,21 +2,29 @@ package copy
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	digest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/specs-go"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.podman.io/image/v5/internal/private"
+	"go.podman.io/image/v5/manifest"
+	ociLayout "go.podman.io/image/v5/oci/layout"
 	"go.podman.io/image/v5/pkg/compression"
 	compressiontypes "go.podman.io/image/v5/pkg/compression/types"
+	"go.podman.io/image/v5/signature"
 	"go.podman.io/image/v5/types"
+	chunkedToc "go.podman.io/storage/pkg/chunked/toc"
 )
 
 func TestUpdatedBlobInfoFromReuse(t *testing.T) {
@@ -158,4 +166,166 @@ func TestComputeDiffID(t *testing.T) {
 	require.NoError(t, err)
 	_, err = computeDiffID(reader, nil)
 	assert.Error(t, err)
+}
+
+// createOCILayoutWithSentinel creates a minimal OCI layout directory containing
+// a single image with a sentinel layer prepended (simulating a zstd:chunked
+// sentinel image). Returns the path to the OCI layout dir.
+func createOCILayoutWithSentinel(t *testing.T, dir string) {
+	t.Helper()
+
+	blobsDir := filepath.Join(dir, "blobs", "sha256")
+	require.NoError(t, os.MkdirAll(blobsDir, 0o755))
+
+	// Write oci-layout
+	ociLayoutJSON, err := json.Marshal(imgspecv1.ImageLayout{Version: specs.Version})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "oci-layout"), ociLayoutJSON, 0o644))
+
+	// Create a real layer (a minimal gzip stream).
+	realLayerContent := []byte("real layer data for testing")
+	realLayerDigest := digest.FromBytes(realLayerContent)
+	require.NoError(t, os.WriteFile(filepath.Join(blobsDir, realLayerDigest.Encoded()), realLayerContent, 0o644))
+
+	// Write sentinel blob.
+	sentinelContent := chunkedToc.ZstdChunkedSentinelContent
+	sentinelDigest := chunkedToc.ZstdChunkedSentinelDigest
+	require.NoError(t, os.WriteFile(filepath.Join(blobsDir, sentinelDigest.Encoded()), sentinelContent, 0o644))
+
+	// Create config with sentinel DiffID at [0].
+	config := imgspecv1.Image{
+		RootFS: imgspecv1.RootFS{
+			Type:    "layers",
+			DiffIDs: []digest.Digest{sentinelDigest, realLayerDigest},
+		},
+	}
+	configBlob, err := json.Marshal(config)
+	require.NoError(t, err)
+	configDigest := digest.FromBytes(configBlob)
+	require.NoError(t, os.WriteFile(filepath.Join(blobsDir, configDigest.Encoded()), configBlob, 0o644))
+
+	// Create OCI manifest with sentinel layer at [0].
+	ociManifest := imgspecv1.Manifest{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: imgspecv1.MediaTypeImageManifest,
+		Config: imgspecv1.Descriptor{
+			MediaType: imgspecv1.MediaTypeImageConfig,
+			Digest:    configDigest,
+			Size:      int64(len(configBlob)),
+		},
+		Layers: []imgspecv1.Descriptor{
+			{
+				MediaType: chunkedToc.ZstdChunkedSentinelMediaType,
+				Digest:    sentinelDigest,
+				Size:      int64(len(sentinelContent)),
+			},
+			{
+				MediaType: imgspecv1.MediaTypeImageLayerZstd,
+				Digest:    realLayerDigest,
+				Size:      int64(len(realLayerContent)),
+			},
+		},
+	}
+	manifestBlob, err := json.Marshal(ociManifest)
+	require.NoError(t, err)
+	manifestDigest := digest.FromBytes(manifestBlob)
+	require.NoError(t, os.WriteFile(filepath.Join(blobsDir, manifestDigest.Encoded()), manifestBlob, 0o644))
+
+	// Create index.json.
+	index := imgspecv1.Index{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: imgspecv1.MediaTypeImageIndex,
+		Manifests: []imgspecv1.Descriptor{
+			{
+				MediaType: imgspecv1.MediaTypeImageManifest,
+				Digest:    manifestDigest,
+				Size:      int64(len(manifestBlob)),
+			},
+		},
+	}
+	indexBlob, err := json.Marshal(index)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "index.json"), indexBlob, 0o644))
+}
+
+func TestStripSentinelOnCompressionChange(t *testing.T) {
+	srcDir := t.TempDir()
+	destDir := t.TempDir()
+
+	createOCILayoutWithSentinel(t, srcDir)
+
+	srcRef, err := ociLayout.ParseReference(srcDir)
+	require.NoError(t, err)
+	destRef, err := ociLayout.ParseReference(destDir)
+	require.NoError(t, err)
+
+	policy := &signature.Policy{Default: signature.PolicyRequirements{signature.NewPRInsecureAcceptAnything()}}
+	pc, err := signature.NewPolicyContext(policy)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, pc.Destroy()) }()
+
+	ctx := context.Background()
+	gzipAlgo := compression.Gzip
+	copiedManifest, err := Image(ctx, pc, destRef, srcRef, &Options{
+		DestinationCtx: &types.SystemContext{
+			CompressionFormat: &gzipAlgo,
+		},
+	})
+	require.NoError(t, err)
+
+	// Parse the resulting manifest and verify the sentinel layer is gone.
+	ociMan, err := manifest.OCI1FromManifest(copiedManifest)
+	require.NoError(t, err)
+
+	for i, layer := range ociMan.Layers {
+		assert.NotEqual(t, chunkedToc.ZstdChunkedSentinelMediaType, layer.MediaType,
+			"sentinel layer should have been stripped, but found at index %d", i)
+	}
+
+	// Read the config from the destination and verify sentinel DiffID is gone.
+	configBlob, err := os.ReadFile(filepath.Join(destDir, "blobs", "sha256", ociMan.Config.Digest.Encoded()))
+	require.NoError(t, err)
+	var ociConfig imgspecv1.Image
+	require.NoError(t, json.Unmarshal(configBlob, &ociConfig))
+
+	for i, diffID := range ociConfig.RootFS.DiffIDs {
+		assert.NotEqual(t, chunkedToc.ZstdChunkedSentinelDigest, diffID,
+			"sentinel DiffID should have been stripped, but found at index %d", i)
+	}
+
+	// Should have exactly 1 layer (the real one, not the sentinel).
+	assert.Len(t, ociMan.Layers, 1, "expected exactly 1 layer after sentinel stripping")
+	assert.Len(t, ociConfig.RootFS.DiffIDs, 1, "expected exactly 1 DiffID after sentinel stripping")
+}
+
+func TestStripSentinelOnDefaultCompression(t *testing.T) {
+	// When no explicit compression format is set, the default (gzip) is used.
+	// The sentinel should be stripped since the destination format differs from zstd:chunked.
+	srcDir := t.TempDir()
+	destDir := t.TempDir()
+
+	createOCILayoutWithSentinel(t, srcDir)
+
+	srcRef, err := ociLayout.ParseReference(srcDir)
+	require.NoError(t, err)
+	destRef, err := ociLayout.ParseReference(destDir)
+	require.NoError(t, err)
+
+	policy := &signature.Policy{Default: signature.PolicyRequirements{signature.NewPRInsecureAcceptAnything()}}
+	pc, err := signature.NewPolicyContext(policy)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, pc.Destroy()) }()
+
+	ctx := context.Background()
+	copiedManifest, err := Image(ctx, pc, destRef, srcRef, &Options{})
+	require.NoError(t, err)
+
+	ociMan, err := manifest.OCI1FromManifest(copiedManifest)
+	require.NoError(t, err)
+
+	for i, layer := range ociMan.Layers {
+		assert.NotEqual(t, chunkedToc.ZstdChunkedSentinelMediaType, layer.MediaType,
+			"sentinel layer should have been stripped, but found at index %d", i)
+	}
+	assert.Len(t, ociMan.Layers, 1, "expected exactly 1 layer after sentinel stripping")
 }

--- a/image/internal/image/docker_schema1.go
+++ b/image/internal/image/docker_schema1.go
@@ -2,6 +2,7 @@ package image
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/opencontainers/go-digest"
@@ -106,6 +107,9 @@ func (m *manifestSchema1) UpdatedImageNeedsLayerDiffIDs(options types.ManifestUp
 // UpdatedImage returns a types.Image modified according to options.
 // This does not change the state of the original Image object.
 func (m *manifestSchema1) UpdatedImage(ctx context.Context, options types.ManifestUpdateOptions) (types.Image, error) {
+	if len(options.PrependLayers) > 0 || len(options.RemoveLayerIndices) > 0 {
+		return nil, errors.New("layer addition/removal is not supported for Docker schema1 manifests")
+	}
 	copy := manifestSchema1{m: manifest.Schema1Clone(m.m)}
 
 	// We have 2 MIME types for schema 1, which are basically equivalent (even the un-"Signed" MIME type will be rejected if there isn’t a signature; so,

--- a/image/internal/image/docker_schema1_test.go
+++ b/image/internal/image/docker_schema1_test.go
@@ -441,6 +441,23 @@ func TestManifestSchema1UpdatedImage(t *testing.T) {
 	assert.Equal(t, *typedM2, *typedOriginal)
 }
 
+func TestManifestSchema1UpdatedImageLayerEditRejection(t *testing.T) {
+	original := manifestSchema1FromFixture(t, "schema1.json")
+
+	_, err := original.UpdatedImage(context.Background(), types.ManifestUpdateOptions{
+		PrependLayers: []types.PrependedLayerInfo{{
+			BlobInfo: types.BlobInfo{Digest: "sha256:aa", Size: 1, MediaType: "application/vnd.test"},
+			DiffID:   "sha256:bb",
+		}},
+	})
+	assert.Error(t, err)
+
+	_, err = original.UpdatedImage(context.Background(), types.ManifestUpdateOptions{
+		RemoveLayerIndices: []int{0},
+	})
+	assert.Error(t, err)
+}
+
 func TestManifestSchema1ConvertToSchema2(t *testing.T) {
 	original := manifestSchema1FromFixture(t, "schema1.json")
 	res, err := original.UpdatedImage(context.Background(), types.ManifestUpdateOptions{

--- a/image/internal/image/docker_schema2.go
+++ b/image/internal/image/docker_schema2.go
@@ -161,6 +161,9 @@ func (m *manifestSchema2) UpdatedImageNeedsLayerDiffIDs(options types.ManifestUp
 // if the CompressionOperation and CompressionAlgorithm specified in one or more
 // options.LayerInfos items is anything other than gzip.
 func (m *manifestSchema2) UpdatedImage(ctx context.Context, options types.ManifestUpdateOptions) (types.Image, error) {
+	if len(options.PrependLayers) > 0 || len(options.RemoveLayerIndices) > 0 {
+		return nil, errors.New("layer addition/removal is not supported for Docker schema2 manifests")
+	}
 	copy := manifestSchema2{ // NOTE: This is not a deep copy, it still shares slices etc.
 		src:        m.src,
 		configBlob: m.configBlob,

--- a/image/internal/image/docker_schema2_test.go
+++ b/image/internal/image/docker_schema2_test.go
@@ -519,6 +519,24 @@ func TestManifestSchema2UpdatedImage(t *testing.T) {
 	assert.Equal(t, *typedM2, *typedOriginal)
 }
 
+func TestManifestSchema2UpdatedImageLayerEditRejection(t *testing.T) {
+	originalSrc := newSchema2ImageSource(t, "httpd:latest")
+	original := manifestSchema2FromFixture(t, originalSrc, "schema2.json", false)
+
+	_, err := original.UpdatedImage(context.Background(), types.ManifestUpdateOptions{
+		PrependLayers: []types.PrependedLayerInfo{{
+			BlobInfo: types.BlobInfo{Digest: "sha256:aa", Size: 1, MediaType: "application/vnd.test"},
+			DiffID:   "sha256:bb",
+		}},
+	})
+	assert.Error(t, err)
+
+	_, err = original.UpdatedImage(context.Background(), types.ManifestUpdateOptions{
+		RemoveLayerIndices: []int{0},
+	})
+	assert.Error(t, err)
+}
+
 func TestConvertToManifestOCI(t *testing.T) {
 	originalSrc := newSchema2ImageSource(t, "httpd-copy:latest")
 	original := manifestSchema2FromFixture(t, originalSrc, "schema2.json", false)

--- a/image/internal/image/oci.go
+++ b/image/internal/image/oci.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 
 	ociencspec "github.com/containers/ocicrypt/spec"
+	digest "github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"go.podman.io/image/v5/docker/reference"
 	"go.podman.io/image/v5/internal/iolimits"
@@ -163,15 +164,120 @@ func (m *manifestOCI1) UpdatedImage(ctx context.Context, options types.ManifestU
 		return converted, nil
 	}
 
+	// Remove layers before UpdateLayerInfos so the counts match.
+	// LayerInfos, if set, must already exclude entries for removed layers.
+	if len(options.RemoveLayerIndices) > 0 {
+		if err := copy.removeLayers(ctx, options.RemoveLayerIndices); err != nil {
+			return nil, err
+		}
+	}
+
 	// No conversion required, update manifest
 	if options.LayerInfos != nil {
 		if err := copy.m.UpdateLayerInfos(options.LayerInfos); err != nil {
 			return nil, err
 		}
 	}
+
+	// Prepend layers after UpdateLayerInfos.
+	if len(options.PrependLayers) > 0 {
+		if err := copy.prependLayers(ctx, options.PrependLayers); err != nil {
+			return nil, err
+		}
+	}
+
 	// Ignore options.EmbeddedDockerReference: it may be set when converting from schema1, but we really don't care.
 
 	return memoryImageFromManifest(&copy), nil
+}
+
+// parseConfigBlob loads the config blob (from cache or source) and parses it.
+func (m *manifestOCI1) parseConfigBlob(ctx context.Context) (*imgspecv1.Image, error) {
+	cb, err := m.ConfigBlob(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("reading config blob: %w", err)
+	}
+	var config imgspecv1.Image
+	if err := json.Unmarshal(cb, &config); err != nil {
+		return nil, fmt.Errorf("parsing config blob: %w", err)
+	}
+	return &config, nil
+}
+
+// updateConfigBlob marshals the config, updates the cached configBlob and the
+// manifest's Config descriptor to match.
+func (m *manifestOCI1) updateConfigBlob(config *imgspecv1.Image) error {
+	configBlob, err := json.Marshal(config)
+	if err != nil {
+		return fmt.Errorf("marshaling updated config: %w", err)
+	}
+	m.configBlob = configBlob
+	m.m.Config = imgspecv1.Descriptor{
+		MediaType: imgspecv1.MediaTypeImageConfig,
+		Digest:    digest.FromBytes(configBlob),
+		Size:      int64(len(configBlob)),
+	}
+	return nil
+}
+
+// removeLayers removes the layers at the given indices from the manifest and
+// the corresponding DiffIDs from the config.
+func (m *manifestOCI1) removeLayers(ctx context.Context, indices []int) error {
+	config, err := m.parseConfigBlob(ctx)
+	if err != nil {
+		return fmt.Errorf("removing layers: %w", err)
+	}
+	if len(config.RootFS.DiffIDs) != len(m.m.Layers) {
+		return fmt.Errorf("removing layers: config has %d DiffIDs but manifest has %d layers", len(config.RootFS.DiffIDs), len(m.m.Layers))
+	}
+	for _, idx := range indices {
+		if idx < 0 || idx >= len(m.m.Layers) {
+			return fmt.Errorf("removing layers: index %d out of range [0, %d)", idx, len(m.m.Layers))
+		}
+	}
+	m.m.Layers = removeIndices(m.m.Layers, indices)
+	config.RootFS.DiffIDs = removeIndices(config.RootFS.DiffIDs, indices)
+	return m.updateConfigBlob(config)
+}
+
+// prependLayers prepends layers to the manifest and corresponding DiffIDs to
+// the config.
+func (m *manifestOCI1) prependLayers(ctx context.Context, layers []types.PrependedLayerInfo) error {
+	config, err := m.parseConfigBlob(ctx)
+	if err != nil {
+		return fmt.Errorf("prepending layers: %w", err)
+	}
+	descs := make([]imgspecv1.Descriptor, 0, len(layers)+len(m.m.Layers))
+	diffIDs := make([]digest.Digest, 0, len(layers)+len(config.RootFS.DiffIDs))
+	for _, l := range layers {
+		descs = append(descs, imgspecv1.Descriptor{
+			MediaType:   l.BlobInfo.MediaType,
+			Digest:      l.BlobInfo.Digest,
+			Size:        l.BlobInfo.Size,
+			URLs:        l.BlobInfo.URLs,
+			Annotations: l.BlobInfo.Annotations,
+		})
+		diffIDs = append(diffIDs, l.DiffID)
+	}
+	m.m.Layers = append(descs, m.m.Layers...)
+	config.RootFS.DiffIDs = append(diffIDs, config.RootFS.DiffIDs...)
+	return m.updateConfigBlob(config)
+}
+
+// removeIndices removes elements at the given indices from a slice, returning
+// a new slice. Indices must be valid for the slice.
+func removeIndices[T any](s []T, indices []int) []T {
+	remove := make(map[int]struct{}, len(indices))
+	for _, idx := range indices {
+		remove[idx] = struct{}{}
+	}
+	result := make([]T, 0, len(s)-len(remove))
+	for i, v := range s {
+		if _, ok := remove[i]; !ok {
+			result = append(result, v)
+		}
+	}
+	return result
 }
 
 func schema2DescriptorFromOCI1Descriptor(d imgspecv1.Descriptor) manifest.Schema2Descriptor {

--- a/image/internal/image/oci_test.go
+++ b/image/internal/image/oci_test.go
@@ -476,6 +476,197 @@ func TestManifestOCI1UpdatedImage(t *testing.T) {
 	assert.Equal(t, *typedM2, *typedOriginal)
 }
 
+func TestManifestOCI1UpdatedImageLayerEdits(t *testing.T) {
+	configJSON, err := os.ReadFile("fixtures/oci1-config.json")
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name                string
+		options             types.ManifestUpdateOptions
+		expectedLayerCount  int
+		expectedDiffIDCount int
+		checkFunc           func(t *testing.T, res types.Image, originalConfig imgspecv1.Image)
+		expectError         bool
+	}{
+		{
+			name: "RemoveLayerIndices removes layer 0",
+			options: types.ManifestUpdateOptions{
+				RemoveLayerIndices: []int{0},
+			},
+			expectedLayerCount:  4,
+			expectedDiffIDCount: 4,
+			checkFunc: func(t *testing.T, res types.Image, originalConfig imgspecv1.Image) {
+				layers := res.LayerInfos()
+				assert.Equal(t, layerDescriptorsLikeFixture[1].Digest, layers[0].Digest)
+				assert.Equal(t, layerDescriptorsLikeFixture[4].Digest, layers[3].Digest)
+
+				cb, err := res.ConfigBlob(context.Background())
+				require.NoError(t, err)
+				var config imgspecv1.Image
+				require.NoError(t, json.Unmarshal(cb, &config))
+				assert.Equal(t, originalConfig.RootFS.DiffIDs[1:], config.RootFS.DiffIDs)
+			},
+		},
+		{
+			name: "RemoveLayerIndices removes last layer",
+			options: types.ManifestUpdateOptions{
+				RemoveLayerIndices: []int{4},
+			},
+			expectedLayerCount:  4,
+			expectedDiffIDCount: 4,
+			checkFunc: func(t *testing.T, res types.Image, originalConfig imgspecv1.Image) {
+				layers := res.LayerInfos()
+				assert.Equal(t, layerDescriptorsLikeFixture[3].Digest, layers[3].Digest)
+
+				cb, err := res.ConfigBlob(context.Background())
+				require.NoError(t, err)
+				var config imgspecv1.Image
+				require.NoError(t, json.Unmarshal(cb, &config))
+				assert.Equal(t, originalConfig.RootFS.DiffIDs[:4], config.RootFS.DiffIDs)
+			},
+		},
+		{
+			name: "RemoveLayerIndices removes multiple layers",
+			options: types.ManifestUpdateOptions{
+				RemoveLayerIndices: []int{0, 2, 4},
+			},
+			expectedLayerCount:  2,
+			expectedDiffIDCount: 2,
+			checkFunc: func(t *testing.T, res types.Image, originalConfig imgspecv1.Image) {
+				layers := res.LayerInfos()
+				assert.Equal(t, layerDescriptorsLikeFixture[1].Digest, layers[0].Digest)
+				assert.Equal(t, layerDescriptorsLikeFixture[3].Digest, layers[1].Digest)
+
+				cb, err := res.ConfigBlob(context.Background())
+				require.NoError(t, err)
+				var config imgspecv1.Image
+				require.NoError(t, json.Unmarshal(cb, &config))
+				assert.Equal(t, []digest.Digest{
+					originalConfig.RootFS.DiffIDs[1],
+					originalConfig.RootFS.DiffIDs[3],
+				}, config.RootFS.DiffIDs)
+			},
+		},
+		{
+			name: "RemoveLayerIndices out of range",
+			options: types.ManifestUpdateOptions{
+				RemoveLayerIndices: []int{5},
+			},
+			expectError: true,
+		},
+		{
+			name: "RemoveLayerIndices negative index",
+			options: types.ManifestUpdateOptions{
+				RemoveLayerIndices: []int{-1},
+			},
+			expectError: true,
+		},
+		{
+			name: "PrependLayers adds a layer",
+			options: types.ManifestUpdateOptions{
+				PrependLayers: []types.PrependedLayerInfo{
+					{
+						BlobInfo: types.BlobInfo{
+							Digest:    "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+							Size:      512,
+							MediaType: "application/vnd.test.sentinel",
+						},
+						DiffID: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+					},
+				},
+			},
+			expectedLayerCount:  6,
+			expectedDiffIDCount: 6,
+			checkFunc: func(t *testing.T, res types.Image, originalConfig imgspecv1.Image) {
+				layers := res.LayerInfos()
+				assert.Equal(t, digest.Digest("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), layers[0].Digest)
+				assert.Equal(t, "application/vnd.test.sentinel", layers[0].MediaType)
+				assert.Equal(t, int64(512), layers[0].Size)
+				assert.Equal(t, layerDescriptorsLikeFixture[0].Digest, layers[1].Digest)
+
+				cb, err := res.ConfigBlob(context.Background())
+				require.NoError(t, err)
+				var config imgspecv1.Image
+				require.NoError(t, json.Unmarshal(cb, &config))
+				assert.Equal(t, digest.Digest("sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"), config.RootFS.DiffIDs[0])
+				assert.Equal(t, originalConfig.RootFS.DiffIDs, config.RootFS.DiffIDs[1:])
+			},
+		},
+		{
+			name: "RemoveLayerIndices with LayerInfos",
+			options: types.ManifestUpdateOptions{
+				RemoveLayerIndices: []int{0},
+				LayerInfos: []types.BlobInfo{
+					{
+						Digest:               layerDescriptorsLikeFixture[1].Digest,
+						Size:                 layerDescriptorsLikeFixture[1].Size,
+						MediaType:            imgspecv1.MediaTypeImageLayerGzip,
+						CompressionOperation: types.PreserveOriginal,
+					},
+					{
+						Digest:               layerDescriptorsLikeFixture[2].Digest,
+						Size:                 layerDescriptorsLikeFixture[2].Size,
+						URLs:                 layerDescriptorsLikeFixture[2].URLs,
+						MediaType:            imgspecv1.MediaTypeImageLayerGzip,
+						CompressionOperation: types.PreserveOriginal,
+					},
+					{
+						Digest:               layerDescriptorsLikeFixture[3].Digest,
+						Size:                 layerDescriptorsLikeFixture[3].Size,
+						Annotations:          layerDescriptorsLikeFixture[3].Annotations,
+						MediaType:            imgspecv1.MediaTypeImageLayerGzip,
+						CompressionOperation: types.PreserveOriginal,
+					},
+					{
+						Digest:               layerDescriptorsLikeFixture[4].Digest,
+						Size:                 layerDescriptorsLikeFixture[4].Size,
+						MediaType:            imgspecv1.MediaTypeImageLayerGzip,
+						CompressionOperation: types.PreserveOriginal,
+					},
+				},
+			},
+			expectedLayerCount:  4,
+			expectedDiffIDCount: 4,
+			checkFunc: func(t *testing.T, res types.Image, originalConfig imgspecv1.Image) {
+				layers := res.LayerInfos()
+				assert.Equal(t, layerDescriptorsLikeFixture[1].Digest, layers[0].Digest)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := manifestOCI1FromComponentsLikeFixture(configJSON)
+
+			var originalConfig imgspecv1.Image
+			require.NoError(t, json.Unmarshal(configJSON, &originalConfig))
+
+			res, err := m.UpdatedImage(context.Background(), tc.options)
+			if tc.expectError {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			layers := res.LayerInfos()
+			assert.Len(t, layers, tc.expectedLayerCount)
+
+			cb, err := res.ConfigBlob(context.Background())
+			require.NoError(t, err)
+			var config imgspecv1.Image
+			require.NoError(t, json.Unmarshal(cb, &config))
+			assert.Len(t, config.RootFS.DiffIDs, tc.expectedDiffIDCount)
+
+			if tc.checkFunc != nil {
+				tc.checkFunc(t, res, originalConfig)
+			}
+
+			// Verify config descriptor is updated
+			configInfo := res.ConfigInfo()
+			assert.Equal(t, digest.FromBytes(cb), configInfo.Digest)
+			assert.Equal(t, int64(len(cb)), configInfo.Size)
+		})
+	}
+}
+
 // successfulOCI1Conversion verifies that an edit of original with edits suceeeds, and and original continues to match originalClone.
 // It returns the resulting image, for more checks
 func successfulOCI1Conversion(t *testing.T, original genericManifest, originalClone genericManifest,

--- a/image/internal/manifest/oci_index.go
+++ b/image/internal/manifest/oci_index.go
@@ -2,6 +2,7 @@ package manifest
 
 import (
 	"bytes"
+	"cmp"
 	"encoding/json"
 	"fmt"
 	"maps"
@@ -12,6 +13,7 @@ import (
 	"github.com/opencontainers/go-digest"
 	imgspec "github.com/opencontainers/image-spec/specs-go"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/sirupsen/logrus"
 	platform "go.podman.io/image/v5/internal/pkg/platform"
 	compression "go.podman.io/image/v5/pkg/compression/types"
 	"go.podman.io/image/v5/types"
@@ -26,6 +28,12 @@ const (
 	// use gzip, depending on their local policy.
 	OCI1InstanceAnnotationCompressionZSTD      = "io.github.containers.compression.zstd"
 	OCI1InstanceAnnotationCompressionZSTDValue = "true"
+
+	// OCI1InstanceAnnotationZstdChunkedSentinel is an annotation name that can be placed on a manifest descriptor
+	// in an OCI index. The value must be "true". It signals that the manifest contains a sentinel layer
+	// prepended to its layers, indicating that aware clients can skip the zstd:chunked full-digest mitigation.
+	OCI1InstanceAnnotationZstdChunkedSentinel      = "io.github.containers.zstd-chunked.sentinel"
+	OCI1InstanceAnnotationZstdChunkedSentinelValue = "true"
 )
 
 // OCI1IndexPublic is just an alias for the OCI index type, but one which we can
@@ -192,18 +200,7 @@ func (index *OCI1IndexPublic) editInstances(editInstances []ListEdit, cannotModi
 	}
 	if len(addedEntries) != 0 || updatedAnnotations {
 		slices.SortStableFunc(index.Manifests, func(a, b imgspecv1.Descriptor) int {
-			// FIXME? With Go 1.21 and cmp.Compare available, turn instanceIsZstd into an integer score that can be compared, and generalizes
-			// into more algorithms?
-			aZstd := instanceIsZstd(a)
-			bZstd := instanceIsZstd(b)
-			switch {
-			case aZstd == bZstd:
-				return 0
-			case !aZstd: // Implies bZstd
-				return -1
-			default: // aZstd && !bZstd
-				return 1
-			}
+			return cmp.Compare(instanceSortScore(a), instanceSortScore(b))
 		})
 	}
 	return nil
@@ -223,9 +220,30 @@ func instanceIsZstd(manifest imgspecv1.Descriptor) bool {
 	return false
 }
 
+// instanceHasSentinel returns true if instance has the zstd:chunked sentinel annotation.
+// Note: This checks the index-level annotation used for instance selection.
+// Actual sentinel layer presence is verified by FilterLayers at pull time.
+func instanceHasSentinel(manifest imgspecv1.Descriptor) bool {
+	return manifest.Annotations[OCI1InstanceAnnotationZstdChunkedSentinel] == OCI1InstanceAnnotationZstdChunkedSentinelValue
+}
+
+// instanceSortScore returns a sorting score for manifest index ordering:
+// 0 = plain (gzip), 1 = zstd, 2 = zstd:chunked sentinel.
+// Lower scores sort first in the index.
+func instanceSortScore(d imgspecv1.Descriptor) int {
+	if instanceHasSentinel(d) {
+		return 2
+	}
+	if instanceIsZstd(d) {
+		return 1
+	}
+	return 0
+}
+
 type instanceCandidate struct {
 	platformIndex    int           // Index of the candidate in platform.WantedPlatforms: lower numbers are preferred; or math.maxInt if the candidate doesn’t have a platform
 	isZstd           bool          // tells if particular instance if zstd instance
+	hasSentinel      bool          // tells if particular instance has the zstd:chunked sentinel layer
 	manifestPosition int           // A zero-based index of the instance in the manifest list
 	digest           digest.Digest // Instance digest
 }
@@ -240,6 +258,8 @@ func (ic instanceCandidate) isPreferredOver(other *instanceCandidate, preferGzip
 		} else {
 			return !ic.isZstd
 		}
+	case ic.hasSentinel != other.hasSentinel:
+		return ic.hasSentinel
 	case ic.manifestPosition != other.manifestPosition:
 		return ic.manifestPosition < other.manifestPosition
 	}
@@ -253,7 +273,7 @@ func (index *OCI1IndexPublic) chooseInstance(ctx *types.SystemContext, preferGzi
 	var bestMatch *instanceCandidate
 	bestMatch = nil
 	for manifestIndex, d := range index.Manifests {
-		candidate := instanceCandidate{platformIndex: math.MaxInt, manifestPosition: manifestIndex, isZstd: instanceIsZstd(d), digest: d.Digest}
+		candidate := instanceCandidate{platformIndex: math.MaxInt, manifestPosition: manifestIndex, isZstd: instanceIsZstd(d), hasSentinel: instanceHasSentinel(d), digest: d.Digest}
 		if d.Platform != nil {
 			imagePlatform := ociPlatformClone(*d.Platform)
 			platformIndex := slices.IndexFunc(wantedPlatforms, func(wantedPlatform imgspecv1.Platform) bool {
@@ -269,6 +289,9 @@ func (index *OCI1IndexPublic) chooseInstance(ctx *types.SystemContext, preferGzi
 		}
 	}
 	if bestMatch != nil {
+		if bestMatch.hasSentinel {
+			logrus.Debugf("Selected instance %s with zstd:chunked sentinel (position %d in index)", bestMatch.digest, bestMatch.manifestPosition)
+		}
 		return bestMatch.digest, nil
 	}
 	return "", fmt.Errorf("no image found in image index for architecture %q, variant %q, OS %q", wantedPlatforms[0].Architecture, wantedPlatforms[0].Variant, wantedPlatforms[0].OS)

--- a/image/storage/storage_dest.go
+++ b/image/storage/storage_dest.go
@@ -58,15 +58,20 @@ type storageImageDestination struct {
 	stubs.AlwaysSupportsSignatures
 
 	imageRef              storageReference
-	directory             string                   // Temporary directory where we store blobs until Commit() time
-	nextTempFileID        atomic.Int32             // A counter that we use for computing filenames to assign to blobs
-	manifest              []byte                   // (Per-instance) manifest contents, or nil if not yet known.
-	manifestMIMEType      string                   // Valid if manifest != nil
-	manifestDigest        digest.Digest            // Valid if manifest != nil
-	untrustedDiffIDValues []digest.Digest          // From config’s RootFS.DiffIDs (not even validated to be valid digest.Digest!); or nil if not read yet
-	signatures            []byte                   // Signature contents, temporary
-	signatureses          map[digest.Digest][]byte // Instance signature contents, temporary
-	metadata              storageImageMetadata     // Metadata contents being built
+	directory             string          // Temporary directory where we store blobs until Commit() time
+	nextTempFileID        atomic.Int32    // A counter that we use for computing filenames to assign to blobs
+	manifest              []byte          // (Per-instance) manifest contents, or nil if not yet known.
+	manifestMIMEType      string          // Valid if manifest != nil
+	manifestDigest        digest.Digest   // Valid if manifest != nil
+	untrustedDiffIDValues []digest.Digest // From config’s RootFS.DiffIDs (not even validated to be valid digest.Digest!); or nil if not read yet
+	// filteredLayerIndices are layer indices marked empty by FilterLayers.
+	// When set, the full-digest mitigation is skipped for remaining layers,
+	// and falling back from partial to ordinary layer download is refused
+	// (because the mitigation would be the only safety net for that path).
+	filteredLayerIndices []int
+	signatures           []byte                   // Signature contents, temporary
+	signatureses         map[digest.Digest][]byte // Instance signature contents, temporary
+	metadata             storageImageMetadata     // Metadata contents being built
 
 	// Mapping from layer (by index) to the associated ID in the storage.
 	// It's protected *implicitly* since `commitLayer()`, at any given
@@ -135,7 +140,8 @@ type storageImageDestinationLockProtected struct {
 // addedLayerInfo records data about a layer to use in this image.
 type addedLayerInfo struct {
 	digest     digest.Digest // Mandatory, the digest of the layer.
-	emptyLayer bool          // The layer is an “empty”/“throwaway” one, and may or may not be physically represented in various transport / storage systems.  false if the manifest type does not have the concept.
+	emptyLayer bool          // The layer is an “empty”/”throwaway” one, and may or may not be physically represented in various transport / storage systems.  false if the manifest type does not have the concept.
+	filtered   bool          // The layer was filtered out (e.g., zstd:chunked sentinel) — not physically stored, distinct from emptyLayer which is a schema1 concept.
 }
 
 // newImageDestination sets us up to write a new image, caching blobs in a temporary directory until
@@ -222,6 +228,19 @@ func (s *storageImageDestination) NoteOriginalOCIConfig(ociConfig *imgspecv1.Ima
 	return nil
 }
 
+// FilterLayers inspects the manifest layer infos and returns indices of layers
+// that should be skipped. For c/storage, this detects the zstd:chunked
+// sentinel layer (by MIME type) and records that the full-digest mitigation
+// can be skipped. This verifies actual sentinel presence in the manifest,
+// independent of any index-level annotation.
+func (s *storageImageDestination) FilterLayers(layerInfos []manifest.LayerInfo) []int {
+	if len(layerInfos) > 0 && layerInfos[0].MediaType == toc.ZstdChunkedSentinelMediaType {
+		s.filteredLayerIndices = []int{0}
+		return s.filteredLayerIndices
+	}
+	return nil
+}
+
 // PutBlobWithOptions writes contents of stream and returns data representing the result.
 // inputInfo.Digest can be optionally provided if known; if provided, and stream is read to the end without error, the digest MUST match the stream contents.
 // inputInfo.Size is the expected length of stream, if known.
@@ -230,6 +249,13 @@ func (s *storageImageDestination) NoteOriginalOCIConfig(ociConfig *imgspecv1.Ima
 // to any other readers for download using the supplied digest.
 // If stream.Read() at any time, ESPECIALLY at end of input, returns an error, PutBlob MUST 1) fail, and 2) delete any data stored so far.
 func (s *storageImageDestination) PutBlobWithOptions(ctx context.Context, stream io.Reader, blobinfo types.BlobInfo, options private.PutBlobOptions) (private.UploadedBlob, error) {
+	// When a sentinel layer is present, all real layers must be consumed via
+	// PutBlobPartial (TOC-based partial pull). Refuse the tar-based code path
+	// to prevent accidental use of the wrong consumption method.
+	if len(s.filteredLayerIndices) > 0 && options.LayerIndex != nil && !options.EmptyLayer {
+		return private.UploadedBlob{}, fmt.Errorf("zstd:chunked sentinel present, refusing ordinary layer download for layer %d", *options.LayerIndex)
+	}
+
 	info, err := s.putBlobToPendingFile(stream, blobinfo, &options)
 	if err != nil {
 		return info, err
@@ -397,6 +423,9 @@ func (s *storageImageDestination) PutBlobPartial(ctx context.Context, chunkAcces
 			return private.UploadedBlob{}, fmt.Errorf("internal error: in PutBlobPartial, untrustedLayerDiffID returned errUntrustedLayerDiffIDNotYetAvailable")
 		case errors.As(err, &diffIDUnknownErr):
 			if inputTOCDigest != nil {
+				if len(s.filteredLayerIndices) > 0 {
+					return private.UploadedBlob{}, fmt.Errorf("zstd:chunked sentinel present, refusing fallback to ordinary layer download: %w", err)
+				}
 				return private.UploadedBlob{}, private.NewErrFallbackToOrdinaryLayerDownload(err)
 			}
 			untrustedDiffID = "" // A schema1 image or a non-TOC layer with no ambiguity, let it through
@@ -416,6 +445,10 @@ func (s *storageImageDestination) PutBlobPartial(ctx context.Context, chunkAcces
 	defer func() {
 		var perr chunked.ErrFallbackToOrdinaryLayerDownload
 		if errors.As(retErr, &perr) {
+			if len(s.filteredLayerIndices) > 0 {
+				retErr = fmt.Errorf("zstd:chunked sentinel present, refusing fallback to ordinary layer download: %w", retErr)
+				return
+			}
 			retErr = private.NewErrFallbackToOrdinaryLayerDownload(retErr)
 		}
 	}()
@@ -425,6 +458,16 @@ func (s *storageImageDestination) PutBlobPartial(ctx context.Context, chunkAcces
 		return private.UploadedBlob{}, err
 	}
 	defer differ.Close()
+	if len(s.filteredLayerIndices) > 0 {
+		// Skipping the mitigation is safe because the sentinel layer guarantees
+		// that only TOC-aware clients will process this image. With the mitigation
+		// skipped, we also refuse any fallback to ordinary layer download (see the
+		// checks above and the deferred error handler).
+		logrus.Debugf("Sentinel detected for layer %s: skipping full-digest mitigation", srcInfo.Digest)
+		if err := chunked.SkipMitigation(differ); err != nil {
+			return private.UploadedBlob{}, err
+		}
+	}
 
 	out, err := s.imageRef.transport.store.PrepareStagedLayer(nil, differ)
 	if err != nil {
@@ -796,7 +839,7 @@ func (s *storageImageDestination) computeID(m manifest.Manifest) (string, error)
 	case *manifest.Schema1:
 		// Build a list of the diffIDs we've generated for the non-throwaway FS layers
 		for i, li := range layerInfos {
-			if li.EmptyLayer {
+			if li.EmptyLayer || slices.Contains(s.filteredLayerIndices, i) {
 				continue
 			}
 			trusted, ok := s.trustedLayerIdentityDataLocked(i, li.Digest)
@@ -845,6 +888,9 @@ func (s *storageImageDestination) computeID(m manifest.Manifest) (string, error)
 	tocIDInput.WriteByte('|') // "|" can not be present in a digest, so this is an unambiguous separator.
 	hasLayerPulledByTOC := false
 	for i, li := range layerInfos {
+		if li.EmptyLayer || slices.Contains(s.filteredLayerIndices, i) {
+			continue
+		}
 		trusted, ok := s.trustedLayerIdentityDataLocked(i, li.Digest)
 		if !ok { // We have already committed all layers if we get to this point, so the data must have been available.
 			return "", fmt.Errorf("internal inconsistency: layer (%d, %q) not found", i, li.Digest)
@@ -967,7 +1013,7 @@ func (s *storageImageDestination) commitLayer(index int, info addedLayerInfo, si
 		parentLayer = prev
 	}
 
-	if info.emptyLayer {
+	if info.emptyLayer || info.filtered {
 		s.indexToStorageID[index] = parentLayer
 		return false, nil
 	}
@@ -1461,12 +1507,16 @@ func (s *storageImageDestination) CommitWithOptions(ctx context.Context, options
 		if stopQueue, err := s.commitLayer(i, addedLayerInfo{
 			digest:     blob.Digest,
 			emptyLayer: blob.EmptyLayer,
+			filtered:   slices.Contains(s.filteredLayerIndices, i),
 		}, blob.Size); err != nil {
 			return err
 		} else if stopQueue {
 			return fmt.Errorf("Internal error: storageImageDestination.CommitWithOptions(): commitLayer() not ready to commit for layer %q", blob.Digest)
 		}
 	}
+	// Resolve lastLayer from indexToStorageID. Filtered layers (e.g., sentinel)
+	// have their indexToStorageID set to parentLayer, so the chain resolves
+	// correctly through them to the last real layer's storage ID.
 	var lastLayer string
 	if len(layerBlobs) > 0 { // Zero-layer images rarely make sense, but it is technically possible, and may happen for non-image artifacts.
 		prev, ok := s.indexToStorageID[len(layerBlobs)-1]

--- a/image/storage/storage_src.go
+++ b/image/storage/storage_src.go
@@ -122,6 +122,10 @@ func (s *storageImageSource) GetBlob(ctx context.Context, info types.BlobInfo, c
 		return io.NopCloser(bytes.NewReader(image.GzippedEmptyLayer)), int64(len(image.GzippedEmptyLayer)), nil
 	}
 
+	if digest == toc.ZstdChunkedSentinelDigest {
+		return io.NopCloser(bytes.NewReader(toc.ZstdChunkedSentinelContent)), int64(len(toc.ZstdChunkedSentinelContent)), nil
+	}
+
 	var layers []storage.Layer
 
 	// This lookup path is strictly necessary for layers identified by TOC digest
@@ -352,9 +356,25 @@ func (s *storageImageSource) LayerInfosForCopy(ctx context.Context, instanceDige
 	}
 	slices.Reverse(physicalBlobInfos)
 
-	res, err := buildLayerInfosForCopy(man.LayerInfos(), physicalBlobInfos, gzipCompressedLayerType)
+	manifestLayerInfos := man.LayerInfos()
+	// The zstd:chunked sentinel layer was never stored physically;
+	// strip it before matching against physical layers, then prepend its blob info to the result.
+	var sentinelBlobInfo *types.BlobInfo
+	if len(manifestLayerInfos) > 0 && manifestLayerInfos[0].MediaType == toc.ZstdChunkedSentinelMediaType {
+		sentinelBlobInfo = &types.BlobInfo{
+			Digest:    manifestLayerInfos[0].Digest,
+			Size:      int64(len(toc.ZstdChunkedSentinelContent)),
+			MediaType: manifestLayerInfos[0].MediaType,
+		}
+		manifestLayerInfos = manifestLayerInfos[1:]
+	}
+
+	res, err := buildLayerInfosForCopy(manifestLayerInfos, physicalBlobInfos, gzipCompressedLayerType)
 	if err != nil {
 		return nil, fmt.Errorf("creating LayerInfosForCopy of image %q: %w", s.image.ID, err)
+	}
+	if sentinelBlobInfo != nil {
+		res = append([]types.BlobInfo{*sentinelBlobInfo}, res...)
 	}
 	return res, nil
 }

--- a/image/types/types.go
+++ b/image/types/types.go
@@ -455,11 +455,21 @@ type ImageCloser interface {
 	Close() error
 }
 
+// PrependedLayerInfo describes a layer to prepend to an image during manifest update.
+// It carries both the blob metadata (for the manifest layer descriptor) and the
+// uncompressed DiffID (for the image config's RootFS).
+type PrependedLayerInfo struct {
+	BlobInfo BlobInfo
+	DiffID   digest.Digest
+}
+
 // ManifestUpdateOptions is a way to pass named optional arguments to Image.UpdatedImage
 type ManifestUpdateOptions struct {
 	LayerInfos              []BlobInfo // Complete BlobInfos (size+digest+urls+annotations) which should replace the originals, in order (the root layer first, and then successive layered layers). BlobInfos' MediaType fields are ignored.
 	EmbeddedDockerReference reference.Named
 	ManifestMIMEType        string
+	PrependLayers           []PrependedLayerInfo // Layers to prepend to the manifest and config (e.g. sentinel layers). Applied after LayerInfos updates.
+	RemoveLayerIndices      []int                // Indices of layers to remove from the manifest and config. LayerInfos, if set, must not include entries for removed layers. Applied before LayerInfos updates.
 	// The values below are NOT requests to modify the image; they provide optional context which may or may not be used.
 	InformationOnly ManifestUpdateInformation
 }

--- a/storage/pkg/chunked/storage_linux.go
+++ b/storage/pkg/chunked/storage_linux.go
@@ -73,6 +73,9 @@ type chunkedDiffer struct {
 	// is no TOC referenced by the manifest.
 	blobDigest digest.Digest
 	blobSize   int64
+	// skipMitigation is set by SkipMitigation to skip the full-digest
+	// verification without using the insecure flag.
+	skipMitigation bool
 
 	// Input format
 	// ==========
@@ -206,6 +209,22 @@ func (c *chunkedDiffer) Close() error {
 // If it returns an error that matches ErrFallbackToOrdinaryLayerDownload, the caller can
 // retry the operation with a different method.
 // The caller must call Close() on the returned Differ.
+
+// SkipMitigation configures the differ to skip the full-digest mitigation.
+// Must be called after NewDiffer and before PrepareStagedLayer.
+func SkipMitigation(d graphdriver.Differ) error {
+	cd, ok := d.(*chunkedDiffer)
+	if !ok {
+		return fmt.Errorf("SkipMitigation called with unexpected type %T", d)
+	}
+	if cd.convertToZstdChunked {
+		return fmt.Errorf("SkipMitigation called on a convert-from-raw differ for blob %s", cd.blobDigest)
+	}
+	logrus.Debugf("SkipMitigation: skipping full-digest verification for blob %s", cd.blobDigest)
+	cd.skipMitigation = true
+	return nil
+}
+
 func NewDiffer(ctx context.Context, store storage.Store, blobDigest digest.Digest, blobSize int64, annotations map[string]string, iss ImageSourceSeekable) (graphdriver.Differ, error) {
 	pullOptions := parsePullOptions(store)
 
@@ -1959,7 +1978,7 @@ func (c *chunkedDiffer) ApplyDiff(dest string, options *archive.TarOptions, diff
 	// via insecureAllowUnpredictableImageContents .
 	if output.UncompressedDigest == "" {
 		switch {
-		case c.pullOptions.insecureAllowUnpredictableImageContents:
+		case c.pullOptions.insecureAllowUnpredictableImageContents || c.skipMitigation:
 			// Oh well.  Skip the costly digest computation.
 		case output.TarSplit != nil:
 			if _, err := output.TarSplit.Seek(0, io.SeekStart); err != nil {

--- a/storage/pkg/chunked/storage_linux_test.go
+++ b/storage/pkg/chunked/storage_linux_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	graphdriver "go.podman.io/storage/drivers"
+	"go.podman.io/storage/pkg/archive"
 )
 
 // Mock for ImageSourceSeekable
@@ -210,4 +212,30 @@ func TestTypeToOsMode(t *testing.T) {
 			}
 		})
 	}
+}
+
+type fakeDiffer struct{}
+
+func (f *fakeDiffer) ApplyDiff(string, *archive.TarOptions, *graphdriver.DifferOptions) (graphdriver.DriverWithDifferOutput, error) {
+	return graphdriver.DriverWithDifferOutput{}, nil
+}
+func (f *fakeDiffer) Close() error { return nil }
+
+func TestSkipMitigationErrors(t *testing.T) {
+	// SkipMitigation on a non-chunkedDiffer type should fail.
+	err := SkipMitigation(&fakeDiffer{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected type")
+
+	// SkipMitigation on a convert-from-raw differ should fail.
+	cd := &chunkedDiffer{convertToZstdChunked: true}
+	err = SkipMitigation(cd)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "convert-from-raw")
+
+	// SkipMitigation on a normal chunkedDiffer should succeed.
+	cd = &chunkedDiffer{}
+	err = SkipMitigation(cd)
+	require.NoError(t, err)
+	assert.True(t, cd.skipMitigation)
 }

--- a/storage/pkg/chunked/storage_unsupported.go
+++ b/storage/pkg/chunked/storage_unsupported.go
@@ -5,11 +5,17 @@ package chunked
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	digest "github.com/opencontainers/go-digest"
 	storage "go.podman.io/storage"
 	graphdriver "go.podman.io/storage/drivers"
 )
+
+// SkipMitigation is not supported on non-Linux platforms.
+func SkipMitigation(d graphdriver.Differ) error {
+	return fmt.Errorf("SkipMitigation is not supported on this platform")
+}
 
 // NewDiffer returns a differ than can be used with [Store.PrepareStagedLayer].
 // The caller must call Close() on the returned Differ.

--- a/storage/pkg/chunked/toc/toc.go
+++ b/storage/pkg/chunked/toc/toc.go
@@ -27,6 +27,43 @@ var ChunkedAnnotations = map[string]struct{}{
 // Duplicate it here to avoid a dependency on the package.
 const tocJSONDigestAnnotation = "containerd.io/snapshot/stargz/toc.digest"
 
+// ZstdChunkedSentinelContent is the well-known content of the sentinel layer
+// used to signal that a manifest's zstd:chunked layers can be used without
+// the full-digest mitigation.
+//
+// It is a 512-byte block (tar header size) that is definitively not valid tar:
+//   - Byte 0 is \x00 (marks as binary/non-text)
+//   - Bytes 148-155 (checksum field) are all \xff (invalid for any tar variant)
+//   - Bytes 257-262 (magic field) are "NOTTAR" instead of "ustar\0"
+//
+// This ensures that no tar implementation can accidentally parse this as a
+// valid archive entry.
+var ZstdChunkedSentinelContent = func() []byte {
+	var block [512]byte
+	// Name field (bytes 0-99): binary zero followed by identifier
+	copy(block[1:], "ZSTD-CHUNKED-SENTINEL")
+	// Checksum field (bytes 148-155): all 0xff — invalid for v7 and ustar
+	for i := 148; i < 156; i++ {
+		block[i] = 0xff
+	}
+	// Magic field (bytes 257-262): "NOTTAR" — not "ustar\0"
+	copy(block[257:], "NOTTAR")
+	// Version + message area (bytes 263-511):
+	msg := "This image must be consumed using the TOC digests " +
+		"and NEVER as a tar archive.\n" +
+		"See: https://github.com/containers/image"
+	copy(block[263:], msg)
+	return block[:]
+}()
+
+// ZstdChunkedSentinelDigest is the digest of ZstdChunkedSentinelContent.
+var ZstdChunkedSentinelDigest = digest.FromBytes(ZstdChunkedSentinelContent)
+
+// ZstdChunkedSentinelMediaType is the MIME type used for the sentinel layer descriptor.
+// This allows detection without committing to a specific digest, so the sentinel
+// content (e.g., embedded URL) can change over time.
+const ZstdChunkedSentinelMediaType = "application/vnd.containers.zstd-chunked-sentinel"
+
 // GetTOCDigest returns the digest of the TOC as recorded in the annotations.
 // This function retrieves a digest that represents the content of a
 // table of contents (TOC) from the image's annotations.


### PR DESCRIPTION
Introduce a sentinel layer variant to safely skip the full-digest mitigation for zstd:chunked pulls.

This PR eliminates the duality by creating a separate manifest variant with a non-tar sentinel layer prepended.  Unaware clients and scanners cannot process the sentinel variant so the image no longer has two possible interpretations.

Aware clients recognize the sentinel, skip it, and pull without the expensive full-digest recomputation safely because no unaware tool can be tricked into validating the wrong content.  Data layers are reused by digest so there is no duplication.

I've pushed an image with the new format here:  quay.io/giuseppe/zstd-chunked:sentinel

@mtrmac @actionmancan this is a PoC for the idea we have discussed on how to relax the mitigation