### PR TITLE
RFC: overlay dirmeta_delegate design

### DIFF
--- a/storage/drivers/overlay/overlay.go
+++ b/storage/drivers/overlay/overlay.go
@@ -112,6 +112,7 @@ type overlayOptions struct {
 	mountOptions      string
 	ignoreChownErrors bool
 	forceMask         *os.FileMode
+	dirmetaDelegate   bool
 	useComposefs      bool
 }
 
@@ -465,7 +466,9 @@ func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) 
 }
 
 func parseOptions(options []string) (*overlayOptions, error) {
-	o := &overlayOptions{}
+	o := &overlayOptions{
+		dirmetaDelegate: true, // default on
+	}
 	for _, option := range options {
 		key, val, err := parsers.ParseKeyValueOpt(option)
 		if err != nil {
@@ -574,6 +577,12 @@ func parseOptions(options []string) (*overlayOptions, error) {
 		case "ignore_chown_errors":
 			logrus.Debugf("overlay: ignore_chown_errors=%s", val)
 			o.ignoreChownErrors, err = strconv.ParseBool(val)
+			if err != nil {
+				return nil, err
+			}
+		case "dirmeta_delegate":
+			logrus.Debugf("overlay: dirmeta_delegate=%s", val)
+			o.dirmetaDelegate, err = strconv.ParseBool(val)
 			if err != nil {
 				return nil, err
 			}
@@ -2485,6 +2494,7 @@ func (d *Driver) applyDiff(target string, options graphdriver.ApplyDiffOpts) (si
 		ForceMask:         d.options.forceMask,
 		WhiteoutFormat:    d.getWhiteoutFormat(),
 		InUserNS:          unshare.IsRootless(),
+		DirmetaDelegate:   d.options.dirmetaDelegate,
 	}); err != nil {
 		return 0, err
 	}

--- a/storage/pkg/archive/archive.go
+++ b/storage/pkg/archive/archive.go
@@ -70,6 +70,12 @@ type (
 		ForceMask *os.FileMode
 		// Timestamp, if set, will be set in each header as create/mod/access time
 		Timestamp *time.Time
+		// DirmetaDelegate, if set, causes implicitly-created parent directories
+		// (structural directories not present as entries in the tar stream) to be
+		// marked with the overlay dirmeta_delegate xattr.  This tells overlayfs to
+		// delegate metadata (timestamps, ownership, mode) for these directories to
+		// a lower layer, preserving the meaningful metadata from base image layers.
+		DirmetaDelegate bool
 	}
 )
 
@@ -1135,7 +1141,11 @@ loop:
 			parent := filepath.Dir(hdr.Name)
 			parentPath := filepath.Join(dest, parent)
 			if err := fileutils.Lexists(parentPath); err != nil && os.IsNotExist(err) {
-				err = idtools.MkdirAllAndChownNew(parentPath, 0o777, rootIDs)
+				if options.DirmetaDelegate {
+					err = mkdirAllAndChownWithDirmetaDelegate(parentPath, 0o777, rootIDs)
+				} else {
+					err = idtools.MkdirAllAndChownNew(parentPath, 0o777, rootIDs)
+				}
 				if err != nil {
 					return err
 				}

--- a/storage/pkg/archive/archive_linux.go
+++ b/storage/pkg/archive/archive_linux.go
@@ -176,6 +176,83 @@ func isWhiteOut(stat os.FileInfo) bool {
 	return major(uint64(s.Rdev)) == 0 && minor(uint64(s.Rdev)) == 0 //nolint:unconvert
 }
 
+// setDirmetaDelegateXattr sets the overlay dirmeta_delegate xattr on a directory,
+// telling overlayfs to delegate metadata lookups to a lower layer.
+func setDirmetaDelegateXattr(path string) error {
+	xattrName := GetOverlayXattrName("dirmeta_delegate")
+	return system.Lsetxattr(path, xattrName, []byte("y"), 0)
+}
+
+// mkdirAllWithDirmetaDelegate creates all directories in path that don't exist,
+// and sets the overlay dirmeta_delegate xattr on each newly-created directory.
+// This marks them as structural directories whose metadata should be delegated
+// to a lower overlayfs layer.
+func mkdirAllWithDirmetaDelegate(path string, mode os.FileMode) error {
+	// Find the deepest existing ancestor so we know which dirs are new
+	existing := path
+	var toCreate []string
+	for {
+		if fi, err := os.Lstat(existing); err == nil && fi.IsDir() {
+			break
+		}
+		toCreate = append(toCreate, filepath.Base(existing))
+		parent := filepath.Dir(existing)
+		if parent == existing {
+			break
+		}
+		existing = parent
+	}
+
+	// Create each missing component and set the xattr
+	current := existing
+	for i := len(toCreate) - 1; i >= 0; i-- {
+		current = filepath.Join(current, toCreate[i])
+		if err := os.Mkdir(current, mode); err != nil && !os.IsExist(err) {
+			return err
+		}
+		if err := setDirmetaDelegateXattr(current); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// mkdirAllAndChownWithDirmetaDelegate creates all directories in path that don't
+// exist, chowns newly-created directories, and sets the overlay dirmeta_delegate
+// xattr on each newly-created directory.
+func mkdirAllAndChownWithDirmetaDelegate(path string, mode os.FileMode, ids idtools.IDPair) error {
+	// Find the deepest existing ancestor
+	existing := path
+	var toCreate []string
+	for {
+		if fi, err := os.Lstat(existing); err == nil && fi.IsDir() {
+			break
+		}
+		toCreate = append(toCreate, filepath.Base(existing))
+		parent := filepath.Dir(existing)
+		if parent == existing {
+			break
+		}
+		existing = parent
+	}
+
+	// Create each missing component, chown it, and set the xattr
+	current := existing
+	for i := len(toCreate) - 1; i >= 0; i-- {
+		current = filepath.Join(current, toCreate[i])
+		if err := os.Mkdir(current, mode); err != nil && !os.IsExist(err) {
+			return err
+		}
+		if err := idtools.SafeChown(current, ids.UID, ids.GID); err != nil {
+			return err
+		}
+		if err := setDirmetaDelegateXattr(current); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func GetFileOwner(path string) (uint32, uint32, uint32, error) {
 	f, err := os.Stat(path)
 	if err != nil {

--- a/storage/pkg/archive/archive_linux_test.go
+++ b/storage/pkg/archive/archive_linux_test.go
@@ -2,12 +2,15 @@ package archive
 
 import (
 	"archive/tar"
+	"bytes"
 	"io"
 	"os"
 	"path/filepath"
 	"syscall"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.podman.io/storage/pkg/system"
 	"golang.org/x/sys/unix"
@@ -200,4 +203,128 @@ func TestNestedOverlayWhiteouts(t *testing.T) {
 	})
 	require.NoError(t, err)
 	checkFileMode(t, filepath.Join(dst, "foo"), os.ModeDevice|os.ModeCharDevice)
+}
+
+func checkDirmetaDelegate(t *testing.T, path string, expected string) {
+	t.Helper()
+	xattrName := GetOverlayXattrName("dirmeta_delegate")
+	val, err := system.Lgetxattr(path, xattrName)
+	require.NoError(t, err)
+	assert.Equal(t, expected, string(val), "unexpected dirmeta_delegate xattr value for %s", path)
+}
+
+// makeTarBuf creates a tar archive in memory from a list of headers and
+// optional content.  For TypeReg entries, content is the file data; for
+// other types content is ignored.
+func makeTarBuf(t *testing.T, entries []tar.Header, contents map[string][]byte) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	for _, hdr := range entries {
+		hdr := hdr
+		if hdr.Typeflag == tar.TypeReg {
+			data := contents[hdr.Name]
+			hdr.Size = int64(len(data))
+			require.NoError(t, tw.WriteHeader(&hdr))
+			if len(data) > 0 {
+				_, err := tw.Write(data)
+				require.NoError(t, err)
+			}
+		} else {
+			require.NoError(t, tw.WriteHeader(&hdr))
+		}
+	}
+	require.NoError(t, tw.Close())
+	return &buf
+}
+
+func TestDirmetaDelegate(t *testing.T) {
+	epoch := time.Unix(0, 0)
+
+	t.Run("implicit dirs get xattr", func(t *testing.T) {
+		// Tar contains only a file at foo/bar/file with no directory
+		// entries.  UnpackLayer must create foo/ and foo/bar/ implicitly.
+		buf := makeTarBuf(t, []tar.Header{
+			{Typeflag: tar.TypeReg, Name: "foo/bar/file", Mode: 0o644},
+		}, map[string][]byte{
+			"foo/bar/file": []byte("hello"),
+		})
+
+		dst := t.TempDir()
+		_, err := UnpackLayer(dst, buf, &TarOptions{DirmetaDelegate: true, IgnoreChownErrors: true})
+		require.NoError(t, err)
+
+		// The file should exist.
+		_, err = os.Lstat(filepath.Join(dst, "foo/bar/file"))
+		require.NoError(t, err)
+
+		// Both implicit parent dirs should have the xattr.
+		checkDirmetaDelegate(t, filepath.Join(dst, "foo"), "y")
+		checkDirmetaDelegate(t, filepath.Join(dst, "foo/bar"), "y")
+	})
+
+	t.Run("explicit dirs do not get xattr", func(t *testing.T) {
+		// Tar contains an explicit directory entry for foo/ with a
+		// specific mtime, followed by a file foo/file.
+		buf := makeTarBuf(t, []tar.Header{
+			{Typeflag: tar.TypeDir, Name: "foo/", Mode: 0o755, ModTime: epoch},
+			{Typeflag: tar.TypeReg, Name: "foo/file", Mode: 0o644},
+		}, map[string][]byte{
+			"foo/file": []byte("world"),
+		})
+
+		dst := t.TempDir()
+		_, err := UnpackLayer(dst, buf, &TarOptions{DirmetaDelegate: true, IgnoreChownErrors: true})
+		require.NoError(t, err)
+
+		// The file should exist.
+		_, err = os.Lstat(filepath.Join(dst, "foo/file"))
+		require.NoError(t, err)
+
+		// The explicit directory should NOT have the xattr.
+		checkDirmetaDelegate(t, filepath.Join(dst, "foo"), "")
+	})
+
+	t.Run("mixed explicit and implicit", func(t *testing.T) {
+		// Tar contains an explicit dir explicit/, but the file beneath
+		// it is at explicit/implicit-child/file — so implicit-child/
+		// must be created implicitly.
+		buf := makeTarBuf(t, []tar.Header{
+			{Typeflag: tar.TypeDir, Name: "explicit/", Mode: 0o755, ModTime: epoch},
+			{Typeflag: tar.TypeReg, Name: "explicit/implicit-child/file", Mode: 0o644},
+		}, map[string][]byte{
+			"explicit/implicit-child/file": []byte("data"),
+		})
+
+		dst := t.TempDir()
+		_, err := UnpackLayer(dst, buf, &TarOptions{DirmetaDelegate: true, IgnoreChownErrors: true})
+		require.NoError(t, err)
+
+		// explicit/ was in the tar stream — no xattr.
+		checkDirmetaDelegate(t, filepath.Join(dst, "explicit"), "")
+
+		// implicit-child/ was NOT in the tar stream — should have xattr.
+		checkDirmetaDelegate(t, filepath.Join(dst, "explicit/implicit-child"), "y")
+	})
+
+	t.Run("disabled does not set xattr", func(t *testing.T) {
+		// Same tar as "implicit dirs get xattr" but with DirmetaDelegate
+		// disabled.
+		buf := makeTarBuf(t, []tar.Header{
+			{Typeflag: tar.TypeReg, Name: "foo/file", Mode: 0o644},
+		}, map[string][]byte{
+			"foo/file": []byte("hello"),
+		})
+
+		dst := t.TempDir()
+		_, err := UnpackLayer(dst, buf, &TarOptions{DirmetaDelegate: false, IgnoreChownErrors: true})
+		require.NoError(t, err)
+
+		// The file should exist.
+		_, err = os.Lstat(filepath.Join(dst, "foo/file"))
+		require.NoError(t, err)
+
+		// No xattr should be set when the feature is off.
+		checkDirmetaDelegate(t, filepath.Join(dst, "foo"), "")
+	})
 }

--- a/storage/pkg/archive/archive_other.go
+++ b/storage/pkg/archive/archive_other.go
@@ -2,10 +2,24 @@
 
 package archive
 
+import (
+	"os"
+
+	"go.podman.io/storage/pkg/idtools"
+)
+
 func GetWhiteoutConverter(_ WhiteoutFormat, _ any) TarWhiteoutConverter {
 	return nil
 }
 
 func GetFileOwner(path string) (uint32, uint32, uint32, error) {
 	return 0, 0, 0, nil
+}
+
+func mkdirAllWithDirmetaDelegate(path string, mode os.FileMode) error {
+	return os.MkdirAll(path, mode)
+}
+
+func mkdirAllAndChownWithDirmetaDelegate(path string, mode os.FileMode, ids idtools.IDPair) error {
+	return idtools.MkdirAllAndChownNew(path, mode, ids)
 }

--- a/storage/pkg/archive/diff.go
+++ b/storage/pkg/archive/diff.go
@@ -83,7 +83,11 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 			parentPath := filepath.Join(dest, parent)
 
 			if err := fileutils.Lexists(parentPath); err != nil && os.IsNotExist(err) {
-				err = os.MkdirAll(parentPath, 0o755)
+				if options.DirmetaDelegate {
+					err = mkdirAllWithDirmetaDelegate(parentPath, 0o755)
+				} else {
+					err = os.MkdirAll(parentPath, 0o755)
+				}
 				if err != nil {
 					return 0, err
 				}


### PR DESCRIPTION
I'm looking for some early feedback on this.  Don't worry too much about all of the details, this is just AI-guided PoC level for now to show integration with potential kernel bits.   For example, this very intentionally ignores the zstd:chunked path but that will need considered in a final version.

Mostly I want to make sure this is a reasonable approach before I start trying to clean up things and push on the kernel side.  I want to avoid investing a nontrivial amount of time fixing the kernel only to find this isn't going to fly over here.  If everything pans out I'll tackle a more stringent final change here.

For some background around this, I've written about it on the [bootc blog](https://bootc-dev.github.io/blog/2025-dec-15-blog-containers-pitfalls-of-incomplete-tar-archives/).  It's a bit long, so the tl;dr is that the handling of implied directories in tar streams is not great and causes us quite a bit of pain in bootc.  I won't reiterate here but the blog also touches on other places in the community where this struggle comes up, it is not exclusive to bootc.

Here's the basic demonstration of the problem:

```
[root@rawhide ~]# podman system reset -f
[root@rawhide ~]# /usr/bin/podman run --quiet --rm quay.io/fedora/fedora-bootc ls -l /usr
total 8
drwxr-xr-x. 1 root root   36 Mar 17 14:21 bin
drwxr-xr-x. 1 root root    0 Jan  1  1970 games
drwxr-xr-x. 1 root root   16 Mar 17 14:21 i686-w64-mingw32
drwxr-xr-x. 1 root root   20 Mar 17 14:21 include
drwxr-xr-x. 1 root root  152 Mar 17 14:21 lib
drwxr-xr-x. 1 root root 1716 Mar 17 14:21 lib64
drwxr-xr-x. 1 root root   82 Mar 17 14:21 libexec
drwxr-xr-x. 1 root root   82 Jan  1  1970 local
lrwxrwxrwx. 2 root root    3 Jan  1  1970 sbin -> bin
drwxr-xr-x. 1 root root   78 Mar 17 14:21 share
drwxr-xr-x. 1 root root   24 Jan  1  1970 src
lrwxrwxrwx. 2 root root   10 Jan  1  1970 tmp -> ../var/tmp
drwxr-xr-x. 1 root root   16 Mar 17 14:21 x86_64-w64-mingw32
```

bootc (via ostree in this case) goes out of its way to set the mtime to 0 everywhere.  During rechunking the layers get shuffled around a bit, but the gist is that for the above, `/usr/bin` (as an example) ends up getting defined in the base layer with the correct mtime of 0.  Later layers end up including specific binaries under `/usr/bin` but none of them explicitly re-define `/usr/bin` itself.  We end up with implicit directories created via those layers that "shadow" the intended base layer metadata.  Meanwhile for things like `/usr/local` no later layers add files to that tree, so the metadata is correct since there's nothing to shadow it.

I've drafted up what I'm calling [dirmeta_delegate](https://gist.github.com/jeckersb/9abe6d08f84be987de62fb4b701c9934) for overlayfs, which is what this patch is utilizing to correct this problem.  By setting an xattr, one can instruct overlayfs to delegate directory metadata to a lower layer.  We use this to label the implied directories during unpacking. 

With a patched kernel and a podman built using a patched containers/storage:

```
[root@rawhide ~]# grep DELEGATE /boot/config-7.0.0-0.rc3.28.fc45.x86_64
CONFIG_OVERLAY_FS_DIRMETA_DELEGATE=y
[root@rawhide ~]# podman system reset -f
[root@rawhide ~]# /root/bin/podman run --quiet --rm quay.io/fedora/fedora-bootc ls -l /usr
total 8
drwxr-xr-x. 1 root root   36 Jan  1  1970 bin
drwxr-xr-x. 1 root root    0 Jan  1  1970 games
drwxr-xr-x. 1 root root   16 Jan  1  1970 i686-w64-mingw32
drwxr-xr-x. 1 root root   20 Jan  1  1970 include
drwxr-xr-x. 1 root root  152 Jan  1  1970 lib
drwxr-xr-x. 1 root root 1716 Jan  1  1970 lib64
drwxr-xr-x. 1 root root   82 Jan  1  1970 libexec
drwxr-xr-x. 1 root root   82 Jan  1  1970 local
lrwxrwxrwx. 2 root root    3 Jan  1  1970 sbin -> bin
drwxr-xr-x. 1 root root   78 Jan  1  1970 share
drwxr-xr-x. 1 root root   24 Jan  1  1970 src
lrwxrwxrwx. 2 root root   10 Jan  1  1970 tmp -> ../var/tmp
drwxr-xr-x. 1 root root   16 Jan  1  1970 x86_64-w64-mingw32
```