### PR TITLE
Use unified configfile parser for policy.json

### DIFF
--- a/common/pkg/config/config.go
+++ b/common/pkg/config/config.go
@@ -488,11 +488,6 @@ type EngineConfig struct {
 	// backwards compat with older version of libpod and Podman.
 	SetOptions
 
-	// SignaturePolicyPath is the path to a signature policy to use for
-	// validating images. If left empty, the containers/image default signature
-	// policy will be used.
-	SignaturePolicyPath string `toml:"-"`
-
 	// SDNotify tells container engine to allow containers to notify the host systemd of
 	// readiness using the SD_NOTIFY mechanism.
 	SDNotify bool `toml:"-"`

--- a/common/pkg/config/config_bsd.go
+++ b/common/pkg/config/config_bsd.go
@@ -2,12 +2,6 @@
 
 package config
 
-const (
-	// DefaultSignaturePolicyPath is the default value for the
-	// policy.json file.
-	DefaultSignaturePolicyPath = "/usr/local/etc/containers/policy.json"
-)
-
 var defaultHelperBinariesDir = []string{
 	"/usr/local/bin",
 	"/usr/local/libexec/podman",

--- a/common/pkg/config/config_darwin.go
+++ b/common/pkg/config/config_darwin.go
@@ -1,11 +1,5 @@
 package config
 
-const (
-	// DefaultSignaturePolicyPath is the default value for the
-	// policy.json file.
-	DefaultSignaturePolicyPath = "/etc/containers/policy.json"
-)
-
 var defaultHelperBinariesDir = []string{
 	// Relative to the binary directory
 	"$BINDIR/../libexec/podman",

--- a/common/pkg/config/config_linux.go
+++ b/common/pkg/config/config_linux.go
@@ -5,12 +5,6 @@ import (
 	"go.podman.io/common/pkg/capabilities"
 )
 
-const (
-	// DefaultSignaturePolicyPath is the default value for the
-	// policy.json file.
-	DefaultSignaturePolicyPath = "/etc/containers/policy.json"
-)
-
 func selinuxEnabled() bool {
 	return selinux.GetEnabled()
 }

--- a/common/pkg/config/config_windows.go
+++ b/common/pkg/config/config_windows.go
@@ -7,10 +7,6 @@ import (
 )
 
 const (
-	// DefaultSignaturePolicyPath is the default value for the
-	// policy.json file.
-	DefaultSignaturePolicyPath = "/etc/containers/policy.json"
-
 	// Mount type for mounting host dir
 	_typeBind = "bind"
 )

--- a/common/pkg/config/default.go
+++ b/common/pkg/config/default.go
@@ -15,7 +15,6 @@ import (
 	nettypes "go.podman.io/common/libnetwork/types"
 	"go.podman.io/common/pkg/apparmor"
 	"go.podman.io/storage/pkg/configfile"
-	"go.podman.io/storage/pkg/fileutils"
 	"go.podman.io/storage/pkg/homedir"
 	"go.podman.io/storage/pkg/unshare"
 	"go.podman.io/storage/types"
@@ -177,9 +176,6 @@ const (
 	// DefaultSubnet is the subnet that will be used for the default
 	// network.
 	DefaultSubnet = "10.88.0.0/16"
-	// DefaultRootlessSignaturePolicyPath is the location within
-	// XDG_CONFIG_HOME of the rootless policy.json file.
-	DefaultRootlessSignaturePolicyPath = "containers/policy.json"
 	// DefaultShmSize is the default upper limit on the size of tmpfs mounts.
 	DefaultShmSize = "65536k"
 	// DefaultUserNSSize indicates the default number of UIDs allocated for user namespace within a container.
@@ -203,23 +199,6 @@ func defaultConfig() (*Config, error) {
 	defaultEngineConfig, err := defaultEngineConfig()
 	if err != nil {
 		return nil, err
-	}
-
-	defaultEngineConfig.SignaturePolicyPath = DefaultSignaturePolicyPath
-	// NOTE: For now we want Windows to use system locations.
-	// GetRootlessUID == -1 on Windows, so exclude negative range
-	if unshare.GetRootlessUID() > 0 {
-		configHome, err := homedir.GetConfigHome()
-		if err != nil {
-			return nil, err
-		}
-		sigPath := filepath.Join(configHome, DefaultRootlessSignaturePolicyPath)
-		defaultEngineConfig.SignaturePolicyPath = sigPath
-		if err := fileutils.Exists(sigPath); err != nil {
-			if err := fileutils.Exists(DefaultSignaturePolicyPath); err == nil {
-				defaultEngineConfig.SignaturePolicyPath = DefaultSignaturePolicyPath
-			}
-		}
 	}
 
 	return &Config{

--- a/image/docs/containers-policy.json.5.md
+++ b/image/docs/containers-policy.json.5.md
@@ -10,7 +10,9 @@ containers-policy.json - syntax for the signature verification policy file
 Signature verification policy files are used to specify policy, e.g. trusted keys,
 applicable when deciding whether to accept an image, or individual signatures of that image, as valid.
 
-By default, the policy is read from `$HOME/.config/containers/policy.json`, if it exists, otherwise from `/etc/containers/policy.json`;  applications performing verification may allow using a different policy instead.
+By default, the policy is read from `$XDG_CONFIG_HOME/containers/policy.json` (or from `$HOME/.config/containers/policy.json` if `$XDG_CONFIG_HOME` is unset), if it exists; otherwise from `/etc/containers/policy.json`;  otherwise from `/usr/share/containers/policy.json`. Applications performing verification may allow using a different policy instead.
+
+If `CONTAINERS_POLICY_JSON` is set, it specifies the only policy file to use.
 
 ## FORMAT
 

--- a/image/docs/containers-policy.json.5.md
+++ b/image/docs/containers-policy.json.5.md
@@ -12,7 +12,8 @@ applicable when deciding whether to accept an image, or individual signatures of
 
 By default, the policy is read from `$XDG_CONFIG_HOME/containers/policy.json` (or from `$HOME/.config/containers/policy.json` if `$XDG_CONFIG_HOME` is unset), if it exists; otherwise from `/etc/containers/policy.json`;  otherwise from `/usr/share/containers/policy.json`. Applications performing verification may allow using a different policy instead.
 
-If `CONTAINERS_POLICY_JSON` is set, it specifies the only policy file to use.
+If `CONTAINERS_POLICY_JSON` is set, it specifies the policy file to use,
+unless overridden by application-specific configuration.
 
 ## FORMAT
 

--- a/image/signature/policy_config.go
+++ b/image/signature/policy_config.go
@@ -57,6 +57,7 @@ func DefaultPolicy(sys *types.SystemContext) (*Policy, error) {
 		DoNotLoadDropInFiles:         true,
 		EnvironmentName:              "CONTAINERS_POLICY_JSON",
 		RootForImplicitAbsolutePaths: rootForImplicitAbsPaths,
+		ErrorIfNotFound:              true,
 	}
 
 	var policy *Policy
@@ -73,10 +74,6 @@ func DefaultPolicy(sys *types.SystemContext) (*Policy, error) {
 		if err != nil {
 			return nil, fmt.Errorf("invalid policy in %q: %w", item.Name, err)
 		}
-	}
-
-	if policy == nil {
-		return nil, fmt.Errorf("no policy.json file found")
 	}
 
 	return policy, nil

--- a/image/signature/policy_config.go
+++ b/image/signature/policy_config.go
@@ -65,6 +65,10 @@ func DefaultPolicy(sys *types.SystemContext) (*Policy, error) {
 		if err != nil {
 			return nil, err
 		}
+		if policy != nil {
+			// Coverage: This should never happen, configfile.Read ensures at most one policy file.
+			return nil, fmt.Errorf("internal error: expected at most one policy file, got another item %q", item.Name) //nolint:revive
+		}
 
 		contents, err := io.ReadAll(item.Reader)
 		if err != nil {

--- a/image/signature/policy_config.go
+++ b/image/signature/policy_config.go
@@ -17,25 +17,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
-	"path/filepath"
 
 	"go.podman.io/image/v5/docker/reference"
 	"go.podman.io/image/v5/signature/internal"
 	"go.podman.io/image/v5/transports"
 	"go.podman.io/image/v5/types"
-	"go.podman.io/storage/pkg/fileutils"
-	"go.podman.io/storage/pkg/homedir"
+	"go.podman.io/storage/pkg/configfile"
 	"go.podman.io/storage/pkg/regexp"
 )
-
-// systemDefaultPolicyPath is the policy path used for DefaultPolicy().
-// You can override this at build time with
-// -ldflags '-X go.podman.io/image/v5/signature.systemDefaultPolicyPath=$your_path'
-var systemDefaultPolicyPath = builtinDefaultPolicyPath
-
-// userPolicyFile is the path to the per user policy path.
-var userPolicyFile = filepath.FromSlash(".config/containers/policy.json")
 
 // InvalidPolicyFormatError is returned when parsing an invalid policy configuration.
 type InvalidPolicyFormatError string
@@ -51,39 +42,44 @@ func (err InvalidPolicyFormatError) Error() string {
 // NOTE: When this function returns an error, report it to the user and abort.
 // DO NOT hard-code fallback policies in your application.
 func DefaultPolicy(sys *types.SystemContext) (*Policy, error) {
-	policyPath, err := defaultPolicyPath(sys)
-	if err != nil {
-		return nil, err
-	}
-	return NewPolicyFromFile(policyPath)
-}
-
-// defaultPolicyPath returns a path to the relevant policy of the system, or an error if the policy is missing.
-func defaultPolicyPath(sys *types.SystemContext) (string, error) {
-	policyFilePath, err := defaultPolicyPathWithHomeDir(sys, homedir.Get(), systemDefaultPolicyPath)
-	if err != nil {
-		return "", err
-	}
-	return policyFilePath, nil
-}
-
-// defaultPolicyPathWithHomeDir is an internal implementation detail of defaultPolicyPath,
-// it exists only to allow testing it with artificial paths.
-func defaultPolicyPathWithHomeDir(sys *types.SystemContext, homeDir string, systemPolicyPath string) (string, error) {
 	if sys != nil && sys.SignaturePolicyPath != "" {
-		return sys.SignaturePolicyPath, nil
+		return NewPolicyFromFile(sys.SignaturePolicyPath)
 	}
-	userPolicyFilePath := filepath.Join(homeDir, userPolicyFile)
-	if err := fileutils.Exists(userPolicyFilePath); err == nil {
-		return userPolicyFilePath, nil
+
+	var rootForImplicitAbsPaths string
+	if sys != nil {
+		rootForImplicitAbsPaths = sys.RootForImplicitAbsolutePaths
 	}
-	if sys != nil && sys.RootForImplicitAbsolutePaths != "" {
-		return filepath.Join(sys.RootForImplicitAbsolutePaths, systemPolicyPath), nil
+
+	policyFiles := configfile.File{
+		Name:                         "policy",
+		Extension:                    "json",
+		DoNotLoadDropInFiles:         true,
+		EnvironmentName:              "CONTAINERS_POLICY_JSON",
+		RootForImplicitAbsolutePaths: rootForImplicitAbsPaths,
 	}
-	if err := fileutils.Exists(systemPolicyPath); err == nil {
-		return systemPolicyPath, nil
+
+	var policy *Policy
+	for item, err := range configfile.Read(&policyFiles) {
+		if err != nil {
+			return nil, err
+		}
+
+		contents, err := io.ReadAll(item.Reader)
+		if err != nil {
+			return nil, err
+		}
+		policy, err = NewPolicyFromBytes(contents)
+		if err != nil {
+			return nil, fmt.Errorf("invalid policy in %q: %w", item.Name, err)
+		}
 	}
-	return "", fmt.Errorf("no policy.json file found at any of the following: %q, %q", userPolicyFilePath, systemPolicyPath)
+
+	if policy == nil {
+		return nil, fmt.Errorf("no policy.json file found")
+	}
+
+	return policy, nil
 }
 
 // NewPolicyFromFile returns a policy configured in the specified file.

--- a/image/signature/policy_config.go
+++ b/image/signature/policy_config.go
@@ -67,7 +67,7 @@ func DefaultPolicy(sys *types.SystemContext) (*Policy, error) {
 		}
 		if policy != nil {
 			// Coverage: This should never happen, configfile.Read ensures at most one policy file.
-			return nil, fmt.Errorf("internal error: expected at most one policy file, got another item %q", item.Name) //nolint:revive
+			return nil, fmt.Errorf("internal error: expected at most one policy file, got another item %q", item.Name)
 		}
 
 		contents, err := io.ReadAll(item.Reader)

--- a/image/signature/policy_config_test.go
+++ b/image/signature/policy_config_test.go
@@ -127,15 +127,21 @@ func TestInvalidPolicyFormatError(t *testing.T) {
 }
 
 func TestDefaultPolicy(t *testing.T) {
-	// prReject
 	const rejectJSON = `{"default":[{"type":"reject"}]}`
-	// prInsecureAcceptAnything
 	const insecureJSON = `{"default":[{"type":"insecureAcceptAnything"}]}`
+	rejectPolicy := &Policy{
+		Default:    PolicyRequirements{NewPRReject()},
+		Transports: map[string]PolicyTransportScopes{},
+	}
+	insecurePolicy := &Policy{
+		Default:    PolicyRequirements{NewPRInsecureAcceptAnything()},
+		Transports: map[string]PolicyTransportScopes{},
+	}
 
 	type tc struct {
 		name           string
 		setup          func(t *testing.T, rootPrefix string) *types.SystemContext
-		expectPolicy   any // *Policy, *prReject, *prInsecureAcceptAnything
+		expectPolicy   *Policy
 		expectErr      bool
 		expectErrMatch string
 	}
@@ -179,7 +185,7 @@ func TestDefaultPolicy(t *testing.T) {
 					RootForImplicitAbsolutePaths: rootPrefix,
 				}
 			},
-			expectPolicy: &prInsecureAcceptAnything{},
+			expectPolicy: insecurePolicy,
 		},
 		{
 			name: "etc fallback when user missing",
@@ -192,7 +198,7 @@ func TestDefaultPolicy(t *testing.T) {
 					RootForImplicitAbsolutePaths: rootPrefix,
 				}
 			},
-			expectPolicy: &prReject{},
+			expectPolicy: rejectPolicy,
 		},
 		{
 			name: "usr fallback when only usr present",
@@ -204,7 +210,7 @@ func TestDefaultPolicy(t *testing.T) {
 					RootForImplicitAbsolutePaths: rootPrefix,
 				}
 			},
-			expectPolicy: &prInsecureAcceptAnything{},
+			expectPolicy: insecurePolicy,
 		},
 		{
 			name: "no policy file found",
@@ -230,7 +236,7 @@ func TestDefaultPolicy(t *testing.T) {
 					RootForImplicitAbsolutePaths: rootPrefix,
 				}
 			},
-			expectPolicy: &prInsecureAcceptAnything{},
+			expectPolicy: insecurePolicy,
 		},
 		{
 			name: "containers policy conf read error",
@@ -290,7 +296,23 @@ func TestDefaultPolicy(t *testing.T) {
 					RootForImplicitAbsolutePaths: rootPrefix,
 				}
 			},
-			expectPolicy: &prReject{},
+			expectPolicy: rejectPolicy,
+		},
+		{
+			name: "nil SystemContext",
+			setup: func(t *testing.T, _ string) *types.SystemContext {
+				t.Setenv("CONTAINERS_POLICY_JSON", "./fixtures/policy.json")
+				return nil
+			},
+			expectPolicy: policyFixtureContents,
+		},
+		{
+			name: "empty SystemContext",
+			setup: func(t *testing.T, _ string) *types.SystemContext {
+				t.Setenv("CONTAINERS_POLICY_JSON", "./fixtures/policy.json")
+				return &types.SystemContext{}
+			},
+			expectPolicy: policyFixtureContents,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -311,19 +333,7 @@ func TestDefaultPolicy(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-
-			switch expected := test.expectPolicy.(type) {
-			case *Policy:
-				assert.Equal(t, expected, policy)
-			case *prInsecureAcceptAnything:
-				_, ok := policy.Default[0].(*prInsecureAcceptAnything)
-				assert.True(t, ok, "expected insecureAcceptAnything policy requirement")
-			case *prReject:
-				_, ok := policy.Default[0].(*prReject)
-				assert.True(t, ok, "expected reject policy requirement")
-			default:
-				t.Fatalf("unexpected expectedPolicy type %T", test.expectPolicy)
-			}
+			assert.Equal(t, test.expectPolicy, policy)
 		})
 	}
 }

--- a/image/signature/policy_config_test.go
+++ b/image/signature/policy_config_test.go
@@ -134,9 +134,7 @@ func TestDefaultPolicy(t *testing.T) {
 
 	type tc struct {
 		name           string
-		setup          func(t *testing.T, rootPrefix string)
-		sys            *types.SystemContext
-		useRootPrefix  bool
+		setup          func(t *testing.T, rootPrefix string) *types.SystemContext
 		expectPolicy   any // *Policy, *prReject, *prInsecureAcceptAnything
 		expectErr      bool
 		expectErrMatch string
@@ -150,128 +148,156 @@ func TestDefaultPolicy(t *testing.T) {
 	for _, test := range []tc{
 		{
 			name: "signature policy path override success",
-			setup: func(t *testing.T, _ string) {
-				// no-op
+			setup: func(t *testing.T, _ string) *types.SystemContext {
+				return &types.SystemContext{SignaturePolicyPath: "./fixtures/policy.json"}
 			},
-			sys:          &types.SystemContext{SignaturePolicyPath: "./fixtures/policy.json"},
 			expectPolicy: policyFixtureContents,
 		},
 		{
 			name: "signature policy path override read error",
-			setup: func(t *testing.T, _ string) {
-				// no-op
+			setup: func(t *testing.T, _ string) *types.SystemContext {
+				return &types.SystemContext{SignaturePolicyPath: "/this/does/not/exist"}
 			},
-			sys:       &types.SystemContext{SignaturePolicyPath: "/this/does/not/exist"},
 			expectErr: true,
 		},
 		{
 			name: "signature policy path override parse error",
-			setup: func(t *testing.T, _ string) {
-				// no-op
+			setup: func(t *testing.T, _ string) *types.SystemContext {
+				return &types.SystemContext{SignaturePolicyPath: "/dev/null"}
 			},
-			sys:       &types.SystemContext{SignaturePolicyPath: "/dev/null"},
 			expectErr: true,
 		},
 		{
 			name: "user wins over etc and usr",
-			setup: func(t *testing.T, rootPrefix string) {
+			setup: func(t *testing.T, rootPrefix string) *types.SystemContext {
 				tempHome := t.TempDir()
 				t.Setenv("XDG_CONFIG_HOME", tempHome)
 				mustWritePolicy(t, filepath.Join(tempHome, "containers", "policy.json"), insecureJSON)
 				mustWritePolicy(t, filepath.Join(rootPrefix, "etc", "containers", "policy.json"), rejectJSON)
 				mustWritePolicy(t, filepath.Join(rootPrefix, "usr", "share", "containers", "policy.json"), rejectJSON)
+				return &types.SystemContext{
+					RootForImplicitAbsolutePaths: rootPrefix,
+				}
 			},
-			sys:           &types.SystemContext{},
-			useRootPrefix: true,
-			expectPolicy:  &prInsecureAcceptAnything{},
+			expectPolicy: &prInsecureAcceptAnything{},
 		},
 		{
 			name: "etc fallback when user missing",
-			setup: func(t *testing.T, rootPrefix string) {
+			setup: func(t *testing.T, rootPrefix string) *types.SystemContext {
 				tempHome := t.TempDir()
 				t.Setenv("XDG_CONFIG_HOME", tempHome)
 				mustWritePolicy(t, filepath.Join(rootPrefix, "etc", "containers", "policy.json"), rejectJSON)
 				mustWritePolicy(t, filepath.Join(rootPrefix, "usr", "share", "containers", "policy.json"), insecureJSON)
+				return &types.SystemContext{
+					RootForImplicitAbsolutePaths: rootPrefix,
+				}
 			},
-			sys:           &types.SystemContext{},
-			useRootPrefix: true,
-			expectPolicy:  &prReject{},
+			expectPolicy: &prReject{},
 		},
 		{
 			name: "usr fallback when only usr present",
-			setup: func(t *testing.T, rootPrefix string) {
+			setup: func(t *testing.T, rootPrefix string) *types.SystemContext {
 				tempHome := t.TempDir()
 				t.Setenv("XDG_CONFIG_HOME", tempHome)
 				mustWritePolicy(t, filepath.Join(rootPrefix, "usr", "share", "containers", "policy.json"), insecureJSON)
+				return &types.SystemContext{
+					RootForImplicitAbsolutePaths: rootPrefix,
+				}
 			},
-			sys:           &types.SystemContext{},
-			useRootPrefix: true,
-			expectPolicy:  &prInsecureAcceptAnything{},
+			expectPolicy: &prInsecureAcceptAnything{},
 		},
 		{
 			name: "no policy file found",
-			setup: func(t *testing.T, _ string) {
-				tempHome := t.TempDir()
-				t.Setenv("XDG_CONFIG_HOME", tempHome)
+			setup: func(t *testing.T, rootPrefix string) *types.SystemContext {
+				t.Setenv("XDG_CONFIG_HOME", "/tmp")
+				return &types.SystemContext{
+					RootForImplicitAbsolutePaths: rootPrefix,
+				}
 			},
-			sys:            &types.SystemContext{},
-			useRootPrefix:  true,
 			expectErr:      true,
-			expectErrMatch: "no policy.json file found",
+			expectErrMatch: "no policy.json file found; searched paths: [\"/tmp/containers/policy.json\" ",
 		},
 		{
 			name: "containers policy conf override base file",
-			setup: func(t *testing.T, rootPrefix string) {
+			setup: func(t *testing.T, rootPrefix string) *types.SystemContext {
 				tempHome := t.TempDir()
 				t.Setenv("XDG_CONFIG_HOME", tempHome)
 				mustWritePolicy(t, filepath.Join(rootPrefix, "etc", "containers", "policy.json"), rejectJSON)
 				base := filepath.Join(t.TempDir(), "env-base.json")
 				mustWritePolicy(t, base, insecureJSON)
 				t.Setenv("CONTAINERS_POLICY_JSON", base)
+				return &types.SystemContext{
+					RootForImplicitAbsolutePaths: rootPrefix,
+				}
 			},
-			sys:          &types.SystemContext{},
 			expectPolicy: &prInsecureAcceptAnything{},
 		},
 		{
 			name: "containers policy conf read error",
-			setup: func(t *testing.T, _ string) {
+			setup: func(t *testing.T, _ string) *types.SystemContext {
 				tempHome := t.TempDir()
 				t.Setenv("XDG_CONFIG_HOME", tempHome)
 				t.Setenv("CONTAINERS_POLICY_JSON", "/this/does/not/exist")
+				return &types.SystemContext{}
 			},
-			sys:       &types.SystemContext{},
 			expectErr: true,
 		},
 		{
 			name: "containers policy conf parse error",
-			setup: func(t *testing.T, _ string) {
+			setup: func(t *testing.T, _ string) *types.SystemContext {
 				tempHome := t.TempDir()
 				t.Setenv("XDG_CONFIG_HOME", tempHome)
 				t.Setenv("CONTAINERS_POLICY_JSON", "/dev/null")
+				return &types.SystemContext{}
 			},
-			sys:       &types.SystemContext{},
 			expectErr: true,
 		},
 		{
+			name: "containers policy conf readall error",
+			setup: func(t *testing.T, _ string) *types.SystemContext {
+				tempHome := t.TempDir()
+				t.Setenv("XDG_CONFIG_HOME", tempHome)
+				// Point the env to a directory so io.ReadAll fails when reading it.
+				dir := t.TempDir()
+				t.Setenv("CONTAINERS_POLICY_JSON", dir)
+				return &types.SystemContext{}
+			},
+			expectErr: true,
+		},
+		{
+			name: "signature policy path wins over root for implicit absolute paths",
+			setup: func(t *testing.T, rootPrefix string) *types.SystemContext {
+				tempHome := t.TempDir()
+				t.Setenv("XDG_CONFIG_HOME", tempHome)
+
+				// If SignaturePolicyPath were ignored, this would be used due to RootForImplicitAbsolutePaths.
+				mustWritePolicy(t, filepath.Join(rootPrefix, "etc", "containers", "policy.json"), rejectJSON)
+
+				return &types.SystemContext{
+					SignaturePolicyPath:          "./fixtures/policy.json",
+					RootForImplicitAbsolutePaths: rootPrefix,
+				}
+			},
+			expectPolicy: policyFixtureContents,
+		},
+		{
 			name: "root for implicit absolute paths is honored",
-			setup: func(t *testing.T, rootPrefix string) {
+			setup: func(t *testing.T, rootPrefix string) *types.SystemContext {
 				tempHome := t.TempDir()
 				t.Setenv("XDG_CONFIG_HOME", tempHome)
 				mustWritePolicy(t, filepath.Join(rootPrefix, "etc", "containers", "policy.json"), rejectJSON)
+				return &types.SystemContext{
+					RootForImplicitAbsolutePaths: rootPrefix,
+				}
 			},
-			sys:           &types.SystemContext{},
-			useRootPrefix: true,
-			expectPolicy:  &prReject{},
+			expectPolicy: &prReject{},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			rootPrefix := t.TempDir()
+			var sys *types.SystemContext
 			if test.setup != nil {
-				test.setup(t, rootPrefix)
-			}
-			sys := test.sys
-			if test.useRootPrefix && sys != nil && sys.RootForImplicitAbsolutePaths == "" && sys.SignaturePolicyPath == "" {
-				sys = &types.SystemContext{RootForImplicitAbsolutePaths: rootPrefix}
+				sys = test.setup(t, rootPrefix)
 			}
 
 			policy, err := DefaultPolicy(sys)
@@ -285,8 +311,6 @@ func TestDefaultPolicy(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			require.NotNil(t, policy)
-			require.NotEmpty(t, policy.Default)
 
 			switch expected := test.expectPolicy.(type) {
 			case *Policy:

--- a/image/signature/policy_config_test.go
+++ b/image/signature/policy_config_test.go
@@ -127,130 +127,180 @@ func TestInvalidPolicyFormatError(t *testing.T) {
 }
 
 func TestDefaultPolicy(t *testing.T) {
-	// We can't test the actual systemDefaultPolicyPath, so override.
-	// TestDefaultPolicyPath below tests that we handle the overrides and defaults
-	// correctly.
+	// prReject
+	const rejectJSON = `{"default":[{"type":"reject"}]}`
+	// prInsecureAcceptAnything
+	const insecureJSON = `{"default":[{"type":"insecureAcceptAnything"}]}`
 
-	// Success
-	policy, err := DefaultPolicy(&types.SystemContext{SignaturePolicyPath: "./fixtures/policy.json"})
-	require.NoError(t, err)
-	assert.Equal(t, policyFixtureContents, policy)
-
-	for _, path := range []string{
-		"/this/does/not/exist", // Error reading file
-		"/dev/null",            // A failure case; most are tested in the individual method unit tests.
-	} {
-		policy, err := DefaultPolicy(&types.SystemContext{SignaturePolicyPath: path})
-		assert.Error(t, err)
-		assert.Nil(t, policy)
+	type tc struct {
+		name           string
+		setup          func(t *testing.T, rootPrefix string)
+		sys            *types.SystemContext
+		useRootPrefix  bool
+		expectPolicy   any // *Policy, *prReject, *prInsecureAcceptAnything
+		expectErr      bool
+		expectErrMatch string
 	}
-}
 
-func TestDefaultPolicyPath(t *testing.T) {
-	const nondefaultPath = "/this/is/not/the/default/path.json"
-	const variableReference = "$HOME"
-	const rootPrefix = "/root/prefix"
-	tempHome := t.TempDir()
-	userDefaultPolicyPath := filepath.Join(tempHome, userPolicyFile)
-	tempsystemdefaultpath := filepath.Join(tempHome, systemDefaultPolicyPath)
-	for _, c := range []struct {
-		sys               *types.SystemContext
-		userfilePresent   bool
-		systemfilePresent bool
-		expected          string
-		expectedError     string
-	}{
-		// The common case
-		{nil, false, true, tempsystemdefaultpath, ""},
-		// There is a context, but it does not override the path.
-		{&types.SystemContext{}, false, true, tempsystemdefaultpath, ""},
-		// Path overridden
-		{&types.SystemContext{SignaturePolicyPath: nondefaultPath}, false, true, nondefaultPath, ""},
-		// Root overridden
+	mustWritePolicy := func(t *testing.T, path, contents string) {
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+	}
+
+	for _, test := range []tc{
 		{
-			&types.SystemContext{RootForImplicitAbsolutePaths: rootPrefix},
-			false,
-			true,
-			filepath.Join(rootPrefix, tempsystemdefaultpath),
-			"",
-		},
-		// Empty context and user policy present
-		{&types.SystemContext{}, true, true, userDefaultPolicyPath, ""},
-		// Only user policy present
-		{nil, true, true, userDefaultPolicyPath, ""},
-		// Context signature path and user policy present
-		{
-			&types.SystemContext{
-				SignaturePolicyPath: nondefaultPath,
+			name: "signature policy path override success",
+			setup: func(t *testing.T, _ string) {
+				// no-op
 			},
-			true,
-			true,
-			nondefaultPath,
-			"",
+			sys:          &types.SystemContext{SignaturePolicyPath: "./fixtures/policy.json"},
+			expectPolicy: policyFixtureContents,
 		},
-		// Root and user policy present
 		{
-			&types.SystemContext{
-				RootForImplicitAbsolutePaths: rootPrefix,
+			name: "signature policy path override read error",
+			setup: func(t *testing.T, _ string) {
+				// no-op
 			},
-			true,
-			true,
-			userDefaultPolicyPath,
-			"",
+			sys:       &types.SystemContext{SignaturePolicyPath: "/this/does/not/exist"},
+			expectErr: true,
 		},
-		// Context and user policy file preset simultaneously
 		{
-			&types.SystemContext{
-				RootForImplicitAbsolutePaths: rootPrefix,
-				SignaturePolicyPath:          nondefaultPath,
+			name: "signature policy path override parse error",
+			setup: func(t *testing.T, _ string) {
+				// no-op
 			},
-			true,
-			true,
-			nondefaultPath,
-			"",
+			sys:       &types.SystemContext{SignaturePolicyPath: "/dev/null"},
+			expectErr: true,
 		},
-		// Root and path overrides present simultaneously,
 		{
-			&types.SystemContext{
-				RootForImplicitAbsolutePaths: rootPrefix,
-				SignaturePolicyPath:          nondefaultPath,
+			name: "user wins over etc and usr",
+			setup: func(t *testing.T, rootPrefix string) {
+				tempHome := t.TempDir()
+				t.Setenv("XDG_CONFIG_HOME", tempHome)
+				mustWritePolicy(t, filepath.Join(tempHome, "containers", "policy.json"), insecureJSON)
+				mustWritePolicy(t, filepath.Join(rootPrefix, "etc", "containers", "policy.json"), rejectJSON)
+				mustWritePolicy(t, filepath.Join(rootPrefix, "usr", "share", "containers", "policy.json"), rejectJSON)
 			},
-			false,
-			true,
-			nondefaultPath,
-			"",
+			sys:           &types.SystemContext{},
+			useRootPrefix: true,
+			expectPolicy:  &prInsecureAcceptAnything{},
 		},
-		// No environment expansion happens in the overridden paths
-		{&types.SystemContext{SignaturePolicyPath: variableReference}, false, true, variableReference, ""},
-		// No policy.json file is present in userfilePath and systemfilePath
-		{nil, false, false, "", fmt.Sprintf("no policy.json file found at any of the following: %q, %q", userDefaultPolicyPath, tempsystemdefaultpath)},
+		{
+			name: "etc fallback when user missing",
+			setup: func(t *testing.T, rootPrefix string) {
+				tempHome := t.TempDir()
+				t.Setenv("XDG_CONFIG_HOME", tempHome)
+				mustWritePolicy(t, filepath.Join(rootPrefix, "etc", "containers", "policy.json"), rejectJSON)
+				mustWritePolicy(t, filepath.Join(rootPrefix, "usr", "share", "containers", "policy.json"), insecureJSON)
+			},
+			sys:           &types.SystemContext{},
+			useRootPrefix: true,
+			expectPolicy:  &prReject{},
+		},
+		{
+			name: "usr fallback when only usr present",
+			setup: func(t *testing.T, rootPrefix string) {
+				tempHome := t.TempDir()
+				t.Setenv("XDG_CONFIG_HOME", tempHome)
+				mustWritePolicy(t, filepath.Join(rootPrefix, "usr", "share", "containers", "policy.json"), insecureJSON)
+			},
+			sys:           &types.SystemContext{},
+			useRootPrefix: true,
+			expectPolicy:  &prInsecureAcceptAnything{},
+		},
+		{
+			name: "no policy file found",
+			setup: func(t *testing.T, _ string) {
+				tempHome := t.TempDir()
+				t.Setenv("XDG_CONFIG_HOME", tempHome)
+			},
+			sys:            &types.SystemContext{},
+			useRootPrefix:  true,
+			expectErr:      true,
+			expectErrMatch: "no policy.json file found",
+		},
+		{
+			name: "containers policy conf override base file",
+			setup: func(t *testing.T, rootPrefix string) {
+				tempHome := t.TempDir()
+				t.Setenv("XDG_CONFIG_HOME", tempHome)
+				mustWritePolicy(t, filepath.Join(rootPrefix, "etc", "containers", "policy.json"), rejectJSON)
+				base := filepath.Join(t.TempDir(), "env-base.json")
+				mustWritePolicy(t, base, insecureJSON)
+				t.Setenv("CONTAINERS_POLICY_JSON", base)
+			},
+			sys:          &types.SystemContext{},
+			expectPolicy: &prInsecureAcceptAnything{},
+		},
+		{
+			name: "containers policy conf read error",
+			setup: func(t *testing.T, _ string) {
+				tempHome := t.TempDir()
+				t.Setenv("XDG_CONFIG_HOME", tempHome)
+				t.Setenv("CONTAINERS_POLICY_JSON", "/this/does/not/exist")
+			},
+			sys:       &types.SystemContext{},
+			expectErr: true,
+		},
+		{
+			name: "containers policy conf parse error",
+			setup: func(t *testing.T, _ string) {
+				tempHome := t.TempDir()
+				t.Setenv("XDG_CONFIG_HOME", tempHome)
+				t.Setenv("CONTAINERS_POLICY_JSON", "/dev/null")
+			},
+			sys:       &types.SystemContext{},
+			expectErr: true,
+		},
+		{
+			name: "root for implicit absolute paths is honored",
+			setup: func(t *testing.T, rootPrefix string) {
+				tempHome := t.TempDir()
+				t.Setenv("XDG_CONFIG_HOME", tempHome)
+				mustWritePolicy(t, filepath.Join(rootPrefix, "etc", "containers", "policy.json"), rejectJSON)
+			},
+			sys:           &types.SystemContext{},
+			useRootPrefix: true,
+			expectPolicy:  &prReject{},
+		},
 	} {
-		paths := []struct {
-			condition bool
-			path      string
-		}{
-			{c.userfilePresent, userDefaultPolicyPath},
-			{c.systemfilePresent, tempsystemdefaultpath},
-		}
-		for _, p := range paths {
-			if p.condition {
-				err := os.MkdirAll(filepath.Dir(p.path), os.ModePerm)
-				require.NoError(t, err)
-				f, err := os.Create(p.path)
-				require.NoError(t, err)
-				f.Close()
-			} else {
-				os.Remove(p.path)
+		t.Run(test.name, func(t *testing.T) {
+			rootPrefix := t.TempDir()
+			if test.setup != nil {
+				test.setup(t, rootPrefix)
 			}
-		}
-		path, err := defaultPolicyPathWithHomeDir(c.sys, tempHome, tempsystemdefaultpath)
-		if c.expectedError != "" {
-			assert.Empty(t, path)
-			assert.EqualError(t, err, c.expectedError)
-		} else {
+			sys := test.sys
+			if test.useRootPrefix && sys != nil && sys.RootForImplicitAbsolutePaths == "" && sys.SignaturePolicyPath == "" {
+				sys = &types.SystemContext{RootForImplicitAbsolutePaths: rootPrefix}
+			}
+
+			policy, err := DefaultPolicy(sys)
+			if test.expectErr {
+				require.Error(t, err)
+				assert.Nil(t, policy)
+				if test.expectErrMatch != "" {
+					assert.Contains(t, err.Error(), test.expectErrMatch)
+				}
+				return
+			}
+
 			require.NoError(t, err)
-			assert.Equal(t, c.expected, path)
-		}
+			require.NotNil(t, policy)
+			require.NotEmpty(t, policy.Default)
+
+			switch expected := test.expectPolicy.(type) {
+			case *Policy:
+				assert.Equal(t, expected, policy)
+			case *prInsecureAcceptAnything:
+				_, ok := policy.Default[0].(*prInsecureAcceptAnything)
+				assert.True(t, ok, "expected insecureAcceptAnything policy requirement")
+			case *prReject:
+				_, ok := policy.Default[0].(*prReject)
+				assert.True(t, ok, "expected reject policy requirement")
+			default:
+				t.Fatalf("unexpected expectedPolicy type %T", test.expectPolicy)
+			}
+		})
 	}
 }
 

--- a/image/signature/policy_paths_common.go
+++ b/image/signature/policy_paths_common.go
@@ -1,3 +1,0 @@
-//go:build !freebsd
-
-package signature

--- a/image/signature/policy_paths_common.go
+++ b/image/signature/policy_paths_common.go
@@ -1,7 +1,3 @@
 //go:build !freebsd
 
 package signature
-
-// builtinDefaultPolicyPath is the policy path used for DefaultPolicy().
-// DO NOT change this, instead see systemDefaultPolicyPath above.
-const builtinDefaultPolicyPath = "/etc/containers/policy.json"

--- a/image/signature/policy_paths_freebsd.go
+++ b/image/signature/policy_paths_freebsd.go
@@ -1,3 +1,0 @@
-//go:build freebsd
-
-package signature

--- a/image/signature/policy_paths_freebsd.go
+++ b/image/signature/policy_paths_freebsd.go
@@ -1,7 +1,3 @@
 //go:build freebsd
 
 package signature
-
-// builtinDefaultPolicyPath is the policy path used for DefaultPolicy().
-// DO NOT change this, instead see systemDefaultPolicyPath above.
-const builtinDefaultPolicyPath = "/usr/local/etc/containers/policy.json"

--- a/storage/pkg/configfile/parse.go
+++ b/storage/pkg/configfile/parse.go
@@ -224,7 +224,7 @@ func Read(conf *File) iter.Seq2[*Item, error] {
 			conf.Modules = resolvedModules
 		}
 
-		if conf.EnvironmentName != "" {
+		if conf.EnvironmentName != "" && !conf.DoNotLoadDropInFiles {
 			// The _OVERRIDE env must be appended after loading all files, even modules.
 			if path := os.Getenv(conf.EnvironmentName + "_OVERRIDE"); path != "" {
 				f, err := os.Open(path)

--- a/storage/pkg/configfile/parse.go
+++ b/storage/pkg/configfile/parse.go
@@ -31,6 +31,10 @@ var (
 	// This can be overridden at build time with the following go linker flag:
 	// -ldflags '-X go.podman.io/storage/pkg/configfile.adminOverrideConfigPath=$your_path'
 	adminOverrideConfigPath = getAdminOverrideConfigPath()
+
+	// ErrConfigFileNotFound is returned when ErrorIfNotFound is true and no config
+	// file could be loaded.
+	ErrConfigFileNotFound = errors.New("config file not found")
 )
 
 type File struct {
@@ -254,7 +258,7 @@ func Read(conf *File) iter.Seq2[*Item, error] {
 		}
 
 		if conf.ErrorIfNotFound && !foundAny {
-			yield(nil, fmt.Errorf("no %s file found; searched paths: %q", configFileName, usedPaths))
+			yield(nil, fmt.Errorf("%w: no %s file found; searched paths: %q", ErrConfigFileNotFound, configFileName, usedPaths))
 			return
 		}
 	}

--- a/storage/pkg/configfile/parse.go
+++ b/storage/pkg/configfile/parse.go
@@ -97,8 +97,6 @@ func getConfName(name, extension string, noExtension bool) string {
 // If an error is returned by the iterator then this must be treated as fatal error and must fail the config file parsing.
 // Expected ENOENT errors are already ignored in this function and must not be handled again by callers.
 // The given File options must not be nil and populated with valid options.
-//
-// The _OVERRIDE environment is ignored if DoNotLoadDropInFiles is set.
 func Read(conf *File) iter.Seq2[*Item, error] {
 	configFileName := getConfName(conf.Name, conf.Extension, conf.DoNotUseExtensionForConfigName)
 

--- a/storage/pkg/configfile/parse.go
+++ b/storage/pkg/configfile/parse.go
@@ -43,6 +43,8 @@ type File struct {
 	Extension string
 
 	// EnvironmentName is the name of environment variable that can be set to specify the override.
+	// If EnvironmentName is set, the variable with _OVERRIDE suffix is also checked for an override
+	// unless DoNotLoadDropInFiles is set.
 	// Optional.
 	EnvironmentName string
 
@@ -55,6 +57,7 @@ type File struct {
 	DoNotLoadMainFiles bool
 
 	// DoNotLoadDropInFiles should be set if only the main files should be loaded.
+	// If DoNotLoadDropInFiles is set, the _OVERRIDE environment variable is ignored.
 	DoNotLoadDropInFiles bool
 
 	// DoNotUseExtensionForConfigName makes it so that the extension is only consulted for the drop in
@@ -70,6 +73,9 @@ type File struct {
 	// For compatibility reasons this field is written to with the fully resolved paths
 	// of each module as this is what podman expects today.
 	Modules []string
+
+	// ErrorIfNotFound is true if an error should be returned if no file is found.
+	ErrorIfNotFound bool
 }
 
 // Item is a single config file that is being read once at a time and returned by the iterator from [Read].
@@ -91,6 +97,8 @@ func getConfName(name, extension string, noExtension bool) string {
 // If an error is returned by the iterator then this must be treated as fatal error and must fail the config file parsing.
 // Expected ENOENT errors are already ignored in this function and must not be handled again by callers.
 // The given File options must not be nil and populated with valid options.
+//
+// The _OVERRIDE environment is ignored if DoNotLoadDropInFiles is set.
 func Read(conf *File) iter.Seq2[*Item, error] {
 	configFileName := getConfName(conf.Name, conf.Extension, conf.DoNotUseExtensionForConfigName)
 
@@ -113,10 +121,14 @@ func Read(conf *File) iter.Seq2[*Item, error] {
 	}
 
 	return func(yield func(*Item, error) bool) {
+		usedPaths := make([]string, 0, 8)
+		foundAny := false
+
 		shouldLoadMainFile := !conf.DoNotLoadMainFiles
 		shouldLoadDropIns := !conf.DoNotLoadDropInFiles
 
 		yieldAndClose := func(f *os.File) bool {
+			foundAny = true
 			ok := yield(&Item{
 				Reader: f,
 				Name:   f.Name(),
@@ -134,6 +146,7 @@ func Read(conf *File) iter.Seq2[*Item, error] {
 
 		if conf.EnvironmentName != "" {
 			if path := os.Getenv(conf.EnvironmentName); path != "" {
+				usedPaths = append(usedPaths, path)
 				f, err := os.Open(path)
 				// Do not ignore ErrNotExist here, we want to hard error if users set a wrong path here.
 				if err != nil {
@@ -165,6 +178,7 @@ func Read(conf *File) iter.Seq2[*Item, error] {
 				if path == "" {
 					continue
 				}
+				usedPaths = append(usedPaths, path)
 				f, err := os.Open(path)
 				// only ignore ErrNotExist, all other errors get return to the caller via yield
 				if err != nil {
@@ -191,6 +205,7 @@ func Read(conf *File) iter.Seq2[*Item, error] {
 				return
 			}
 			for _, file := range files {
+				usedPaths = append(usedPaths, file)
 				f, err := os.Open(file)
 				// only ignore ErrNotExist, all other errors get return to the caller via yield
 				if err != nil {
@@ -211,7 +226,7 @@ func Read(conf *File) iter.Seq2[*Item, error] {
 			dirs := moduleDirectories(defaultConfig, overrideConfig, userConfig)
 			resolvedModules := make([]string, 0, len(conf.Modules))
 			for _, module := range conf.Modules {
-				f, err := resolveModule(module, dirs)
+				f, err := resolveModule(module, dirs, &usedPaths)
 				if err != nil {
 					yield(nil, fmt.Errorf("could not resolve module: %w", err))
 					return
@@ -227,6 +242,7 @@ func Read(conf *File) iter.Seq2[*Item, error] {
 		if conf.EnvironmentName != "" && !conf.DoNotLoadDropInFiles {
 			// The _OVERRIDE env must be appended after loading all files, even modules.
 			if path := os.Getenv(conf.EnvironmentName + "_OVERRIDE"); path != "" {
+				usedPaths = append(usedPaths, path)
 				f, err := os.Open(path)
 				// Do not ignore ErrNotExist here, we want to hard error if users set a wrong path here.
 				if err != nil {
@@ -237,6 +253,11 @@ func Read(conf *File) iter.Seq2[*Item, error] {
 					return
 				}
 			}
+		}
+
+		if conf.ErrorIfNotFound && !foundAny {
+			yield(nil, fmt.Errorf("no %s file found; searched paths: %q", configFileName, usedPaths))
+			return
 		}
 	}
 }
@@ -324,8 +345,11 @@ func moduleDirectories(defaultConfig, overrideConfig, userConfig string) []strin
 }
 
 // Resolve the specified path to a module.
-func resolveModule(path string, dirs []string) (*os.File, error) {
+func resolveModule(path string, dirs []string, usedPaths *[]string) (*os.File, error) {
 	if filepath.IsAbs(path) {
+		if usedPaths != nil {
+			*usedPaths = append(*usedPaths, path)
+		}
 		return os.Open(path)
 	}
 
@@ -334,6 +358,9 @@ func resolveModule(path string, dirs []string) (*os.File, error) {
 	var multiErr error
 	for _, d := range dirs {
 		candidate := filepath.Join(d, path)
+		if usedPaths != nil {
+			*usedPaths = append(*usedPaths, candidate)
+		}
 
 		f, err := os.Open(candidate)
 		if err == nil {

--- a/storage/pkg/configfile/parse_test.go
+++ b/storage/pkg/configfile/parse_test.go
@@ -113,8 +113,10 @@ func Test_Read(t *testing.T) {
 		setup func(t *testing.T, tc *testcase)
 		// Expected result, file content in right order.
 		want []string
-		// wantErr is the error type matched with errors.Is() is the function should error instead
+		// wantErr is matched with errors.Is() when the function should error instead.
 		wantErr error
+		// wantErrContains, if non-empty, asserts a substring of the error string instead of wantErr.
+		wantErrContains string
 	}
 
 	tests := []testcase{
@@ -125,6 +127,16 @@ func Test_Read(t *testing.T) {
 				Extension: "conf",
 			},
 			want: nil,
+		},
+		{
+			name: "no files error if not found",
+			arg: File{
+				Name:            "containers",
+				Extension:       "conf",
+				ErrorIfNotFound: true,
+			},
+			// Read records real paths (under RootForImplicitAbsolutePaths / XDG); the message is fmt.Errorf(..., %q, usedPaths).
+			wantErrContains: "no containers.conf file found; searched paths:",
 		},
 		{
 			name: "simple main file",
@@ -555,7 +567,7 @@ func Test_Read(t *testing.T) {
 				tt.setup(t, &tt)
 			}
 			seq := Read(&tt.arg)
-			if tt.wantErr == nil {
+			if tt.wantErr == nil && tt.wantErrContains == "" {
 				confs := collectConfigs(t, seq)
 				assert.Equal(t, tt.want, confs)
 
@@ -570,7 +582,12 @@ func Test_Read(t *testing.T) {
 
 				_, err, ok := next()
 				assert.True(t, ok)
-				assert.ErrorIs(t, err, tt.wantErr)
+				if tt.wantErrContains != "" {
+					assert.ErrorContains(t, err, tt.wantErrContains)
+					assert.Contains(t, err.Error(), tt.arg.RootForImplicitAbsolutePaths)
+				} else {
+					assert.ErrorIs(t, err, tt.wantErr)
+				}
 
 				// end of iterator
 				_, _, ok = next()

--- a/storage/pkg/configfile/parse_test.go
+++ b/storage/pkg/configfile/parse_test.go
@@ -137,6 +137,7 @@ func Test_Read(t *testing.T) {
 			},
 			// Read records real paths (under RootForImplicitAbsolutePaths / XDG); the message is fmt.Errorf(..., %q, usedPaths).
 			wantErrContains: "no containers.conf file found; searched paths:",
+			wantErr:         ErrConfigFileNotFound,
 		},
 		{
 			name: "simple main file",
@@ -585,7 +586,8 @@ func Test_Read(t *testing.T) {
 				if tt.wantErrContains != "" {
 					assert.ErrorContains(t, err, tt.wantErrContains)
 					assert.Contains(t, err.Error(), tt.arg.RootForImplicitAbsolutePaths)
-				} else {
+				}
+				if tt.wantErr != nil {
 					assert.ErrorIs(t, err, tt.wantErr)
 				}
 


### PR DESCRIPTION
This PR switches `policy.json` loading to the unified `storage/pkg/configfile` parser instead of maintaining separate lookup logic in image/signature.

The `SignaturePolicyPath` support is preserved, so explicit callers continue to work as before. The policy loader also now uses CONTAINERS_POLICY_JSON for environment-based override. The `CONTAINERS_POLICY_JSON_OVERRIDE` remains ignored for policy.json because drop-in loading is disabled for that this configuration file.

It also extends the `configfile` API to return the paths it searched. This is showed to users when there is no policy.json found.

Fixes: #207
Fixes: #202