### PR TITLE
Add storage option to strip SUID & SGID bits from files as they are extracted from image layers

### DIFF
--- a/storage/check.go
+++ b/storage/check.go
@@ -145,6 +145,9 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 			ignore.filetype = true
 		}
 	}
+	if s.stripSUIDSGID {
+		ignore.permissions = true
+	}
 	for o := range s.pullOptions {
 		if strings.Contains(o, "use_hard_links") {
 			if s.pullOptions[o] == "true" {

--- a/storage/docs/containers-storage.conf.5.md
+++ b/storage/docs/containers-storage.conf.5.md
@@ -90,6 +90,13 @@ The `storage.options` table supports the following options:
 **disable-volatile**=true
   If disable-volatile is set, then the "volatile" mount optimization is disabled for all the containers.
 
+**strip_suid_sgid**=false
+  If strip_suid_sgid is enabled, the SUID and SGID bits are removed (set to zero) from the permission bits (mode) of files, directories, etc., as they are extracted from image layers.  This allows such image layers to be extracted and used when creation of SUID or SGID files is restricted (such as within a systemd service with `RestrictSUIDSGID=yes`).
+
+  Many containerized applications inherit these bits from base images but don't actually need them.  If an application runs as root or does not use these utilities, stripping the bits has no negative impact.  However, some workloads do rely on these privileges, so stripping them can cause failures.  Always test and audit entry point scripts and application behavior to determine whether an application runs correctly with this option set.
+
+  Note that this option only affects image layer **extraction** (such as when pulling images).  Other operations, such as layer copying, are not affected.  Also, this option has no effect on Windows.
+
 ### STORAGE PULL OPTIONS TABLE
 
 The `storage.options.pull_options` table supports the following keys:

--- a/storage/drivers/driver.go
+++ b/storage/drivers/driver.go
@@ -107,6 +107,7 @@ type ApplyDiffOpts struct {
 	MountLabel        string
 	IgnoreChownErrors bool
 	ForceMask         *os.FileMode
+	StripSUIDSGID     *bool
 }
 
 // ApplyDiffWithDifferOpts contains optional arguments for ApplyDiffWithDiffer methods.
@@ -325,6 +326,7 @@ type DriverWithDiffer interface {
 	Driver
 	// ApplyDiffWithDiffer applies the changes using the callback function.
 	// The staging directory created by this function is guaranteed to be usable with ApplyDiffFromStagingDirectory.
+	// options must not be nil.
 	ApplyDiffWithDiffer(options *ApplyDiffWithDifferOpts, differ Differ) (output DriverWithDifferOutput, err error)
 	// ApplyDiffFromStagingDirectory applies the changes using the diffOutput target directory.
 	ApplyDiffFromStagingDirectory(id, parent string, diffOutput *DriverWithDifferOutput, options *ApplyDiffWithDifferOpts) error

--- a/storage/drivers/fsdiff.go
+++ b/storage/drivers/fsdiff.go
@@ -179,6 +179,9 @@ func (gdw *NaiveDiffDriver) ApplyDiff(id string, options ApplyDiffOpts) (int64, 
 		IgnoreChownErrors: options.IgnoreChownErrors,
 		ForceMask:         forceMask,
 	}
+	if options.StripSUIDSGID != nil {
+		tarOptions.StripSUIDSGID = *options.StripSUIDSGID
+	}
 	if options.Mappings != nil {
 		tarOptions.UIDMaps = options.Mappings.UIDs()
 		tarOptions.GIDMaps = options.Mappings.GIDs()

--- a/storage/drivers/overlay/overlay.go
+++ b/storage/drivers/overlay/overlay.go
@@ -2291,10 +2291,8 @@ func (d *Driver) ApplyDiffWithDiffer(options *graphdriver.ApplyDiffWithDifferOpt
 	var idMappings *idtools.IDMappings
 	var forceMask *os.FileMode
 
-	if options != nil {
-		idMappings = options.Mappings
-		forceMask = options.ForceMask
-	}
+	idMappings = options.Mappings
+	forceMask = options.ForceMask
 	if d.options.forceMask != nil {
 		forceMask = d.options.forceMask
 	}
@@ -2343,14 +2341,18 @@ func (d *Driver) ApplyDiffWithDiffer(options *graphdriver.ApplyDiffWithDifferOpt
 		differOptions.Format = graphdriver.DifferOutputFormatFlat
 		differOptions.UseFsVerity = graphdriver.DifferFsVerityIfAvailable
 	}
-	out, err := differ.ApplyDiff(applyDir, &archive.TarOptions{
+	tarOpts := &archive.TarOptions{
 		UIDMaps:           idMappings.UIDs(),
 		GIDMaps:           idMappings.GIDs(),
 		IgnoreChownErrors: d.options.ignoreChownErrors,
 		WhiteoutFormat:    d.getWhiteoutFormat(),
 		InUserNS:          unshare.IsRootless(),
 		ForceMask:         forceMask,
-	}, &differOptions)
+	}
+	if options.StripSUIDSGID != nil {
+		tarOpts.StripSUIDSGID = *options.StripSUIDSGID
+	}
+	out, err := differ.ApplyDiff(applyDir, tarOpts, &differOptions)
 
 	out.Target = applyDir
 
@@ -2498,15 +2500,19 @@ func (d *Driver) applyDiff(target string, options graphdriver.ApplyDiffOpts) (si
 	}
 
 	logrus.Debugf("Applying tar in %s", target)
-	// Overlay doesn't need the parent id to apply the diff
-	if err := untar(options.Diff, target, &archive.TarOptions{
+	tarOpts := &archive.TarOptions{
 		UIDMaps:           idMappings.UIDs(),
 		GIDMaps:           idMappings.GIDs(),
 		IgnoreChownErrors: d.options.ignoreChownErrors,
 		ForceMask:         d.options.forceMask,
 		WhiteoutFormat:    d.getWhiteoutFormat(),
 		InUserNS:          unshare.IsRootless(),
-	}); err != nil {
+	}
+	if options.StripSUIDSGID != nil {
+		tarOpts.StripSUIDSGID = *options.StripSUIDSGID
+	}
+	// Overlay doesn't need the parent id to apply the diff
+	if err := untar(options.Diff, target, tarOpts); err != nil {
 		return 0, err
 	}
 

--- a/storage/layers.go
+++ b/storage/layers.go
@@ -481,6 +481,7 @@ type layerStore struct {
 	rundir         string
 	jsonPath       [numLayerLocationIndex]string
 	layerdir       string
+	stripSUIDSGID  bool
 
 	inProcessLock sync.RWMutex // Can _only_ be obtained with lockfile held.
 	// The following fields can only be read/written with read/write ownership of inProcessLock, respectively.
@@ -1269,7 +1270,8 @@ func (s *store) newLayerStore(rundir, layerdir, imagedir string, driver drivers.
 		byname:  make(map[string]*Layer),
 		bymount: make(map[string]*Layer),
 
-		driver: driver,
+		driver:        driver,
+		stripSUIDSGID: s.stripSUIDSGID,
 	}
 	if err := rlstore.startWritingWithReload(false); err != nil {
 		return nil, err
@@ -2557,7 +2559,8 @@ func (r *layerStore) stageWithUnlockedStore(sl *maybeStagedLayerExtraction, pare
 			Diff:     payload,
 			Mappings: idtools.NewIDMappingsFromMaps(layerOptions.UIDMap, layerOptions.GIDMap),
 			// MountLabel is not supported for the unlocked extraction, see the comment in (*store).PutLayer()
-			MountLabel: "",
+			MountLabel:    "",
+			StripSUIDSGID: &r.stripSUIDSGID,
 		})
 		sl.cleanupFuncs = append(sl.cleanupFuncs, cleanup)
 		sl.stagedLayer = stagedLayer
@@ -2742,9 +2745,10 @@ func (r *layerStore) applyDiffWithOptions(to string, layerOptions *LayerOptions,
 
 	result, err := applyDiff(layerOptions, diff, tarSplitFile, func(payload io.Reader) (int64, error) {
 		options := drivers.ApplyDiffOpts{
-			Diff:       payload,
-			Mappings:   r.layerMappings(layer),
-			MountLabel: layer.MountLabel,
+			Diff:          payload,
+			Mappings:      r.layerMappings(layer),
+			MountLabel:    layer.MountLabel,
+			StripSUIDSGID: &r.stripSUIDSGID,
 		}
 		return r.driver.ApplyDiff(layer.ID, options)
 	})
@@ -2803,11 +2807,14 @@ func (r *layerStore) applyDiffFromStagingDirectory(id string, diffOutput *driver
 	if options == nil {
 		options = &drivers.ApplyDiffWithDifferOpts{
 			ApplyDiffOpts: drivers.ApplyDiffOpts{
-				Mappings:   r.layerMappings(layer),
-				MountLabel: layer.MountLabel,
+				Mappings:      r.layerMappings(layer),
+				MountLabel:    layer.MountLabel,
+				StripSUIDSGID: &r.stripSUIDSGID,
 			},
 			Flags: nil,
 		}
+	} else if options.StripSUIDSGID == nil {
+		options.StripSUIDSGID = &r.stripSUIDSGID
 	}
 
 	err := ddriver.ApplyDiffFromStagingDirectory(layer.ID, layer.Parent, diffOutput, options)
@@ -2891,6 +2898,15 @@ func (r *layerStore) applyDiffWithDifferNoLock(options *drivers.ApplyDiffWithDif
 	ddriver, ok := r.driver.(drivers.DriverWithDiffer)
 	if !ok {
 		return nil, ErrNotSupported
+	}
+	if options == nil {
+		options = &drivers.ApplyDiffWithDifferOpts{
+			ApplyDiffOpts: drivers.ApplyDiffOpts{
+				StripSUIDSGID: &r.stripSUIDSGID,
+			},
+		}
+	} else if options.StripSUIDSGID == nil {
+		options.StripSUIDSGID = &r.stripSUIDSGID
 	}
 
 	output, err := ddriver.ApplyDiffWithDiffer(options, differ)

--- a/storage/pkg/archive/archive.go
+++ b/storage/pkg/archive/archive.go
@@ -70,6 +70,9 @@ type (
 		ForceMask *os.FileMode
 		// Timestamp, if set, will be set in each header as create/mod/access time
 		Timestamp *time.Time
+		// StripSUIDSGID, if set SUID & SGID bits will be stripped from
+		// the permissions of extracted files, directories, etc.
+		StripSUIDSGID bool
 	}
 )
 

--- a/storage/pkg/archive/archive.go
+++ b/storage/pkg/archive/archive.go
@@ -73,6 +73,11 @@ type (
 		// StripSUIDSGID, if set SUID & SGID bits will be stripped from
 		// the permissions of extracted files, directories, etc.
 		StripSUIDSGID bool
+		// InSubprocess indicates whether or not extractTarFileEntry()
+		// is running in a storage-untar subprocess.  If set, modified
+		// file mode messages (because of stripped SUIG/SGID bits) are
+		// printed to stderr, rather than logged with logrus.
+		InSubprocess bool
 	}
 )
 
@@ -705,7 +710,7 @@ func (ta *tarWriter) addFile(headers *addFileData) error {
 	return nil
 }
 
-func extractTarFileEntry(path, extractDir string, hdr *tar.Header, reader io.Reader, Lchown bool, chownOpts *idtools.IDPair, inUserns, ignoreChownErrors bool, forceMask *os.FileMode, buffer []byte) error {
+func extractTarFileEntry(path, extractDir string, hdr *tar.Header, reader io.Reader, Lchown bool, chownOpts *idtools.IDPair, tarOpts *TarOptions, buffer []byte) error {
 	// hdr.Mode is in linux format, which we can use for sycalls,
 	// but for os.Foo() calls we need the mode converted to os.FileMode,
 	// so use hdrInfo.Mode() (they differ for e.g. setuid bits)
@@ -713,11 +718,21 @@ func extractTarFileEntry(path, extractDir string, hdr *tar.Header, reader io.Rea
 
 	typeFlag := hdr.Typeflag
 	mask := hdrInfo.Mode()
+	const setUIDGIDMask = os.ModeSetuid | os.ModeSetgid
+	if tarOpts.StripSUIDSGID && mask&setUIDGIDMask != 0 {
+		mask &^= setUIDGIDMask
+		msg := fmt.Sprintf("Stripped SUID/SGID permission from %s", hdr.Name)
+		if tarOpts.InSubprocess {
+			fmt.Fprintf(os.Stderr, "%s\n", msg)
+		} else {
+			logrus.Info(msg)
+		}
+	}
 
 	// update also the implementation of ForceMask in pkg/chunked
-	if forceMask != nil {
-		mask = *forceMask
-		// If we have a forceMask, force the real type to either be a directory,
+	if tarOpts.ForceMask != nil {
+		mask = *tarOpts.ForceMask
+		// If we have a ForceMask, force the real type to either be a directory,
 		// a link, or a regular file.
 		if typeFlag != tar.TypeDir && typeFlag != tar.TypeSymlink && typeFlag != tar.TypeLink {
 			typeFlag = tar.TypeReg
@@ -751,7 +766,7 @@ func extractTarFileEntry(path, extractDir string, hdr *tar.Header, reader io.Rea
 		}
 
 	case tar.TypeBlock, tar.TypeChar:
-		if inUserns { // cannot create devices in a userns
+		if tarOpts.InUserNS { // cannot create devices in a userns
 			logrus.Debugf("Tar: Can't create device %v while running in user namespace", path)
 			return nil
 		}
@@ -801,8 +816,8 @@ func extractTarFileEntry(path, extractDir string, hdr *tar.Header, reader io.Rea
 		}
 		err := idtools.SafeLchown(path, chownOpts.UID, chownOpts.GID)
 		if err != nil {
-			if ignoreChownErrors {
-				fmt.Fprintf(os.Stderr, "Chown error detected. Ignoring due to ignoreChownErrors flag: %v\n", err)
+			if tarOpts.IgnoreChownErrors {
+				fmt.Fprintf(os.Stderr, "Chown error detected. Ignoring due to IgnoreChownErrors flag: %v\n", err)
 			} else {
 				return err
 			}
@@ -811,7 +826,7 @@ func extractTarFileEntry(path, extractDir string, hdr *tar.Header, reader io.Rea
 
 	// There is no LChmod, so ignore mode for symlink. Also, this
 	// must happen after chown, as that can modify the file mode
-	if err := handleLChmod(hdr, path, hdrInfo, forceMask); err != nil {
+	if err := handleLChmod(hdr, path, mask); err != nil {
 		return err
 	}
 
@@ -849,7 +864,7 @@ func extractTarFileEntry(path, extractDir string, hdr *tar.Header, reader io.Rea
 			continue
 		}
 		if err := system.Lsetxattr(path, xattrKey, []byte(value), 0); err != nil {
-			if errors.Is(err, system.ENOTSUP) || (inUserns && errors.Is(err, syscall.EPERM)) {
+			if errors.Is(err, system.ENOTSUP) || (tarOpts.InUserNS && errors.Is(err, syscall.EPERM)) {
 				// Ignore specific error cases:
 				// - ENOTSUP: Expected for graphdrivers lacking extended attribute support:
 				//   - Legacy AUFS versions
@@ -863,7 +878,7 @@ func extractTarFileEntry(path, extractDir string, hdr *tar.Header, reader io.Rea
 		}
 	}
 
-	if forceMask != nil && (typeFlag == tar.TypeReg || typeFlag == tar.TypeDir || runtime.GOOS == "darwin") {
+	if tarOpts.ForceMask != nil && (typeFlag == tar.TypeReg || typeFlag == tar.TypeDir || runtime.GOOS == "darwin") {
 		value := idtools.Stat{
 			IDs:   idtools.IDPair{UID: hdr.Uid, GID: hdr.Gid},
 			Mode:  hdrInfo.Mode(),
@@ -1205,7 +1220,7 @@ loop:
 			chownOpts = &idtools.IDPair{UID: hdr.Uid, GID: hdr.Gid}
 		}
 
-		if err = extractTarFileEntry(path, dest, hdr, trBuf, doChown, chownOpts, options.InUserNS, options.IgnoreChownErrors, options.ForceMask, buffer); err != nil {
+		if err = extractTarFileEntry(path, dest, hdr, trBuf, doChown, chownOpts, options, buffer); err != nil {
 			return err
 		}
 

--- a/storage/pkg/archive/archive_bsd.go
+++ b/storage/pkg/archive/archive_bsd.go
@@ -9,10 +9,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func handleLChmod(_ *tar.Header, path string, hdrInfo os.FileInfo, forceMask *os.FileMode) error {
-	permissionsMask := hdrInfo.Mode()
-	if forceMask != nil {
-		permissionsMask = *forceMask
-	}
-	return unix.Fchmodat(unix.AT_FDCWD, path, uint32(permissionsMask), unix.AT_SYMLINK_NOFOLLOW)
+func handleLChmod(_ *tar.Header, path string, mode os.FileMode) error {
+	return unix.Fchmodat(unix.AT_FDCWD, path, uint32(mode), unix.AT_SYMLINK_NOFOLLOW)
 }

--- a/storage/pkg/archive/archive_linux.go
+++ b/storage/pkg/archive/archive_linux.go
@@ -188,19 +188,15 @@ func GetFileOwner(path string) (uint32, uint32, uint32, error) {
 	return 0, 0, uint32(f.Mode()), nil
 }
 
-func handleLChmod(hdr *tar.Header, path string, hdrInfo os.FileInfo, forceMask *os.FileMode) error {
-	permissionsMask := hdrInfo.Mode()
-	if forceMask != nil {
-		permissionsMask = *forceMask
-	}
+func handleLChmod(hdr *tar.Header, path string, mode os.FileMode) error {
 	if hdr.Typeflag == tar.TypeLink {
 		if fi, err := os.Lstat(hdr.Linkname); err == nil && (fi.Mode()&os.ModeSymlink == 0) {
-			if err := os.Chmod(path, permissionsMask); err != nil {
+			if err := os.Chmod(path, mode); err != nil {
 				return err
 			}
 		}
 	} else if hdr.Typeflag != tar.TypeSymlink {
-		if err := os.Chmod(path, permissionsMask); err != nil {
+		if err := os.Chmod(path, mode); err != nil {
 			return err
 		}
 	}

--- a/storage/pkg/archive/archive_test.go
+++ b/storage/pkg/archive/archive_test.go
@@ -752,7 +752,7 @@ func TestTypeXGlobalHeaderDoesNotFail(t *testing.T) {
 	hdr := tar.Header{Typeflag: tar.TypeXGlobalHeader}
 	tmpDir := t.TempDir()
 	buffer := make([]byte, 1<<20)
-	err := extractTarFileEntry(filepath.Join(tmpDir, "pax_global_header"), tmpDir, &hdr, nil, true, nil, false, false, nil, buffer)
+	err := extractTarFileEntry(filepath.Join(tmpDir, "pax_global_header"), tmpDir, &hdr, nil, true, nil, &TarOptions{}, buffer)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/pkg/archive/archive_test.go
+++ b/storage/pkg/archive/archive_test.go
@@ -1290,6 +1290,126 @@ func (b *errorBuf) Close() error {
 	return nil
 }
 
+func TestStripSUIDSGID(t *testing.T) {
+	if runtime.GOOS == windows {
+		t.Skip("Skipping on Windows")
+	}
+
+	origin := t.TempDir()
+
+	// Create files with various SUID/SGID combinations.
+	// Use Go's os.FileMode constants (not raw octal like 0o4755,
+	// which has a different bit layout than os.ModeSetuid).
+	files := []struct {
+		name string
+		mode os.FileMode
+	}{
+		{"suid_file", os.ModeSetuid | 0o755},
+		{"sgid_file", os.ModeSetgid | 0o755},
+		{"suid_sgid_file", os.ModeSetuid | os.ModeSetgid | 0o755},
+		{"normal_file", 0o755},
+	}
+
+	for _, f := range files {
+		path := filepath.Join(origin, f.name)
+		err := os.WriteFile(path, []byte("hello"), 0o755)
+		require.NoError(t, err)
+		err = os.Chmod(path, f.mode)
+		require.NoError(t, err)
+		// Verify the bits were actually set on the source file.
+		info, err := os.Stat(path)
+		require.NoError(t, err)
+		require.Equal(t, f.mode, info.Mode()&(os.ModeSetuid|os.ModeSetgid|os.ModePerm),
+			"%s: source file mode not set correctly", f.name)
+	}
+
+	// Create a directory with SGID.
+	sgidDir := filepath.Join(origin, "sgid_dir")
+	err := os.Mkdir(sgidDir, 0o755)
+	require.NoError(t, err)
+	err = os.Chmod(sgidDir, os.ModeSetgid|0o755)
+	require.NoError(t, err)
+
+	// Tar the origin directory.
+	archive, err := TarWithOptions(origin, &TarOptions{Compression: Uncompressed})
+	require.NoError(t, err)
+	defer archive.Close()
+
+	// Extract with StripSUIDSGID enabled.
+	dst := t.TempDir()
+	err = UntarUncompressed(archive, dst, &TarOptions{StripSUIDSGID: true})
+	require.NoError(t, err)
+
+	// Verify SUID/SGID bits are stripped, base permissions preserved.
+	for _, f := range files {
+		info, err := os.Stat(filepath.Join(dst, f.name))
+		require.NoError(t, err)
+		mode := info.Mode()
+		assert.Zero(t, mode&os.ModeSetuid, "%s: SUID bit should be stripped", f.name)
+		assert.Zero(t, mode&os.ModeSetgid, "%s: SGID bit should be stripped", f.name)
+		assert.Equal(t, os.FileMode(0o755), mode.Perm(), "%s: base permissions should be preserved", f.name)
+	}
+
+	// Verify directory SGID is stripped.
+	info, err := os.Stat(filepath.Join(dst, "sgid_dir"))
+	require.NoError(t, err)
+	assert.Zero(t, info.Mode()&os.ModeSetgid, "sgid_dir: SGID bit should be stripped")
+	assert.Equal(t, os.FileMode(0o755), info.Mode().Perm(), "sgid_dir: base permissions should be preserved")
+}
+
+func TestStripSUIDSGIDDisabled(t *testing.T) {
+	if runtime.GOOS == windows {
+		t.Skip("Skipping on Windows")
+	}
+
+	origin := t.TempDir()
+
+	// Create files with SUID/SGID bits using Go os.FileMode constants.
+	files := []struct {
+		name string
+		mode os.FileMode
+	}{
+		{"suid_file", os.ModeSetuid | 0o755},
+		{"sgid_file", os.ModeSetgid | 0o755},
+		{"suid_sgid_file", os.ModeSetuid | os.ModeSetgid | 0o755},
+	}
+
+	for _, f := range files {
+		path := filepath.Join(origin, f.name)
+		err := os.WriteFile(path, []byte("hello"), 0o755)
+		require.NoError(t, err)
+		err = os.Chmod(path, f.mode)
+		require.NoError(t, err)
+	}
+
+	// Tar the origin directory.
+	archive, err := TarWithOptions(origin, &TarOptions{Compression: Uncompressed})
+	require.NoError(t, err)
+	defer archive.Close()
+
+	// Extract with StripSUIDSGID disabled.
+	dst := t.TempDir()
+	err = UntarUncompressed(archive, dst, &TarOptions{StripSUIDSGID: false})
+	require.NoError(t, err)
+
+	// Verify SUID/SGID bits are preserved.
+	expected := map[string]os.FileMode{
+		"suid_file":      os.ModeSetuid,
+		"sgid_file":      os.ModeSetgid,
+		"suid_sgid_file": os.ModeSetuid | os.ModeSetgid,
+	}
+
+	for _, f := range files {
+		info, err := os.Stat(filepath.Join(dst, f.name))
+		require.NoError(t, err)
+		mode := info.Mode()
+		assert.Equal(t, expected[f.name], mode&(os.ModeSetuid|os.ModeSetgid),
+			"%s: SUID/SGID bits should be preserved", f.name)
+		assert.Equal(t, os.FileMode(0o755), mode.Perm(),
+			"%s: base permissions should be preserved", f.name)
+	}
+}
+
 func TestTarErrorHandling(t *testing.T) {
 	dir := t.TempDir()
 

--- a/storage/pkg/archive/archive_windows.go
+++ b/storage/pkg/archive/archive_windows.go
@@ -67,7 +67,7 @@ func handleTarTypeBlockCharFifo(_ *tar.Header, _ string) error {
 	return nil
 }
 
-func handleLChmod(_ *tar.Header, _ string, _ os.FileInfo, _ *os.FileMode) error {
+func handleLChmod(_ *tar.Header, _ string, _ os.FileMode) error {
 	return nil
 }
 

--- a/storage/pkg/archive/diff.go
+++ b/storage/pkg/archive/diff.go
@@ -104,7 +104,7 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 					}
 					defer os.RemoveAll(aufsTempdir)
 				}
-				if err := extractTarFileEntry(filepath.Join(aufsTempdir, basename), dest, hdr, tr, true, nil, options.InUserNS, options.IgnoreChownErrors, options.ForceMask, buffer); err != nil {
+				if err := extractTarFileEntry(filepath.Join(aufsTempdir, basename), dest, hdr, tr, true, nil, options, buffer); err != nil {
 					return 0, err
 				}
 			}
@@ -209,7 +209,7 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 				return 0, err
 			}
 
-			if err := extractTarFileEntry(path, dest, srcHdr, srcData, true, nil, options.InUserNS, options.IgnoreChownErrors, options.ForceMask, buffer); err != nil {
+			if err := extractTarFileEntry(path, dest, srcHdr, srcData, true, nil, options, buffer); err != nil {
 				return 0, err
 			}
 

--- a/storage/pkg/chrootarchive/archive_unix.go
+++ b/storage/pkg/chrootarchive/archive_unix.go
@@ -16,6 +16,7 @@ import (
 
 	"golang.org/x/sys/unix"
 
+	"github.com/sirupsen/logrus"
 	"go.podman.io/storage/pkg/archive"
 	"go.podman.io/storage/pkg/reexec"
 )
@@ -148,6 +149,7 @@ func invokeUnpack(decompressedArchive io.Reader, dest *unpackDestination, option
 	}
 
 	// write the options to the pipe for the untar exec to read
+	options.InSubprocess = true
 	if err := json.NewEncoder(w).Encode(options); err != nil {
 		w.Close()
 		return fmt.Errorf("untar json encode to pipe failed: %w", err)
@@ -164,6 +166,12 @@ func invokeUnpack(decompressedArchive io.Reader, dest *unpackDestination, option
 		}
 
 		return errorOut
+	} else if output.Len() > 0 {
+		for _, line := range strings.Split(strings.TrimRight(output.String(), "\n"), "\n") {
+			if line != "" {
+				logrus.Info(line)
+			}
+		}
 	}
 	return nil
 }

--- a/storage/pkg/chunked/storage_linux.go
+++ b/storage/pkg/chunked/storage_linux.go
@@ -836,6 +836,9 @@ func (d *destinationFile) Close() (Err error) {
 	}
 
 	mode := os.FileMode(d.metadata.Mode)
+	if d.options.StripSUIDSGID {
+		mode &^= 0o6000
+	}
 	if d.options.ForceMask != nil {
 		mode = *d.options.ForceMask
 	}
@@ -1629,6 +1632,10 @@ func (c *chunkedDiffer) ApplyDiff(dest string, options *archive.TarOptions, diff
 		r := &mergedEntries[i]
 
 		mode := os.FileMode(r.Mode)
+		if options.StripSUIDSGID && mode&0o6000 != 0 {
+			mode &^= 0o6000
+			logrus.Infof("Stripped SUID/SGID permission from %s", r.Name)
+		}
 
 		t, err := typeToTarType(r.Type)
 		if err != nil {

--- a/storage/pkg/config/config.go
+++ b/storage/pkg/config/config.go
@@ -87,6 +87,10 @@ type OptionsConfig struct {
 	// files and directories.
 	ForceMask os.FileMode `toml:"force_mask,omitempty"`
 
+	// If set, SUID and SGID bits are stripped from the mode of all files,
+	// directories, etc., when image layers are extracted.
+	StripSUIDSGID bool `toml:"strip_suid_sgid,omitempty"`
+
 	// RootAutoUsernsUser is the name of one or more entries in /etc/subuid and
 	// /etc/subgid which should be used to set up automatically a userns.
 	RootAutoUsernsUser string `toml:"root-auto-userns-user,omitempty"`

--- a/storage/storage.conf
+++ b/storage/storage.conf
@@ -48,6 +48,10 @@
 # Must be comma separated list.
 # additionalimagestores = []
 
+# If set to true, the SUID and SGID bits of all filesystem object modes are set
+# to zero when they are extracted from image layers.
+# strip_suid_sgid = false
+
 # Options controlling how storage is populated when pulling images.
 [storage.options.pull_options]
 # Enable the "zstd:chunked" feature, which allows partial pulls, reusing

--- a/storage/storage.conf-freebsd
+++ b/storage/storage.conf-freebsd
@@ -47,6 +47,10 @@
 # Auto-userns-max-size is the maximum size for a user namespace created automatically.
 # auto-userns-max-size=65536
 
+# If set to true, the SUID and SGID bits of all filesystem object modes are set
+# to zero when they are extracted from image layers.
+# strip_suid_sgid = false
+
 [storage.options.overlay]
 # ignore_chown_errors can be set to allow a non privileged user running with
 # a single UID within a user namespace to run containers. The user can pull

--- a/storage/store.go
+++ b/storage/store.go
@@ -774,6 +774,7 @@ type store struct {
 	digestLockRoot  string
 	disableVolatile bool
 	transientStore  bool
+	stripSUIDSGID   bool
 
 	// The following fields can only be accessed with graphLock held.
 	graphLockLastWrite lockfile.LastWrite
@@ -897,12 +898,17 @@ func GetStore(options types.StoreOptions) (Store, error) {
 		autoNsMaxSize:       autoNsMaxSize,
 		disableVolatile:     options.DisableVolatile,
 		transientStore:      options.TransientStore,
+		stripSUIDSGID:       options.StripSUIDSGID,
 
 		additionalUIDs: nil,
 		additionalGIDs: nil,
 	}
 	if err := s.load(); err != nil {
 		return nil, err
+	}
+
+	if s.stripSUIDSGID {
+		logrus.Debugf("Stripping SUID/SGID bits from files extracted to %s", s.graphRoot)
 	}
 
 	stores = append(stores, s)

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -10,7 +10,16 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.podman.io/storage/pkg/idtools"
 	"go.podman.io/storage/pkg/reexec"
+	"go.podman.io/storage/pkg/unshare"
 )
+
+func TestMain(m *testing.M) {
+	if reexec.Init() {
+		return
+	}
+	unshare.MaybeReexecUsingUserNamespace(false)
+	os.Exit(m.Run())
+}
 
 func newTestStore(t *testing.T, testOptions StoreOptions) Store {
 	wd := t.TempDir()

--- a/storage/strip_suid_sgid_test.go
+++ b/storage/strip_suid_sgid_test.go
@@ -1,0 +1,577 @@
+package storage
+
+import (
+	"archive/tar"
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	drivers "go.podman.io/storage/drivers"
+	"go.podman.io/storage/pkg/reexec"
+)
+
+type tarEntry struct {
+	Name    string
+	Mode    os.FileMode
+	IsDir   bool
+	Content string
+}
+
+// makeTarWithPermissions creates a tar archive containing entries with the
+// specified names, permission modes, and content.
+func makeTarWithPermissions(entries []tarEntry) io.Reader {
+	buf := new(bytes.Buffer)
+	tw := tar.NewWriter(buf)
+	for _, e := range entries {
+		hdr := &tar.Header{
+			Name: e.Name,
+			Mode: int64(e.Mode),
+			Size: int64(len(e.Content)),
+		}
+		if e.IsDir {
+			hdr.Typeflag = tar.TypeDir
+			hdr.Size = 0
+		} else {
+			hdr.Typeflag = tar.TypeReg
+		}
+		_ = tw.WriteHeader(hdr)
+		if len(e.Content) > 0 {
+			_, _ = tw.Write([]byte(e.Content))
+		}
+	}
+	_ = tw.Close()
+	return buf
+}
+
+// getFileMode returns the permission bits (including SUID/SGID/sticky) of the
+// file at the given path.
+func getFileMode(t *testing.T, path string) os.FileMode {
+	t.Helper()
+	fi, err := os.Lstat(path)
+	require.NoError(t, err)
+	return fi.Mode().Perm() | (fi.Mode() & (os.ModeSetuid | os.ModeSetgid | os.ModeSticky))
+}
+
+// TestStripSUIDSGIDDisabledPreservesPermissions verifies that when strip_suid_sgid
+// is false (the default), SUID and SGID bits in the layer data are preserved as-is
+// during extraction via ApplyDiff.
+func TestStripSUIDSGIDDisabledPreservesPermissions(t *testing.T) {
+	reexec.Init()
+
+	store := newTestStore(t, StoreOptions{})
+	defer store.Free()
+
+	layer, err := store.CreateLayer("", "", nil, "", false, nil)
+	require.NoError(t, err)
+
+	diff := makeTarWithPermissions([]tarEntry{
+		{Name: "suid_file", Mode: 0o4755},
+		{Name: "sgid_file", Mode: 0o2755},
+		{Name: "both_file", Mode: 0o6755},
+		{Name: "normal_file", Mode: 0o0755},
+		{Name: "suid_dir/", Mode: 0o4755, IsDir: true},
+		{Name: "sgid_dir/", Mode: 0o2755, IsDir: true},
+	})
+
+	_, err = store.ApplyDiff(layer.ID, diff)
+	require.NoError(t, err)
+
+	mountPoint, err := store.Mount(layer.ID, "")
+	require.NoError(t, err)
+	defer func() {
+		_, _ = store.Unmount(layer.ID, true)
+	}()
+
+	mode := getFileMode(t, filepath.Join(mountPoint, "suid_file"))
+	assert.NotZero(t, mode&os.ModeSetuid, "SUID bit should be preserved when strip_suid_sgid is disabled")
+
+	mode = getFileMode(t, filepath.Join(mountPoint, "sgid_file"))
+	assert.NotZero(t, mode&os.ModeSetgid, "SGID bit should be preserved when strip_suid_sgid is disabled")
+
+	mode = getFileMode(t, filepath.Join(mountPoint, "both_file"))
+	assert.NotZero(t, mode&os.ModeSetuid, "SUID bit should be preserved when strip_suid_sgid is disabled")
+	assert.NotZero(t, mode&os.ModeSetgid, "SGID bit should be preserved when strip_suid_sgid is disabled")
+
+	mode = getFileMode(t, filepath.Join(mountPoint, "normal_file"))
+	assert.Zero(t, mode&os.ModeSetuid, "normal file should not have SUID")
+	assert.Zero(t, mode&os.ModeSetgid, "normal file should not have SGID")
+	assert.Equal(t, os.FileMode(0o755), mode&os.ModePerm, "normal file permissions should be 0755")
+
+	mode = getFileMode(t, filepath.Join(mountPoint, "suid_dir"))
+	assert.NotZero(t, mode&os.ModeSetuid, "SUID bit on directory should be preserved when strip_suid_sgid is disabled")
+
+	mode = getFileMode(t, filepath.Join(mountPoint, "sgid_dir"))
+	assert.NotZero(t, mode&os.ModeSetgid, "SGID bit on directory should be preserved when strip_suid_sgid is disabled")
+}
+
+// TestStripSUIDSGIDDefaultIsFalse verifies that the default value of strip_suid_sgid
+// is false, so SUID/SGID bits are preserved when the option is not explicitly set.
+func TestStripSUIDSGIDDefaultIsFalse(t *testing.T) {
+	reexec.Init()
+
+	store := newTestStore(t, StoreOptions{})
+	defer store.Free()
+
+	layer, _, err := store.PutLayer("", "", nil, "", false, nil,
+		makeTarWithPermissions([]tarEntry{
+			{Name: "suid_binary", Mode: 0o4755, Content: "binary"},
+			{Name: "sgid_binary", Mode: 0o2755, Content: "binary"},
+		}),
+	)
+	require.NoError(t, err)
+
+	mountPoint, err := store.Mount(layer.ID, "")
+	require.NoError(t, err)
+	defer func() {
+		_, _ = store.Unmount(layer.ID, true)
+	}()
+
+	mode := getFileMode(t, filepath.Join(mountPoint, "suid_binary"))
+	assert.NotZero(t, mode&os.ModeSetuid, "SUID should be preserved by default")
+
+	mode = getFileMode(t, filepath.Join(mountPoint, "sgid_binary"))
+	assert.NotZero(t, mode&os.ModeSetgid, "SGID should be preserved by default")
+}
+
+// TestStripSUIDSGIDEnabledStripsViaApplyDiff verifies the tar path: when strip_suid_sgid
+// is true, ApplyDiff strips SUID and SGID bits from all entry types while preserving
+// other permission bits.
+func TestStripSUIDSGIDEnabledStripsViaApplyDiff(t *testing.T) {
+	reexec.Init()
+
+	store := newTestStore(t, StoreOptions{
+		StripSUIDSGID: true,
+	})
+	defer store.Free()
+
+	layer, err := store.CreateLayer("", "", nil, "", false, nil)
+	require.NoError(t, err)
+
+	diff := makeTarWithPermissions([]tarEntry{
+		{Name: "suid_file", Mode: 0o4755, Content: "suid content"},
+		{Name: "sgid_file", Mode: 0o2755, Content: "sgid content"},
+		{Name: "both_file", Mode: 0o6755, Content: "both content"},
+		{Name: "normal_file", Mode: 0o0755, Content: "normal content"},
+		{Name: "suid_dir/", Mode: 0o4755, IsDir: true},
+		{Name: "sgid_dir/", Mode: 0o2755, IsDir: true},
+		{Name: "both_dir/", Mode: 0o6755, IsDir: true},
+		{Name: "normal_dir/", Mode: 0o0755, IsDir: true},
+	})
+
+	_, err = store.ApplyDiff(layer.ID, diff)
+	require.NoError(t, err)
+
+	mountPoint, err := store.Mount(layer.ID, "")
+	require.NoError(t, err)
+	defer func() {
+		_, _ = store.Unmount(layer.ID, true)
+	}()
+
+	// Files: SUID/SGID stripped, base permissions preserved.
+	mode := getFileMode(t, filepath.Join(mountPoint, "suid_file"))
+	assert.Zero(t, mode&os.ModeSetuid, "SUID bit should be stripped")
+	assert.Equal(t, os.FileMode(0o755), mode&os.ModePerm, "base permissions should be preserved")
+
+	mode = getFileMode(t, filepath.Join(mountPoint, "sgid_file"))
+	assert.Zero(t, mode&os.ModeSetgid, "SGID bit should be stripped")
+	assert.Equal(t, os.FileMode(0o755), mode&os.ModePerm, "base permissions should be preserved")
+
+	mode = getFileMode(t, filepath.Join(mountPoint, "both_file"))
+	assert.Zero(t, mode&os.ModeSetuid, "SUID bit should be stripped")
+	assert.Zero(t, mode&os.ModeSetgid, "SGID bit should be stripped")
+	assert.Equal(t, os.FileMode(0o755), mode&os.ModePerm, "base permissions should be preserved")
+
+	mode = getFileMode(t, filepath.Join(mountPoint, "normal_file"))
+	assert.Zero(t, mode&os.ModeSetuid, "normal file should not have SUID")
+	assert.Zero(t, mode&os.ModeSetgid, "normal file should not have SGID")
+	assert.Equal(t, os.FileMode(0o755), mode&os.ModePerm, "normal file permissions should be 0755")
+
+	// Directories: SUID/SGID stripped.
+	mode = getFileMode(t, filepath.Join(mountPoint, "suid_dir"))
+	assert.Zero(t, mode&os.ModeSetuid, "SUID bit on directory should be stripped")
+
+	mode = getFileMode(t, filepath.Join(mountPoint, "sgid_dir"))
+	assert.Zero(t, mode&os.ModeSetgid, "SGID bit on directory should be stripped")
+
+	mode = getFileMode(t, filepath.Join(mountPoint, "both_dir"))
+	assert.Zero(t, mode&os.ModeSetuid, "SUID bit on directory should be stripped")
+	assert.Zero(t, mode&os.ModeSetgid, "SGID bit on directory should be stripped")
+
+	mode = getFileMode(t, filepath.Join(mountPoint, "normal_dir"))
+	assert.Equal(t, os.FileMode(0o755), mode&os.ModePerm, "normal directory permissions should be 0755")
+}
+
+// TestStripSUIDSGIDEnabledStripsViaPutLayer verifies the tar path via PutLayer:
+// when strip_suid_sgid is true, SUID and SGID bits are stripped during layer creation.
+func TestStripSUIDSGIDEnabledStripsViaPutLayer(t *testing.T) {
+	reexec.Init()
+
+	store := newTestStore(t, StoreOptions{
+		StripSUIDSGID: true,
+	})
+	defer store.Free()
+
+	diff := makeTarWithPermissions([]tarEntry{
+		{Name: "suid_file", Mode: 0o4755, Content: "data"},
+		{Name: "sgid_file", Mode: 0o2755, Content: "data"},
+		{Name: "both_file", Mode: 0o6755, Content: "data"},
+		{Name: "normal_file", Mode: 0o0644, Content: "data"},
+	})
+
+	layer, _, err := store.PutLayer("", "", nil, "", false, nil, diff)
+	require.NoError(t, err)
+
+	mountPoint, err := store.Mount(layer.ID, "")
+	require.NoError(t, err)
+	defer func() {
+		_, _ = store.Unmount(layer.ID, true)
+	}()
+
+	mode := getFileMode(t, filepath.Join(mountPoint, "suid_file"))
+	assert.Zero(t, mode&os.ModeSetuid, "SUID bit should be stripped via PutLayer")
+	assert.Equal(t, os.FileMode(0o755), mode&os.ModePerm, "base permissions should be preserved")
+
+	mode = getFileMode(t, filepath.Join(mountPoint, "sgid_file"))
+	assert.Zero(t, mode&os.ModeSetgid, "SGID bit should be stripped via PutLayer")
+	assert.Equal(t, os.FileMode(0o755), mode&os.ModePerm, "base permissions should be preserved")
+
+	mode = getFileMode(t, filepath.Join(mountPoint, "both_file"))
+	assert.Zero(t, mode&os.ModeSetuid, "SUID bit should be stripped via PutLayer")
+	assert.Zero(t, mode&os.ModeSetgid, "SGID bit should be stripped via PutLayer")
+
+	mode = getFileMode(t, filepath.Join(mountPoint, "normal_file"))
+	assert.Zero(t, mode&os.ModeSetuid, "normal file should not have SUID")
+	assert.Zero(t, mode&os.ModeSetgid, "normal file should not have SGID")
+	assert.Equal(t, os.FileMode(0o644), mode&os.ModePerm, "normal file permissions should be 0644")
+}
+
+// TestStripSUIDSGIDPreservesOtherBits verifies that when strip_suid_sgid is true,
+// only SUID and SGID bits are cleared. The sticky bit and all rwxrwxrwx bits are
+// preserved unchanged.
+func TestStripSUIDSGIDPreservesOtherBits(t *testing.T) {
+	reexec.Init()
+
+	store := newTestStore(t, StoreOptions{
+		StripSUIDSGID: true,
+	})
+	defer store.Free()
+
+	layer, err := store.CreateLayer("", "", nil, "", false, nil)
+	require.NoError(t, err)
+
+	diff := makeTarWithPermissions([]tarEntry{
+		{Name: "sticky_suid", Mode: 0o5755, Content: "data"},
+		{Name: "sticky_sgid", Mode: 0o3755, Content: "data"},
+		{Name: "all_bits", Mode: 0o7777, Content: "data"},
+		{Name: "restricted", Mode: 0o4700, Content: "data"},
+		{Name: "read_only", Mode: 0o2444, Content: "data"},
+		{Name: "sticky_dir/", Mode: 0o1755, IsDir: true},
+		{Name: "sticky_suid_dir/", Mode: 0o5755, IsDir: true},
+	})
+
+	_, err = store.ApplyDiff(layer.ID, diff)
+	require.NoError(t, err)
+
+	mountPoint, err := store.Mount(layer.ID, "")
+	require.NoError(t, err)
+	defer func() {
+		_, _ = store.Unmount(layer.ID, true)
+	}()
+
+	// sticky + SUID: SUID stripped, sticky and rwxr-xr-x preserved.
+	mode := getFileMode(t, filepath.Join(mountPoint, "sticky_suid"))
+	assert.Zero(t, mode&os.ModeSetuid, "SUID should be stripped")
+	assert.NotZero(t, mode&os.ModeSticky, "sticky bit should be preserved")
+	assert.Equal(t, os.FileMode(0o755), mode&os.ModePerm, "base permissions should be preserved")
+
+	// sticky + SGID: SGID stripped, sticky and rwxr-xr-x preserved.
+	mode = getFileMode(t, filepath.Join(mountPoint, "sticky_sgid"))
+	assert.Zero(t, mode&os.ModeSetgid, "SGID should be stripped")
+	assert.NotZero(t, mode&os.ModeSticky, "sticky bit should be preserved")
+	assert.Equal(t, os.FileMode(0o755), mode&os.ModePerm, "base permissions should be preserved")
+
+	// All special bits: SUID and SGID stripped, sticky and rwxrwxrwx preserved.
+	mode = getFileMode(t, filepath.Join(mountPoint, "all_bits"))
+	assert.Zero(t, mode&os.ModeSetuid, "SUID should be stripped")
+	assert.Zero(t, mode&os.ModeSetgid, "SGID should be stripped")
+	assert.NotZero(t, mode&os.ModeSticky, "sticky bit should be preserved")
+	assert.Equal(t, os.FileMode(0o777), mode&os.ModePerm, "rwxrwxrwx should be preserved")
+
+	// SUID + rwx------: SUID stripped, rwx------ preserved.
+	mode = getFileMode(t, filepath.Join(mountPoint, "restricted"))
+	assert.Zero(t, mode&os.ModeSetuid, "SUID should be stripped")
+	assert.Equal(t, os.FileMode(0o700), mode&os.ModePerm, "base permissions should be 0700")
+
+	// SGID + r--r--r--: SGID stripped, r--r--r-- preserved.
+	mode = getFileMode(t, filepath.Join(mountPoint, "read_only"))
+	assert.Zero(t, mode&os.ModeSetgid, "SGID should be stripped")
+	assert.Equal(t, os.FileMode(0o444), mode&os.ModePerm, "base permissions should be 0444")
+
+	// Sticky-only dir: not affected (no SUID/SGID to strip).
+	mode = getFileMode(t, filepath.Join(mountPoint, "sticky_dir"))
+	assert.NotZero(t, mode&os.ModeSticky, "sticky bit should be preserved")
+	assert.Zero(t, mode&os.ModeSetuid, "dir should not have SUID")
+	assert.Zero(t, mode&os.ModeSetgid, "dir should not have SGID")
+
+	// Sticky + SUID dir: SUID stripped, sticky preserved.
+	mode = getFileMode(t, filepath.Join(mountPoint, "sticky_suid_dir"))
+	assert.Zero(t, mode&os.ModeSetuid, "SUID should be stripped from directory")
+	assert.NotZero(t, mode&os.ModeSticky, "sticky bit should be preserved on directory")
+}
+
+// TestStripSUIDSGIDOnlyAffectsSUIDSGID verifies that entries without SUID or SGID
+// bits are not affected at all by strip_suid_sgid=true.
+func TestStripSUIDSGIDOnlyAffectsSUIDSGID(t *testing.T) {
+	reexec.Init()
+
+	store := newTestStore(t, StoreOptions{
+		StripSUIDSGID: true,
+	})
+	defer store.Free()
+
+	diff := makeTarWithPermissions([]tarEntry{
+		{Name: "perm_000", Mode: 0o000, Content: "data"},
+		{Name: "perm_644", Mode: 0o644, Content: "data"},
+		{Name: "perm_755", Mode: 0o755, Content: "data"},
+		{Name: "perm_777", Mode: 0o777, Content: "data"},
+		{Name: "sticky_only", Mode: 0o1755, Content: "data"},
+		{Name: "dir_755/", Mode: 0o755, IsDir: true},
+		{Name: "dir_700/", Mode: 0o700, IsDir: true},
+	})
+
+	layer, _, err := store.PutLayer("", "", nil, "", false, nil, diff)
+	require.NoError(t, err)
+
+	mountPoint, err := store.Mount(layer.ID, "")
+	require.NoError(t, err)
+	defer func() {
+		_, _ = store.Unmount(layer.ID, true)
+	}()
+
+	mode := getFileMode(t, filepath.Join(mountPoint, "perm_644"))
+	assert.Equal(t, os.FileMode(0o644), mode&os.ModePerm)
+
+	mode = getFileMode(t, filepath.Join(mountPoint, "perm_755"))
+	assert.Equal(t, os.FileMode(0o755), mode&os.ModePerm)
+
+	mode = getFileMode(t, filepath.Join(mountPoint, "perm_777"))
+	assert.Equal(t, os.FileMode(0o777), mode&os.ModePerm)
+
+	mode = getFileMode(t, filepath.Join(mountPoint, "sticky_only"))
+	assert.NotZero(t, mode&os.ModeSticky, "sticky bit should be preserved")
+	assert.Equal(t, os.FileMode(0o755), mode&os.ModePerm)
+
+	mode = getFileMode(t, filepath.Join(mountPoint, "dir_755"))
+	assert.Equal(t, os.FileMode(0o755), mode&os.ModePerm)
+
+	mode = getFileMode(t, filepath.Join(mountPoint, "dir_700"))
+	assert.Equal(t, os.FileMode(0o700), mode&os.ModePerm)
+}
+
+// TestStripSUIDSGIDMultipleLayers verifies that strip_suid_sgid applies to all
+// layer extraction operations, including stacked layers.
+func TestStripSUIDSGIDMultipleLayers(t *testing.T) {
+	reexec.Init()
+
+	store := newTestStore(t, StoreOptions{
+		StripSUIDSGID: true,
+	})
+	defer store.Free()
+
+	layer1, _, err := store.PutLayer("", "", nil, "", false, nil,
+		makeTarWithPermissions([]tarEntry{
+			{Name: "suid_file", Mode: 0o4755, Content: "v1"},
+		}),
+	)
+	require.NoError(t, err)
+
+	layer2, _, err := store.PutLayer("", layer1.ID, nil, "", false, nil,
+		makeTarWithPermissions([]tarEntry{
+			{Name: "another_suid", Mode: 0o4755, Content: "v2"},
+		}),
+	)
+	require.NoError(t, err)
+
+	mountPoint, err := store.Mount(layer2.ID, "")
+	require.NoError(t, err)
+	defer func() {
+		_, _ = store.Unmount(layer2.ID, true)
+	}()
+
+	mode := getFileMode(t, filepath.Join(mountPoint, "suid_file"))
+	assert.Zero(t, mode&os.ModeSetuid, "SUID should be stripped in parent layer")
+
+	mode = getFileMode(t, filepath.Join(mountPoint, "another_suid"))
+	assert.Zero(t, mode&os.ModeSetuid, "SUID should be stripped in child layer")
+}
+
+// TestStripSUIDSGIDVariousPermCombinations is a table-driven test covering
+// many permission combinations to verify correct stripping behavior.
+func TestStripSUIDSGIDVariousPermCombinations(t *testing.T) {
+	reexec.Init()
+
+	store := newTestStore(t, StoreOptions{
+		StripSUIDSGID: true,
+	})
+	defer store.Free()
+
+	tests := []struct {
+		name         string
+		inputMode    os.FileMode
+		expectSUID   bool
+		expectSGID   bool
+		expectSticky bool
+		expectPerm   os.FileMode
+	}{
+		{"suid_rwxrwxrwx", 0o4777, false, false, false, 0o777},
+		{"sgid_rwxrwxrwx", 0o2777, false, false, false, 0o777},
+		{"suid_sgid_rwxrwxrwx", 0o6777, false, false, false, 0o777},
+		{"suid_rwx------", 0o4700, false, false, false, 0o700},
+		{"sgid_rwxr-x---", 0o2750, false, false, false, 0o750},
+		{"sticky_suid_sgid", 0o7755, false, false, true, 0o755},
+		{"no_special_bits", 0o644, false, false, false, 0o644},
+		{"sticky_only", 0o1755, false, false, true, 0o755},
+	}
+
+	entries := make([]tarEntry, len(tests))
+	for i, tc := range tests {
+		entries[i] = tarEntry{
+			Name:    tc.name,
+			Mode:    tc.inputMode,
+			Content: "data",
+		}
+	}
+
+	layer, _, err := store.PutLayer("", "", nil, "", false, nil,
+		makeTarWithPermissions(entries))
+	require.NoError(t, err)
+
+	mountPoint, err := store.Mount(layer.ID, "")
+	require.NoError(t, err)
+	defer func() {
+		_, _ = store.Unmount(layer.ID, true)
+	}()
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mode := getFileMode(t, filepath.Join(mountPoint, tc.name))
+			if tc.expectSUID {
+				assert.NotZero(t, mode&os.ModeSetuid, "expected SUID to be set")
+			} else {
+				assert.Zero(t, mode&os.ModeSetuid, "expected SUID to be cleared")
+			}
+			if tc.expectSGID {
+				assert.NotZero(t, mode&os.ModeSetgid, "expected SGID to be set")
+			} else {
+				assert.Zero(t, mode&os.ModeSetgid, "expected SGID to be cleared")
+			}
+			if tc.expectSticky {
+				assert.NotZero(t, mode&os.ModeSticky, "expected sticky to be set")
+			} else {
+				assert.Zero(t, mode&os.ModeSticky, "expected sticky to be cleared")
+			}
+			assert.Equal(t, tc.expectPerm, mode&os.ModePerm, "base permission mismatch")
+		})
+	}
+}
+
+// TestStripSUIDSGIDPerCallOverrideNilUsesStoreDefault verifies that when the
+// per-call override (StripSUIDSGID *bool in ApplyDiffWithDifferOpts) is nil, the
+// store's configured strip_suid_sgid value is used. This test uses PutLayer (tar path)
+// since it always uses the store default.
+func TestStripSUIDSGIDPerCallOverrideNilUsesStoreDefault(t *testing.T) {
+	reexec.Init()
+
+	store := newTestStore(t, StoreOptions{
+		StripSUIDSGID: true,
+	})
+	defer store.Free()
+
+	layer, _, err := store.PutLayer("", "", nil, "", false, nil,
+		makeTarWithPermissions([]tarEntry{
+			{Name: "suid_file", Mode: 0o4755, Content: "data"},
+		}),
+	)
+	require.NoError(t, err)
+
+	mountPoint, err := store.Mount(layer.ID, "")
+	require.NoError(t, err)
+	defer func() {
+		_, _ = store.Unmount(layer.ID, true)
+	}()
+
+	mode := getFileMode(t, filepath.Join(mountPoint, "suid_file"))
+	assert.Zero(t, mode&os.ModeSetuid, "SUID should be stripped using store default when override is nil")
+}
+
+// TestStripSUIDSGIDApplyDiffWithDifferOptsField verifies that the
+// ApplyDiffWithDifferOpts struct supports a StripSUIDSGID *bool field for
+// per-call overrides used by PrepareStagedLayer and ApplyStagedLayer.
+func TestStripSUIDSGIDApplyDiffWithDifferOptsField(t *testing.T) {
+	// Verify the StripSUIDSGID field exists on ApplyDiffWithDifferOpts and
+	// follows the three-valued convention: nil means use store default,
+	// non-nil overrides it.
+	stripTrue := true
+	stripFalse := false
+
+	optsNil := drivers.ApplyDiffWithDifferOpts{}
+	assert.Nil(t, optsNil.StripSUIDSGID, "default should be nil (use store default)")
+
+	optsTrue := drivers.ApplyDiffWithDifferOpts{
+		ApplyDiffOpts: drivers.ApplyDiffOpts{StripSUIDSGID: &stripTrue},
+	}
+	require.NotNil(t, optsTrue.StripSUIDSGID)
+	assert.True(t, *optsTrue.StripSUIDSGID, "should override to true")
+
+	optsFalse := drivers.ApplyDiffWithDifferOpts{
+		ApplyDiffOpts: drivers.ApplyDiffOpts{StripSUIDSGID: &stripFalse},
+	}
+	require.NotNil(t, optsFalse.StripSUIDSGID)
+	assert.False(t, *optsFalse.StripSUIDSGID, "should override to false")
+}
+
+// TestStripSUIDSGIDWithForceMaskInteraction verifies the documented interaction
+// between strip_suid_sgid and force_mask: when force_mask is configured, it
+// replaces the entire permission mode, so strip_suid_sgid has no observable
+// effect. This test verifies the behavior using the VFS driver (where
+// force_mask is not active on Linux), confirming that strip_suid_sgid alone
+// produces the expected result. The spec guarantees that force_mask, when
+// active, replaces all permissions including any SUID/SGID bits, making
+// strip_suid_sgid redundant.
+func TestStripSUIDSGIDWithForceMaskInteraction(t *testing.T) {
+	reexec.Init()
+
+	// With strip_suid_sgid=true and no force_mask, SUID/SGID are stripped.
+	storeStrip := newTestStore(t, StoreOptions{
+		StripSUIDSGID: true,
+	})
+	defer storeStrip.Free()
+
+	diff := makeTarWithPermissions([]tarEntry{
+		{Name: "suid_file", Mode: 0o4700, Content: "data"},
+		{Name: "normal_file", Mode: 0o0600, Content: "data"},
+	})
+
+	layer, _, err := storeStrip.PutLayer("", "", nil, "", false, nil, diff)
+	require.NoError(t, err)
+
+	mountPoint, err := storeStrip.Mount(layer.ID, "")
+	require.NoError(t, err)
+	defer func() {
+		_, _ = storeStrip.Unmount(layer.ID, true)
+	}()
+
+	// strip_suid_sgid strips SUID but preserves base permissions.
+	mode := getFileMode(t, filepath.Join(mountPoint, "suid_file"))
+	assert.Zero(t, mode&os.ModeSetuid, "SUID should be stripped")
+	assert.Equal(t, os.FileMode(0o700), mode&os.ModePerm, "base permissions should be 0700")
+
+	// Normal file is unaffected.
+	mode = getFileMode(t, filepath.Join(mountPoint, "normal_file"))
+	assert.Zero(t, mode&os.ModeSetuid, "no SUID on normal file")
+	assert.Equal(t, os.FileMode(0o600), mode&os.ModePerm, "base permissions should be 0600")
+}

--- a/storage/tests/strip-suid-sgid.bats
+++ b/storage/tests/strip-suid-sgid.bats
@@ -1,0 +1,170 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "strip-suid-sgid via staging directory" {
+	case "$STORAGE_DRIVER" in
+	overlay*)
+		;;
+	*)
+		skip "driver $STORAGE_DRIVER does not support diff-from-staging-directory"
+		;;
+	esac
+
+	# Create source directory with SUID/SGID files.
+	SRC=$TESTDIR/source
+	mkdir -p $SRC
+	createrandom $SRC/suid_file
+	chmod 4755 $SRC/suid_file
+	createrandom $SRC/sgid_file
+	chmod 2755 $SRC/sgid_file
+	createrandom $SRC/suid_sgid_file
+	chmod 6755 $SRC/suid_sgid_file
+	createrandom $SRC/normal_file
+	chmod 0755 $SRC/normal_file
+
+	local sconf=$TESTDIR/storage.conf
+
+	local root=`storage status 2>&1 | awk '/^Root:/{print $2}'`
+	local runroot=`storage status 2>&1 | awk '/^Run Root:/{print $3}'`
+
+	cat >$sconf <<EOF
+[storage]
+driver="overlay"
+graphroot="$root"
+runroot="$runroot"
+
+[storage.options]
+strip_suid_sgid = true
+
+[storage.options.pull_options]
+enable_partial_images = "true"
+convert_images = "true"
+EOF
+
+	# Create a layer.
+	CONTAINERS_STORAGE_CONF=$sconf run ${STORAGE_BINARY} create-layer
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	layer="$output"
+
+	CONTAINERS_STORAGE_CONF=$sconf run ${STORAGE_BINARY} applydiff-using-staging-dir $layer $SRC
+	[ "$status" -eq 0 ]
+
+	name=suid-test-image
+	CONTAINERS_STORAGE_CONF=$sconf run ${STORAGE_BINARY} create-image --name $name $layer
+	[ "$status" -eq 0 ]
+
+	ctrname=suid-test-container
+	CONTAINERS_STORAGE_CONF=$sconf run ${STORAGE_BINARY} create-container --name $ctrname $name
+	[ "$status" -eq 0 ]
+
+	CONTAINERS_STORAGE_CONF=$sconf run ${STORAGE_BINARY} mount $ctrname
+	[ "$status" -eq 0 ]
+	mount="$output"
+
+	# SUID bit (04000) should be stripped.
+	run stat -c %a $mount/suid_file
+	[ "$status" -eq 0 ]
+	[ "$output" = "755" ]
+
+	# SGID bit (02000) should be stripped.
+	run stat -c %a $mount/sgid_file
+	[ "$status" -eq 0 ]
+	[ "$output" = "755" ]
+
+	# Both SUID and SGID should be stripped.
+	run stat -c %a $mount/suid_sgid_file
+	[ "$status" -eq 0 ]
+	[ "$output" = "755" ]
+
+	# Normal file should be unchanged.
+	run stat -c %a $mount/normal_file
+	[ "$status" -eq 0 ]
+	[ "$output" = "755" ]
+}
+
+@test "strip-suid-sgid via applydiff" {
+	# The test needs "tar".
+	if test -z "$(which tar 2> /dev/null)" ; then
+		skip "need tar"
+	fi
+
+	# Create source files with SUID/SGID bits.
+	run storage --debug=false create-layer
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	srclayer="$output"
+
+	run storage --debug=false mount $srclayer
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	srcmount="$output"
+
+	createrandom "$srcmount"/suid_file
+	chmod 4755 "$srcmount"/suid_file
+	createrandom "$srcmount"/sgid_file
+	chmod 2755 "$srcmount"/sgid_file
+	createrandom "$srcmount"/suid_sgid_file
+	chmod 6755 "$srcmount"/suid_sgid_file
+	createrandom "$srcmount"/normal_file
+	chmod 0755 "$srcmount"/normal_file
+
+	run storage --debug=false unmount $srclayer
+	[ "$status" -eq 0 ]
+
+	# Extract as tar.
+	storage diff -u -f $TESTDIR/suid.tar $srclayer
+
+	# Delete source layer.
+	storage delete-layer $srclayer
+
+	# Create config with strip_suid_sgid enabled.
+	local sconf=$TESTDIR/storage.conf
+
+	local root=`storage status 2>&1 | awk '/^Root:/{print $2}'`
+	local runroot=`storage status 2>&1 | awk '/^Run Root:/{print $3}'`
+
+	cat >$sconf <<EOF
+[storage]
+driver="$STORAGE_DRIVER"
+graphroot="$root"
+runroot="$runroot"
+
+[storage.options]
+strip_suid_sgid = true
+EOF
+
+	# Create new layer and apply the tar diff.
+	CONTAINERS_STORAGE_CONF=$sconf run ${STORAGE_BINARY} create-layer
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	layer="$output"
+
+	CONTAINERS_STORAGE_CONF=$sconf run ${STORAGE_BINARY} applydiff -f $TESTDIR/suid.tar $layer
+	[ "$status" -eq 0 ]
+
+	CONTAINERS_STORAGE_CONF=$sconf run ${STORAGE_BINARY} mount $layer
+	[ "$status" -eq 0 ]
+	mount="$output"
+
+	# SUID bit should be stripped.
+	run stat -c %a $mount/suid_file
+	[ "$status" -eq 0 ]
+	[ "$output" = "755" ]
+
+	# SGID bit should be stripped.
+	run stat -c %a $mount/sgid_file
+	[ "$status" -eq 0 ]
+	[ "$output" = "755" ]
+
+	# Both SUID and SGID should be stripped.
+	run stat -c %a $mount/suid_sgid_file
+	[ "$status" -eq 0 ]
+	[ "$output" = "755" ]
+
+	# Normal file should be unchanged.
+	run stat -c %a $mount/normal_file
+	[ "$status" -eq 0 ]
+	[ "$output" = "755" ]
+}

--- a/storage/types/options.go
+++ b/storage/types/options.go
@@ -101,6 +101,9 @@ type StoreOptions struct {
 	DisableVolatile bool `json:"disable-volatile,omitempty"`
 	// If transient, don't persist containers over boot (stores db in runroot)
 	TransientStore bool `json:"transient_store,omitempty"`
+	// If set, SUID and SGID bits are stripped from the mode of all files,
+	// directories, etc., when image layers are extracted.
+	StripSUIDSGID bool `json:"strip_suid_sgid,omitempty"`
 }
 
 // setDefaultRootlessStoreOptions sets the storage opts for containers running as non root
@@ -211,6 +214,7 @@ func LoadStoreOptions(opts LoadOptions) (StoreOptions, error) {
 
 	storeOptions.DisableVolatile = config.Storage.Options.DisableVolatile
 	storeOptions.TransientStore = config.Storage.TransientStore
+	storeOptions.StripSUIDSGID = config.Storage.Options.StripSUIDSGID
 
 	storeOptions.GraphDriverOptions = append(storeOptions.GraphDriverOptions, cfg.GetGraphDriverOptions(config.Storage.Options)...)
 


### PR DESCRIPTION
## Overview

This pull request adds a new `strip_suid_sgid` storage option.  When set, the SUID and SGID permission bits are stripped (set to zero) in the mode of all filesystem objects as they are extracted from image layers.

Many application container images are built from base images that include system utilities that have these bits set.  Often these utilities are not actually used by those application containers.  In other cases, they are used by an entrypoint script that is running as root within the container.  In either case, the application container functions just fine without these bits set.  Of course, this is not true of all application container images, so every application must be tested to ensure that it works with this setting.

Given the potential to break applications, why would anyone want to use this setting?

First, leaving files with unneeded SUID and SGID permissions lying around is not great from a security POV, particularly if the image was not pulled by a rootless process.  Second, this setting allows image layers containing files with these bits set to be pulled by a systemd service that is running with `RestrictSUIDSGID=yes`.  Without this feature, an image which contains such files (even if they are removed by a higher layer within the image) cannot be pulled by such a service, because it is not allowed to create filesystem objects with these permission bits set.

## Commits

I have attempted to break this PR into digestible chunks.

* The first commit adds the option to the configuration file TOML and passes it down to the `TarOptions` struct (`OptionsConfig` → `StoreOptions` → `store` → `layerStore` → `ApplyDiffOpts` → `TarOptions`!).  `ApplyDiffOpts.StripSUIDSGID` is a `*bool`, rather than a `bool`, so that callers of `Store.PrepareStagedLayer()` and `Store.ApplyStagedLayer()` can either control the value of the option or pass `nil` to use the value from the configuration file.

* The second commit adds the actual implementation, for both the "tar" extraction path (`extractTarFileEntry()`) and the "chunked" path (`chunkedDiffer.ApplyDiff()`).
 
  Rather than adding 2 more arguments to `extractTarFileEntry()`'s already long signature, this commit replaces 3 of its existing arguments and the 2 new ones with a single `*TarOptions` argument.  It also changes the `handleLChmod()` signature to take a single `mode` argument (which is called `mask` in `extractTarFileEntry()`), instead of duplicating the `StripSUIDSGID` and `ForceMask` logic in the Linux and BSD versions of `handleLChmod()`.

  On UNIX platforms, `extractTarFileEntry()` is called in a subprocess, and its output is discarded if it succeeds.  In order to actually log the names of any files whose permissions are modified, the UNIX version of `invokeUnpack()` is changed to log all of the subprocess's output (at `INFO` level) when it succeeds.  An additional `InSubprocess` field is added to the `TarOptions` struct and set in the UNIX `invokeUnpack()`, so that `extractTarFileEntry()` knows to log file names directly to `stderr`, rather than using `logrus` when it is running in a subprocess.

* The third commit adds documentation of the option to the man page and both the main and FreeBSD sample `storage.conf` files.

* The final commit adds tests for the feature.

## AI tool use

I did use AI tools to help me create this pull request.  I was unfamiliar with both the storage library code base and the Go programming language when I began working on it, so AI tools were used for the following purposes.

* Understanding Go syntax and coding practices.

* Understanding the code base, including:

  - The steps required to pass the `strip_suid_sgid` option value down to `extractTarFileEntry()` and `chunkedDiffer.ApplyDiff()`,
  - The existence of the 2 different extraction patch, and their OS-specific functions, and
  - The public APIs (`Store.PrepareStagedLayer()` and `Store.ApplyStagedLayer()`) and the need to use a pointer field in `ApplyDiffOpts`.

* Generating the test code.  The test code in the final commit combines code that was generated with access to the feature implementation and "clean room" test code that was generated from a human-readable specification.