### PR TITLE
Actually include the config digest in the TOC computation

### DIFF
--- a/image/storage/storage_dest.go
+++ b/image/storage/storage_dest.go
@@ -841,6 +841,8 @@ func (s *storageImageDestination) computeID(m manifest.Manifest) (string, error)
 	// ordinaryImageID is a digest of a config, which is a JSON value.
 	// To avoid the risk of collisions, start the input with @ so that the input is not a valid JSON.
 	tocIDInput.WriteString("@With TOC:")
+	tocIDInput.WriteString(ordinaryImageID)
+	tocIDInput.WriteByte('|') // "|" can not be present in a digest, so this is an unambiguous separator.
 	hasLayerPulledByTOC := false
 	for i, li := range layerInfos {
 		trusted, ok := s.trustedLayerIdentityDataLocked(i, li.Digest)


### PR DESCRIPTION
... as, previously, the commit meessage claimed we do.

Otherwise we could easily deduplicate images with different configs or even different (non-chunked-pulled) layers.

(Full disclosure: I did not actually test this.)