### PR TITLE
Refactor `Store.Check`

### DIFF
--- a/storage/check.go
+++ b/storage/check.go
@@ -625,11 +625,11 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 		if err != nil {
 			return struct{}{}, true, err
 		}
+		maximumAge := defaultMaximumUnreferencedLayerAge
+		if options.LayerUnreferencedMaximumAge != nil {
+			maximumAge = *options.LayerUnreferencedMaximumAge
+		}
 		for _, layer := range layers {
-			maximumAge := defaultMaximumUnreferencedLayerAge
-			if options.LayerUnreferencedMaximumAge != nil {
-				maximumAge = *options.LayerUnreferencedMaximumAge
-			}
 			if referenced := referencedLayers[layer.ID]; !referenced {
 				if layer.Created.IsZero() || layer.Created.Add(maximumAge).Before(time.Now()) {
 					// Either we don't (and never will) know when this layer was

--- a/storage/check.go
+++ b/storage/check.go
@@ -454,10 +454,6 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 			return struct{}{}, true, err
 		}
 		isReadWrite := roImageStoreIsReallyReadWrite(store)
-		readWriteDesc := ""
-		if !isReadWrite {
-			readWriteDesc = "read-only "
-		}
 		// Examine each image in turn.
 		for i := range images {
 			image := images[i]
@@ -484,7 +480,11 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 				continue
 			}
 			examinedImages[id] = struct{}{}
-			logrus.Debugf("checking %simage %s", readWriteDesc, id)
+			if isReadWrite {
+				logrus.Debugf("checking image %s", id)
+			} else {
+				logrus.Debugf("checking read-only image %s", id)
+			}
 			if options.ImageData {
 				// Check that all of the big data items are present and reading them
 				// back gives us the right amount of data.  Even though we record

--- a/storage/check.go
+++ b/storage/check.go
@@ -539,11 +539,11 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 							referencedROLayers[layer] = true
 						}
 					}
-					if len(report.Layers[layer]) > 0 {
-						appendErrors(report.Layers[layer]...)
+					if layerErrs := report.Layers[layer]; len(layerErrs) > 0 {
+						appendErrors(layerErrs...)
 					}
-					if len(report.ROLayers[layer]) > 0 {
-						appendErrors(report.ROLayers[layer]...)
+					if layerErrs := report.ROLayers[layer]; len(layerErrs) > 0 {
+						appendErrors(layerErrs...)
 					}
 				}
 			}
@@ -597,11 +597,11 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 					err := fmt.Errorf("image %s: %w", container.ImageID, ErrContainerImageMissing)
 					appendErrors(err)
 				}
-				if len(report.Images[container.ImageID]) > 0 {
-					appendErrors(report.Images[container.ImageID]...)
+				if imageErrs := report.Images[container.ImageID]; len(imageErrs) > 0 {
+					appendErrors(imageErrs...)
 				}
-				if len(report.ROImages[container.ImageID]) > 0 {
-					appendErrors(report.ROImages[container.ImageID]...)
+				if imageErrs := report.ROImages[container.ImageID]; len(imageErrs) > 0 {
+					appendErrors(imageErrs...)
 				}
 			}
 			// Count the container's layer as referenced.

--- a/storage/check.go
+++ b/storage/check.go
@@ -447,6 +447,23 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 		for i := range images {
 			image := images[i]
 			id := image.ID
+			var appendErrors func(errors ...error)
+			var recordError func(err error)
+			if isReadWrite {
+				appendErrors = func(errors ...error) {
+					report.Images[id] = append(report.Images[id], errors...)
+				}
+				recordError = func(err error) {
+					appendErrors(fmt.Errorf("image %s: %w", id, err))
+				}
+			} else {
+				appendErrors = func(errors ...error) {
+					report.ROImages[id] = append(report.ROImages[id], errors...)
+				}
+				recordError = func(err error) {
+					appendErrors(fmt.Errorf("read-only image %s: %w", id, err))
+				}
+			}
 			// If we've already seen an image with this ID, skip it.
 			if _, checked := examinedImages[id]; checked {
 				continue
@@ -464,29 +481,14 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 						data, err := store.BigData(id, key)
 						if err != nil {
 							if errors.Is(err, os.ErrNotExist) {
-								err = fmt.Errorf("%simage %s: data item %q: %w", readWriteDesc, id, key, ErrImageDataMissing)
-								if isReadWrite {
-									report.Images[id] = append(report.Images[id], err)
-								} else {
-									report.ROImages[id] = append(report.ROImages[id], err)
-								}
+								recordError(fmt.Errorf("data item %q: %w", key, ErrImageDataMissing))
 								return
 							}
-							err = fmt.Errorf("%simage %s: data item %q: %w", readWriteDesc, id, key, err)
-							if isReadWrite {
-								report.Images[id] = append(report.Images[id], err)
-							} else {
-								report.ROImages[id] = append(report.ROImages[id], err)
-							}
+							recordError(fmt.Errorf("data item %q: %w", key, err))
 							return
 						}
 						if int64(len(data)) != image.BigDataSizes[key] {
-							err = fmt.Errorf("%simage %s: data item %q: %w", readWriteDesc, id, key, ErrImageDataIncorrectSize)
-							if isReadWrite {
-								report.Images[id] = append(report.Images[id], err)
-							} else {
-								report.ROImages[id] = append(report.ROImages[id], err)
-							}
+							recordError(fmt.Errorf("data item %q: %w", key, ErrImageDataIncorrectSize))
 							return
 						}
 					}()
@@ -510,12 +512,7 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 					_, checkedRO := referencedROLayers[layer]
 					if !checked && !checkedRO {
 						err := fmt.Errorf("layer %s: %w", layer, ErrImageLayerMissing)
-						err = fmt.Errorf("%simage %s: %w", readWriteDesc, id, err)
-						if isReadWrite {
-							report.Images[id] = append(report.Images[id], err)
-						} else {
-							report.ROImages[id] = append(report.ROImages[id], err)
-						}
+						recordError(err)
 					} else {
 						// Count this layer as referenced.  Whether by the
 						// image or one of its child layers doesn't matter
@@ -527,20 +524,11 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 							referencedROLayers[layer] = true
 						}
 					}
-					if isReadWrite {
-						if len(report.Layers[layer]) > 0 {
-							report.Images[id] = append(report.Images[id], report.Layers[layer]...)
-						}
-						if len(report.ROLayers[layer]) > 0 {
-							report.Images[id] = append(report.Images[id], report.ROLayers[layer]...)
-						}
-					} else {
-						if len(report.Layers[layer]) > 0 {
-							report.ROImages[id] = append(report.ROImages[id], report.Layers[layer]...)
-						}
-						if len(report.ROLayers[layer]) > 0 {
-							report.ROImages[id] = append(report.ROImages[id], report.ROLayers[layer]...)
-						}
+					if len(report.Layers[layer]) > 0 {
+						appendErrors(report.Layers[layer]...)
+					}
+					if len(report.ROLayers[layer]) > 0 {
+						appendErrors(report.ROLayers[layer]...)
 					}
 				}
 			}

--- a/storage/check.go
+++ b/storage/check.go
@@ -231,22 +231,22 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 			// were stored.
 			if options.LayerData {
 				for _, name := range layer.BigDataNames {
-					func() {
+					if err := func() error {
 						rc, err := store.BigData(id, name)
 						if err != nil {
 							if errors.Is(err, os.ErrNotExist) {
-								recordError(fmt.Errorf("data item %q: %w", name, ErrLayerDataMissing))
-								return
+								return ErrLayerDataMissing
 							}
-							recordError(fmt.Errorf("data item %q: %w", name, err))
-							return
+							return err
 						}
 						defer rc.Close()
 						if _, err = io.Copy(io.Discard, rc); err != nil {
-							recordError(fmt.Errorf("data item %q: %w", name, err))
-							return
+							return err
 						}
-					}()
+						return nil
+					}(); err != nil {
+						recordError(fmt.Errorf("data item %q: %w", name, err))
+					}
 				}
 			}
 			// Check that the content we get back when extracting the layer's contents
@@ -257,12 +257,11 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 			// diff, which we can use to reconstruct the expected contents for the tree
 			// we see when the layer is mounted.
 			if options.LayerDigests && layer.UncompressedDigest != "" {
-				func() {
+				if err := func() error {
 					expectedDigest := layer.UncompressedDigest
 					// Double-check that the digest isn't invalid somehow.
 					if err := layer.UncompressedDigest.Validate(); err != nil {
-						recordError(err)
-						return
+						return err
 					}
 					// Extract the diff.
 					uncompressed := archive.Uncompressed
@@ -271,8 +270,7 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 					}
 					diff, err := store.Diff("", id, &diffOptions)
 					if err != nil {
-						recordError(err)
-						return
+						return err
 					}
 					// Digest and count the length of the diff.
 					digester := expectedDigest.Algorithm().Digester()
@@ -305,8 +303,7 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 						diffHeadersByLayerMutex.Lock()
 						delete(diffHeadersByLayer, id)
 						diffHeadersByLayerMutex.Unlock()
-						recordError(archiveErr)
-						return
+						return archiveErr
 					}
 					if digester.Digest() != layer.UncompressedDigest {
 						// The diff digest didn't match.
@@ -323,7 +320,10 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 						diffHeadersByLayerMutex.Unlock()
 						recordError(fmt.Errorf("read %d bytes instead of %d bytes: %w", counter.Count, layer.UncompressedSize, ErrLayerIncorrectContentSize))
 					}
-				}()
+					return nil
+				}(); err != nil {
+					recordError(err)
+				}
 			}
 		}
 		// At this point we're out of things that we can be sure will work in read-only
@@ -341,24 +341,22 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 			// flag cases where content is in the layer that shouldn't be there.  The
 			// tar-split implementation of Diff() won't catch this problem by itself.
 			if options.LayerMountable {
-				func() {
+				if err := func() error {
 					// Mount the layer.
 					mountPoint, err := s.graphDriver.Get(id, drivers.MountOpts{MountLabel: layer.MountLabel, Options: []string{"ro"}})
 					if err != nil {
-						recordError(err)
-						return
+						return err
 					}
 					// Unmount the layer when we're done in here.
 					defer func() {
 						if err := s.graphDriver.Put(id); err != nil {
 							recordError(err)
-							return
 						}
 					}()
 					// If we're not looking at layer contents, or we didn't
 					// look at the diff for this layer, we're done here.
 					if !options.LayerDigests || layer.UncompressedDigest == "" || !options.LayerContents {
-						return
+						return nil
 					}
 					// Build a list of all of the changes in all of the layers
 					// that make up the tree we're looking at.
@@ -370,7 +368,7 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 						layerChanges, haveChanges := diffHeadersByLayer[layerID]
 						diffHeadersByLayerMutex.Unlock()
 						if !haveChanges {
-							return
+							return nil
 						}
 						// The diff headers for this layer go _before_ those of
 						// layers that inherited some of its contents.
@@ -388,15 +386,17 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 					}
 					actualCheckDirectory, err := newCheckDirectoryFromDirectory(mountPoint)
 					if err != nil {
-						recordError(fmt.Errorf("scanning contents: %w", err))
-						return
+						return fmt.Errorf("scanning contents: %w", err)
 					}
 					// Every departure from our expectations is an error.
 					diffs := compareCheckDirectory(expectedCheckDirectory, actualCheckDirectory, idmap, ignore)
 					for _, diff := range diffs {
 						recordError(fmt.Errorf("%s, %w", diff, ErrLayerContentModified))
 					}
-				}()
+					return nil
+				}(); err != nil {
+					recordError(err)
+				}
 			}
 		}
 		// Check that we don't have any dangling parent layer references.
@@ -477,21 +477,21 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 				// were calculated (they're only used as lookup keys), so do not try
 				// to check them.
 				for _, key := range image.BigDataNames {
-					func() {
+					if err := func() error {
 						data, err := store.BigData(id, key)
 						if err != nil {
 							if errors.Is(err, os.ErrNotExist) {
-								recordError(fmt.Errorf("data item %q: %w", key, ErrImageDataMissing))
-								return
+								return ErrImageDataMissing
 							}
-							recordError(fmt.Errorf("data item %q: %w", key, err))
-							return
+							return err
 						}
 						if int64(len(data)) != image.BigDataSizes[key] {
-							recordError(fmt.Errorf("data item %q: %w", key, ErrImageDataIncorrectSize))
-							return
+							return ErrImageDataIncorrectSize
 						}
-					}()
+						return nil
+					}(); err != nil {
+						recordError(fmt.Errorf("data item %q: %w", key, err))
+					}
 				}
 			}
 			// Walk the layers list for the image.  For every layer that the image uses
@@ -558,21 +558,21 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 				// Check that all of the big data items are present and reading them
 				// back gives us the right amount of data.
 				for _, key := range container.BigDataNames {
-					func() {
+					if err := func() error {
 						data, err := s.containerStore.BigData(id, key)
 						if err != nil {
 							if errors.Is(err, os.ErrNotExist) {
-								recordError(fmt.Errorf("data item %q: %w", key, ErrContainerDataMissing))
-								return
+								return ErrContainerDataMissing
 							}
-							recordError(fmt.Errorf("data item %q: %w", key, err))
-							return
+							return err
 						}
 						if int64(len(data)) != container.BigDataSizes[key] {
-							recordError(fmt.Errorf("data item %q: %w", key, ErrContainerDataIncorrectSize))
-							return
+							return ErrContainerDataIncorrectSize
 						}
-					}()
+						return nil
+					}(); err != nil {
+						recordError(fmt.Errorf("data item %q: %w", key, err))
+					}
 				}
 			}
 			// Look at the container's base image.  If the image has errors, the image's errors

--- a/storage/check.go
+++ b/storage/check.go
@@ -547,6 +547,12 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 		for i := range containers {
 			container := containers[i]
 			id := container.ID
+			appendErrors := func(errors ...error) {
+				report.Containers[id] = append(report.Containers[id], errors...)
+			}
+			recordError := func(err error) {
+				appendErrors(fmt.Errorf("container %s: %w", id, err))
+			}
 			logrus.Debugf("checking container %s", id)
 			if options.ContainerData {
 				// Check that all of the big data items are present and reading them
@@ -556,17 +562,14 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 						data, err := s.containerStore.BigData(id, key)
 						if err != nil {
 							if errors.Is(err, os.ErrNotExist) {
-								err = fmt.Errorf("container %s: data item %q: %w", id, key, ErrContainerDataMissing)
-								report.Containers[id] = append(report.Containers[id], err)
+								recordError(fmt.Errorf("data item %q: %w", key, ErrContainerDataMissing))
 								return
 							}
-							err = fmt.Errorf("container %s: data item %q: %w", id, key, err)
-							report.Containers[id] = append(report.Containers[id], err)
+							recordError(fmt.Errorf("data item %q: %w", key, err))
 							return
 						}
 						if int64(len(data)) != container.BigDataSizes[key] {
-							err = fmt.Errorf("container %s: data item %q: %w", id, key, ErrContainerDataIncorrectSize)
-							report.Containers[id] = append(report.Containers[id], err)
+							recordError(fmt.Errorf("data item %q: %w", key, ErrContainerDataIncorrectSize))
 							return
 						}
 					}()
@@ -577,13 +580,13 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 			if container.ImageID != "" {
 				if _, checked := examinedImages[container.ImageID]; !checked {
 					err := fmt.Errorf("image %s: %w", container.ImageID, ErrContainerImageMissing)
-					report.Containers[id] = append(report.Containers[id], err)
+					appendErrors(err)
 				}
 				if len(report.Images[container.ImageID]) > 0 {
-					report.Containers[id] = append(report.Containers[id], report.Images[container.ImageID]...)
+					appendErrors(report.Images[container.ImageID]...)
 				}
 				if len(report.ROImages[container.ImageID]) > 0 {
-					report.Containers[id] = append(report.Containers[id], report.ROImages[container.ImageID]...)
+					appendErrors(report.ROImages[container.ImageID]...)
 				}
 			}
 			// Count the container's layer as referenced.

--- a/storage/check.go
+++ b/storage/check.go
@@ -298,14 +298,13 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 					reader := io.TeeReader(diff, counter)
 
 					var archiveErr error
+					var diffHeaders []*tar.Header
 					func() {
 						// Read the diff, one item at a time.
 						tr := tar.NewReader(reader)
 						hdr, err := tr.Next()
 						for err == nil {
-							diffHeadersByLayerMutex.Lock()
-							diffHeadersByLayer[id] = append(diffHeadersByLayer[id], hdr)
-							diffHeadersByLayerMutex.Unlock()
+							diffHeaders = append(diffHeaders, hdr)
 							hdr, err = tr.Next()
 						}
 						if !errors.Is(err, io.EOF) {
@@ -320,25 +319,21 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 					diff.Close()
 					if archiveErr != nil {
 						// Reading the diff didn't end as expected
-						diffHeadersByLayerMutex.Lock()
-						delete(diffHeadersByLayer, id)
-						diffHeadersByLayerMutex.Unlock()
 						return archiveErr
 					}
+					failed := false
 					if digester.Digest() != layer.UncompressedDigest {
-						// The diff digest didn't match.
-						diffHeadersByLayerMutex.Lock()
-						delete(diffHeadersByLayer, id)
-						diffHeadersByLayerMutex.Unlock()
+						failed = true // The diff digest didn't match.
 						recordError(ErrLayerIncorrectContentDigest)
 					}
 					if layer.UncompressedSize != -1 && counter.Count != layer.UncompressedSize {
-						// We expected the diff to have a specific size, and
-						// it didn't match.
-						diffHeadersByLayerMutex.Lock()
-						delete(diffHeadersByLayer, id)
-						diffHeadersByLayerMutex.Unlock()
+						failed = true // We expected the diff to have a specific size, and it didn't match.
 						recordError(fmt.Errorf("read %d bytes instead of %d bytes: %w", counter.Count, layer.UncompressedSize, ErrLayerIncorrectContentSize))
+					}
+					if !failed {
+						diffHeadersByLayerMutex.Lock()
+						diffHeadersByLayer[id] = diffHeaders
+						diffHeadersByLayerMutex.Unlock()
 					}
 					return nil
 				}(); err != nil {

--- a/storage/check.go
+++ b/storage/check.go
@@ -296,9 +296,9 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 					digester := expectedDigest.Algorithm().Digester()
 					counter := ioutils.NewWriteCounter(digester.Hash())
 					reader := io.TeeReader(diff, counter)
-					var wg sync.WaitGroup
+
 					var archiveErr error
-					wg.Go(func() {
+					func() {
 						// Read the diff, one item at a time.
 						tr := tar.NewReader(reader)
 						hdr, err := tr.Next()
@@ -315,8 +315,8 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 						if _, err := io.Copy(io.Discard, reader); err != nil {
 							recordError(fmt.Errorf("consume any trailer after the EOF marker: %w", err))
 						}
-					})
-					wg.Wait()
+					}()
+
 					diff.Close()
 					if archiveErr != nil {
 						// Reading the diff didn't end as expected

--- a/storage/check.go
+++ b/storage/check.go
@@ -187,14 +187,27 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 			return struct{}{}, true, err
 		}
 		isReadWrite := roLayerStoreIsReallyReadWrite(store)
-		readWriteDesc := ""
-		if !isReadWrite {
+		var readWriteDesc string
+		var recordError2 func(id string, err error)
+		if isReadWrite {
+			readWriteDesc = ""
+			recordError2 = func(id string, err error) {
+				report.Layers[id] = append(report.Layers[id],
+					fmt.Errorf("layer %s: %w", id, err))
+			}
+		} else {
 			readWriteDesc = "read-only "
+			recordError2 = func(id string, err error) {
+				report.ROLayers[id] = append(report.ROLayers[id],
+					fmt.Errorf("read-only layer %s: %w", id, err))
+			}
 		}
+
 		// Examine each layer in turn.
 		for i := range layers {
 			layer := layers[i]
 			id := layer.ID
+			recordError := func(err error) { recordError2(id, err) }
 			// If we've already seen a layer with this ID, no need to process it again.
 			if _, checked := referencedLayers[id]; checked {
 				continue
@@ -222,30 +235,15 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 						rc, err := store.BigData(id, name)
 						if err != nil {
 							if errors.Is(err, os.ErrNotExist) {
-								err := fmt.Errorf("%slayer %s: data item %q: %w", readWriteDesc, id, name, ErrLayerDataMissing)
-								if isReadWrite {
-									report.Layers[id] = append(report.Layers[id], err)
-								} else {
-									report.ROLayers[id] = append(report.ROLayers[id], err)
-								}
+								recordError(fmt.Errorf("data item %q: %w", name, ErrLayerDataMissing))
 								return
 							}
-							err = fmt.Errorf("%slayer %s: data item %q: %w", readWriteDesc, id, name, err)
-							if isReadWrite {
-								report.Layers[id] = append(report.Layers[id], err)
-							} else {
-								report.ROLayers[id] = append(report.ROLayers[id], err)
-							}
+							recordError(fmt.Errorf("data item %q: %w", name, err))
 							return
 						}
 						defer rc.Close()
 						if _, err = io.Copy(io.Discard, rc); err != nil {
-							err = fmt.Errorf("%slayer %s: data item %q: %w", readWriteDesc, id, name, err)
-							if isReadWrite {
-								report.Layers[id] = append(report.Layers[id], err)
-							} else {
-								report.ROLayers[id] = append(report.ROLayers[id], err)
-							}
+							recordError(fmt.Errorf("data item %q: %w", name, err))
 							return
 						}
 					}()
@@ -263,12 +261,7 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 					expectedDigest := layer.UncompressedDigest
 					// Double-check that the digest isn't invalid somehow.
 					if err := layer.UncompressedDigest.Validate(); err != nil {
-						err := fmt.Errorf("%slayer %s: %w", readWriteDesc, id, err)
-						if isReadWrite {
-							report.Layers[id] = append(report.Layers[id], err)
-						} else {
-							report.ROLayers[id] = append(report.ROLayers[id], err)
-						}
+						recordError(err)
 						return
 					}
 					// Extract the diff.
@@ -278,12 +271,7 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 					}
 					diff, err := store.Diff("", id, &diffOptions)
 					if err != nil {
-						err := fmt.Errorf("%slayer %s: %w", readWriteDesc, id, err)
-						if isReadWrite {
-							report.Layers[id] = append(report.Layers[id], err)
-						} else {
-							report.ROLayers[id] = append(report.ROLayers[id], err)
-						}
+						recordError(err)
 						return
 					}
 					// Digest and count the length of the diff.
@@ -307,12 +295,7 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 						}
 						// consume any trailer after the EOF marker
 						if _, err := io.Copy(io.Discard, reader); err != nil {
-							err = fmt.Errorf("layer %s: consume any trailer after the EOF marker: %w", id, err)
-							if isReadWrite {
-								report.Layers[id] = append(report.Layers[id], err)
-							} else {
-								report.ROLayers[id] = append(report.ROLayers[id], err)
-							}
+							recordError(fmt.Errorf("consume any trailer after the EOF marker: %w", err))
 						}
 					})
 					wg.Wait()
@@ -322,12 +305,7 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 						diffHeadersByLayerMutex.Lock()
 						delete(diffHeadersByLayer, id)
 						diffHeadersByLayerMutex.Unlock()
-						archiveErr = fmt.Errorf("%slayer %s: %w", readWriteDesc, id, archiveErr)
-						if isReadWrite {
-							report.Layers[id] = append(report.Layers[id], archiveErr)
-						} else {
-							report.ROLayers[id] = append(report.ROLayers[id], archiveErr)
-						}
+						recordError(archiveErr)
 						return
 					}
 					if digester.Digest() != layer.UncompressedDigest {
@@ -335,12 +313,7 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 						diffHeadersByLayerMutex.Lock()
 						delete(diffHeadersByLayer, id)
 						diffHeadersByLayerMutex.Unlock()
-						err := fmt.Errorf("%slayer %s: %w", readWriteDesc, id, ErrLayerIncorrectContentDigest)
-						if isReadWrite {
-							report.Layers[id] = append(report.Layers[id], err)
-						} else {
-							report.ROLayers[id] = append(report.ROLayers[id], err)
-						}
+						recordError(ErrLayerIncorrectContentDigest)
 					}
 					if layer.UncompressedSize != -1 && counter.Count != layer.UncompressedSize {
 						// We expected the diff to have a specific size, and
@@ -348,12 +321,7 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 						diffHeadersByLayerMutex.Lock()
 						delete(diffHeadersByLayer, id)
 						diffHeadersByLayerMutex.Unlock()
-						err := fmt.Errorf("%slayer %s: read %d bytes instead of %d bytes: %w", readWriteDesc, id, counter.Count, layer.UncompressedSize, ErrLayerIncorrectContentSize)
-						if isReadWrite {
-							report.Layers[id] = append(report.Layers[id], err)
-						} else {
-							report.ROLayers[id] = append(report.ROLayers[id], err)
-						}
+						recordError(fmt.Errorf("read %d bytes instead of %d bytes: %w", counter.Count, layer.UncompressedSize, ErrLayerIncorrectContentSize))
 					}
 				}()
 			}
@@ -368,6 +336,7 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 		for i := range layers {
 			layer := layers[i]
 			id := layer.ID
+			recordError := func(err error) { recordError2(id, err) }
 			// Compare to what we see when we mount the layer and walk the tree, and
 			// flag cases where content is in the layer that shouldn't be there.  The
 			// tar-split implementation of Diff() won't catch this problem by itself.
@@ -376,23 +345,13 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 					// Mount the layer.
 					mountPoint, err := s.graphDriver.Get(id, drivers.MountOpts{MountLabel: layer.MountLabel, Options: []string{"ro"}})
 					if err != nil {
-						err := fmt.Errorf("%slayer %s: %w", readWriteDesc, id, err)
-						if isReadWrite {
-							report.Layers[id] = append(report.Layers[id], err)
-						} else {
-							report.ROLayers[id] = append(report.ROLayers[id], err)
-						}
+						recordError(err)
 						return
 					}
 					// Unmount the layer when we're done in here.
 					defer func() {
 						if err := s.graphDriver.Put(id); err != nil {
-							err := fmt.Errorf("%slayer %s: %w", readWriteDesc, id, err)
-							if isReadWrite {
-								report.Layers[id] = append(report.Layers[id], err)
-							} else {
-								report.ROLayers[id] = append(report.ROLayers[id], err)
-							}
+							recordError(err)
 							return
 						}
 					}()
@@ -429,23 +388,13 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 					}
 					actualCheckDirectory, err := newCheckDirectoryFromDirectory(mountPoint)
 					if err != nil {
-						err := fmt.Errorf("scanning contents of %slayer %s: %w", readWriteDesc, id, err)
-						if isReadWrite {
-							report.Layers[id] = append(report.Layers[id], err)
-						} else {
-							report.ROLayers[id] = append(report.ROLayers[id], err)
-						}
+						recordError(fmt.Errorf("scanning contents: %w", err))
 						return
 					}
 					// Every departure from our expectations is an error.
 					diffs := compareCheckDirectory(expectedCheckDirectory, actualCheckDirectory, idmap, ignore)
 					for _, diff := range diffs {
-						err := fmt.Errorf("%slayer %s: %s, %w", readWriteDesc, id, diff, ErrLayerContentModified)
-						if isReadWrite {
-							report.Layers[id] = append(report.Layers[id], err)
-						} else {
-							report.ROLayers[id] = append(report.ROLayers[id], err)
-						}
+						recordError(fmt.Errorf("%s, %w", diff, ErrLayerContentModified))
 					}
 				}()
 			}
@@ -465,6 +414,9 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 			}
 			// We haven't seen a layer with the ID that this layer's record
 			// says is its parent's ID.
+
+			// Not recordError2 because we are recording for layer "id"
+			// but the text talks about layer "parent".
 			err := fmt.Errorf("%slayer %s: %w", readWriteDesc, parent, ErrLayerMissing)
 			report.Layers[id] = append(report.Layers[id], err)
 		}

--- a/storage/check.go
+++ b/storage/check.go
@@ -118,6 +118,26 @@ type CheckReport struct {
 	Containers            map[string][]error // damaged containers (including those based on damaged images)
 }
 
+func (r *CheckReport) recordLayerErrors(id string, errs ...error) {
+	r.Layers[id] = append(r.Layers[id], errs...)
+}
+
+func (r *CheckReport) recordROLayerErrors(id string, errs ...error) {
+	r.ROLayers[id] = append(r.ROLayers[id], errs...)
+}
+
+func (r *CheckReport) recordImageErrors(id string, errs ...error) {
+	r.Images[id] = append(r.Images[id], errs...)
+}
+
+func (r *CheckReport) recordROImageErrors(id string, errs ...error) {
+	r.ROImages[id] = append(r.ROImages[id], errs...)
+}
+
+func (r *CheckReport) recordContainerErrors(id string, errs ...error) {
+	r.Containers[id] = append(r.Containers[id], errs...)
+}
+
 // RepairOptions is the set of options for Repair().
 type RepairOptions struct {
 	RemoveContainers bool // Remove damaged containers
@@ -192,13 +212,13 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 		if isReadWrite {
 			readWriteDesc = ""
 			recordError2 = func(id string, err error) {
-				report.Layers[id] = append(report.Layers[id],
+				report.recordLayerErrors(id,
 					fmt.Errorf("layer %s: %w", id, err))
 			}
 		} else {
 			readWriteDesc = "read-only "
 			recordError2 = func(id string, err error) {
-				report.ROLayers[id] = append(report.ROLayers[id],
+				report.recordROLayerErrors(id,
 					fmt.Errorf("read-only layer %s: %w", id, err))
 			}
 		}
@@ -417,8 +437,8 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 
 			// Not recordError2 because we are recording for layer "id"
 			// but the text talks about layer "parent".
-			err := fmt.Errorf("%slayer %s: %w", readWriteDesc, parent, ErrLayerMissing)
-			report.Layers[id] = append(report.Layers[id], err)
+			report.recordLayerErrors(id,
+				fmt.Errorf("%slayer %s: %w", readWriteDesc, parent, ErrLayerMissing))
 		}
 		return struct{}{}, false, nil
 	}); err != nil {
@@ -451,14 +471,14 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 			var recordError func(err error)
 			if isReadWrite {
 				appendErrors = func(errors ...error) {
-					report.Images[id] = append(report.Images[id], errors...)
+					report.recordImageErrors(id, errors...)
 				}
 				recordError = func(err error) {
 					appendErrors(fmt.Errorf("image %s: %w", id, err))
 				}
 			} else {
 				appendErrors = func(errors ...error) {
-					report.ROImages[id] = append(report.ROImages[id], errors...)
+					report.recordROImageErrors(id, errors...)
 				}
 				recordError = func(err error) {
 					appendErrors(fmt.Errorf("read-only image %s: %w", id, err))
@@ -548,7 +568,7 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 			container := containers[i]
 			id := container.ID
 			appendErrors := func(errors ...error) {
-				report.Containers[id] = append(report.Containers[id], errors...)
+				report.recordContainerErrors(id, errors...)
 			}
 			recordError := func(err error) {
 				appendErrors(fmt.Errorf("container %s: %w", id, err))
@@ -621,8 +641,8 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 					// created, or it was created far enough in the past that we're
 					// reasonably sure it's not part of an image that's being written
 					// right now.
-					err := fmt.Errorf("layer %s: %w", layer.ID, ErrLayerUnreferenced)
-					report.Layers[layer.ID] = append(report.Layers[layer.ID], err)
+					report.recordLayerErrors(layer.ID,
+						fmt.Errorf("layer %s: %w", layer.ID, ErrLayerUnreferenced))
 				}
 			}
 		}
@@ -656,8 +676,8 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 
 			for i, id := range driverLayers {
 				if _, known := referencedLayers[id]; !known {
-					err := fmt.Errorf("layer %s: %w", id, ErrLayerUnaccounted)
-					report.Layers[id] = append(report.Layers[id], err)
+					report.recordLayerErrors(id,
+						fmt.Errorf("layer %s: %w", id, ErrLayerUnaccounted))
 				}
 				report.layerOrder[id] = i + 1
 			}


### PR DESCRIPTION
This is low-priority, mostly a byproduct of me trying to carefully read the code.

The principal improvement should be that reporting errors is much less repetitive, making it easier to follow the primary code structure.

See individual commit messages for details.

Should not change behavior overall, except for some error texts.