### PR TITLE
Fix quota option handling

### DIFF
--- a/storage/drivers/btrfs/btrfs.go
+++ b/storage/drivers/btrfs/btrfs.go
@@ -492,6 +492,11 @@ func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) error {
 }
 
 func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts, readOnly bool) error {
+	quota, err := d.parseStorageOpt(opts, readOnly)
+	if err != nil {
+		return err
+	}
+
 	quotas := d.quotasDir()
 	subvolumes := d.subvolumesDir()
 	if err := os.MkdirAll(subvolumes, 0o700); err != nil {
@@ -518,15 +523,6 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts, readOnl
 		}
 	}
 
-	var storageOpt map[string]string
-	if opts != nil {
-		storageOpt = opts.StorageOpt
-	}
-
-	quota, err := d.parseStorageOpt(storageOpt, readOnly)
-	if err != nil {
-		return err
-	}
 	if quota != nil {
 		if err := d.setStorageSize(path.Join(subvolumes, id), *quota); err != nil {
 			return err
@@ -554,7 +550,12 @@ type layerQuota struct {
 
 // parseStorageOpt parses CreateOpts.StorageOpt.
 // Returns a *layerQuota if a quota should be applied, nil otherwise.
-func (d *Driver) parseStorageOpt(storageOpt map[string]string, readOnly bool) (*layerQuota, error) {
+func (d *Driver) parseStorageOpt(opts *graphdriver.CreateOpts, readOnly bool) (*layerQuota, error) {
+	var storageOpt map[string]string = nil // Iterating over a nil map is safe
+	if opts != nil {
+		storageOpt = opts.StorageOpt
+	}
+
 	res := layerQuota{}
 	needQuota := false
 

--- a/storage/drivers/btrfs/btrfs.go
+++ b/storage/drivers/btrfs/btrfs.go
@@ -483,15 +483,15 @@ func (d *Driver) CreateFromTemplate(id, template string, templateIDMappings *idt
 // CreateReadWrite creates a layer that is writable for use as a container
 // file system.
 func (d *Driver) CreateReadWrite(id, parent string, opts *graphdriver.CreateOpts) error {
-	return d.create(id, parent, opts, true)
+	return d.create(id, parent, opts, false)
 }
 
 // Create the filesystem with given id.
 func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) error {
-	return d.create(id, parent, opts, false)
+	return d.create(id, parent, opts, true)
 }
 
-func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts, applyDriverDefaultQuota bool) error {
+func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts, readOnly bool) error {
 	quotas := d.quotasDir()
 	subvolumes := d.subvolumesDir()
 	if err := os.MkdirAll(subvolumes, 0o700); err != nil {
@@ -533,7 +533,7 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts, applyDr
 		quotaSize = driver.options.size
 		needQuota = true
 	}
-	if !needQuota && applyDriverDefaultQuota && d.options.size > 0 {
+	if !needQuota && !readOnly && d.options.size > 0 {
 		quotaSize = d.options.size
 		needQuota = true
 	}

--- a/storage/drivers/btrfs/btrfs.go
+++ b/storage/drivers/btrfs/btrfs.go
@@ -523,22 +523,12 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts, readOnl
 		storageOpt = opts.StorageOpt
 	}
 
-	var quota layerQuota
-	var needQuota bool
-	if _, ok := storageOpt["size"]; ok {
-		q, err := d.parseStorageOpt(storageOpt)
-		if err != nil {
-			return err
-		}
-		quota = q
-		needQuota = true
+	quota, err := d.parseStorageOpt(storageOpt, readOnly)
+	if err != nil {
+		return err
 	}
-	if !needQuota && !readOnly && d.options.size > 0 {
-		quota.size = d.options.size
-		needQuota = true
-	}
-	if needQuota {
-		if err := d.setStorageSize(path.Join(subvolumes, id), quota); err != nil {
+	if quota != nil {
+		if err := d.setStorageSize(path.Join(subvolumes, id), *quota); err != nil {
 			return err
 		}
 		if err := os.MkdirAll(quotas, 0o700); err != nil {
@@ -562,9 +552,17 @@ type layerQuota struct {
 	size uint64
 }
 
-// Parse btrfs storage options
-func (d *Driver) parseStorageOpt(storageOpt map[string]string) (layerQuota, error) {
+// parseStorageOpt parses CreateOpts.StorageOpt.
+// Returns a *layerQuota if a quota should be applied, nil otherwise.
+func (d *Driver) parseStorageOpt(storageOpt map[string]string, readOnly bool) (*layerQuota, error) {
 	res := layerQuota{}
+	needQuota := false
+
+	if !readOnly && d.options.size > 0 {
+		res.size = d.options.size
+		needQuota = true
+	}
+
 	// Read size to change the subvolume disk quota per container
 	for key, val := range storageOpt {
 		key := strings.ToLower(key)
@@ -572,15 +570,19 @@ func (d *Driver) parseStorageOpt(storageOpt map[string]string) (layerQuota, erro
 		case "size":
 			size, err := units.RAMInBytes(val)
 			if err != nil {
-				return layerQuota{}, err
+				return nil, err
 			}
 			res.size = uint64(size)
+			needQuota = true
 		default:
-			return layerQuota{}, fmt.Errorf("unknown option %s (%q)", key, storageOpt)
+			return nil, fmt.Errorf("unknown option %s (%q)", key, storageOpt)
 		}
 	}
 
-	return res, nil
+	if needQuota {
+		return &res, nil
+	}
+	return nil, nil
 }
 
 // Set btrfs storage size

--- a/storage/drivers/btrfs/btrfs.go
+++ b/storage/drivers/btrfs/btrfs.go
@@ -523,29 +523,28 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts, readOnl
 		storageOpt = opts.StorageOpt
 	}
 
-	var quotaSize uint64
+	var quota layerQuota
 	var needQuota bool
 	if _, ok := storageOpt["size"]; ok {
-		driver := &Driver{}
-		if err := d.parseStorageOpt(storageOpt, driver); err != nil {
+		q, err := d.parseStorageOpt(storageOpt)
+		if err != nil {
 			return err
 		}
-		quotaSize = driver.options.size
+		quota = q
 		needQuota = true
 	}
 	if !needQuota && !readOnly && d.options.size > 0 {
-		quotaSize = d.options.size
+		quota.size = d.options.size
 		needQuota = true
 	}
 	if needQuota {
-		layerDriver := &Driver{options: btrfsOptions{size: quotaSize}}
-		if err := d.setStorageSize(path.Join(subvolumes, id), layerDriver); err != nil {
+		if err := d.setStorageSize(path.Join(subvolumes, id), quota); err != nil {
 			return err
 		}
 		if err := os.MkdirAll(quotas, 0o700); err != nil {
 			return err
 		}
-		if err := os.WriteFile(path.Join(quotas, id), []byte(fmt.Sprint(quotaSize)), 0o644); err != nil {
+		if err := os.WriteFile(path.Join(quotas, id), []byte(fmt.Sprint(quota.size)), 0o644); err != nil {
 			return err
 		}
 	}
@@ -558,8 +557,14 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts, readOnl
 	return label.Relabel(path.Join(subvolumes, id), mountLabel, false)
 }
 
+// layerQuota contains per-layer quota settings.
+type layerQuota struct {
+	size uint64
+}
+
 // Parse btrfs storage options
-func (d *Driver) parseStorageOpt(storageOpt map[string]string, driver *Driver) error {
+func (d *Driver) parseStorageOpt(storageOpt map[string]string) (layerQuota, error) {
+	res := layerQuota{}
 	// Read size to change the subvolume disk quota per container
 	for key, val := range storageOpt {
 		key := strings.ToLower(key)
@@ -567,23 +572,23 @@ func (d *Driver) parseStorageOpt(storageOpt map[string]string, driver *Driver) e
 		case "size":
 			size, err := units.RAMInBytes(val)
 			if err != nil {
-				return err
+				return layerQuota{}, err
 			}
-			driver.options.size = uint64(size)
+			res.size = uint64(size)
 		default:
-			return fmt.Errorf("unknown option %s (%q)", key, storageOpt)
+			return layerQuota{}, fmt.Errorf("unknown option %s (%q)", key, storageOpt)
 		}
 	}
 
-	return nil
+	return res, nil
 }
 
 // Set btrfs storage size
-func (d *Driver) setStorageSize(dir string, driver *Driver) error {
-	if driver.options.size <= 0 {
-		return fmt.Errorf("btrfs: invalid storage size: %s", units.HumanSize(float64(driver.options.size)))
+func (d *Driver) setStorageSize(dir string, quota layerQuota) error {
+	if quota.size <= 0 {
+		return fmt.Errorf("btrfs: invalid storage size: %s", units.HumanSize(float64(quota.size)))
 	}
-	if d.options.minSpace > 0 && driver.options.size < d.options.minSpace {
+	if d.options.minSpace > 0 && quota.size < d.options.minSpace {
 		return fmt.Errorf("btrfs: storage size cannot be less than %s", units.HumanSize(float64(d.options.minSpace)))
 	}
 
@@ -591,7 +596,7 @@ func (d *Driver) setStorageSize(dir string, driver *Driver) error {
 		return err
 	}
 
-	if err := subvolLimitQgroup(dir, driver.options.size); err != nil {
+	if err := subvolLimitQgroup(dir, quota.size); err != nil {
 		return err
 	}
 

--- a/storage/drivers/overlay/overlay.go
+++ b/storage/drivers/overlay/overlay.go
@@ -1129,15 +1129,15 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts, readOnl
 	if d.quotaCtl != nil && !disableQuota {
 		quota := quota.Quota{}
 		if opts != nil && len(opts.StorageOpt) > 0 {
-			driver := &Driver{}
-			if err := d.parseStorageOpt(opts.StorageOpt, driver); err != nil {
+			q, err := d.parseStorageOpt(opts.StorageOpt)
+			if err != nil {
 				return err
 			}
-			if driver.options.quota.Size > 0 {
-				quota.Size = driver.options.quota.Size
+			if q.Size > 0 {
+				quota.Size = q.Size
 			}
-			if driver.options.quota.Inodes > 0 {
-				quota.Inodes = driver.options.quota.Inodes
+			if q.Inodes > 0 {
+				quota.Inodes = q.Inodes
 			}
 		}
 		// Set container disk quota limit
@@ -1226,7 +1226,8 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts, readOnl
 }
 
 // Parse overlay storage options
-func (d *Driver) parseStorageOpt(storageOpt map[string]string, driver *Driver) error {
+func (d *Driver) parseStorageOpt(storageOpt map[string]string) (quota.Quota, error) {
+	res := quota.Quota{}
 	// Read size to set the disk project quota per container
 	for key, val := range storageOpt {
 		key := strings.ToLower(key)
@@ -1234,21 +1235,21 @@ func (d *Driver) parseStorageOpt(storageOpt map[string]string, driver *Driver) e
 		case "size":
 			size, err := units.RAMInBytes(val)
 			if err != nil {
-				return err
+				return quota.Quota{}, err
 			}
-			driver.options.quota.Size = uint64(size)
+			res.Size = uint64(size)
 		case "inodes":
 			inodes, err := strconv.ParseUint(val, 10, 64)
 			if err != nil {
-				return err
+				return quota.Quota{}, err
 			}
-			driver.options.quota.Inodes = inodes
+			res.Inodes = inodes
 		default:
-			return fmt.Errorf("unknown option %s", key)
+			return quota.Quota{}, fmt.Errorf("unknown option %s", key)
 		}
 	}
 
-	return nil
+	return res, nil
 }
 
 func (d *Driver) getLower(parent string) (string, error) {

--- a/storage/drivers/overlay/overlay.go
+++ b/storage/drivers/overlay/overlay.go
@@ -991,28 +991,8 @@ func (d *Driver) CreateReadWrite(id, parent string, opts *graphdriver.CreateOpts
 		return fmt.Errorf("--storage-opt is supported only for overlay over xfs with 'pquota' mount option")
 	}
 
-	if opts == nil {
-		opts = &graphdriver.CreateOpts{
-			StorageOpt: map[string]string{},
-		}
-	}
-
 	if d.options.forceMask != nil && d.options.mountProgram == "" {
 		return fmt.Errorf("overlay: force_mask option for writeable layers is only supported with a mount_program")
-	}
-
-	if _, ok := opts.StorageOpt["size"]; !ok {
-		if opts.StorageOpt == nil {
-			opts.StorageOpt = map[string]string{}
-		}
-		opts.StorageOpt["size"] = strconv.FormatUint(d.options.quota.Size, 10)
-	}
-
-	if _, ok := opts.StorageOpt["inodes"]; !ok {
-		if opts.StorageOpt == nil {
-			opts.StorageOpt = map[string]string{}
-		}
-		opts.StorageOpt["inodes"] = strconv.FormatUint(d.options.quota.Inodes, 10)
 	}
 
 	return d.create(id, parent, opts, false)
@@ -1127,18 +1107,9 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts, readOnl
 	}()
 
 	if d.quotaCtl != nil && !disableQuota {
-		quota := quota.Quota{}
-		if opts != nil && len(opts.StorageOpt) > 0 {
-			q, err := d.parseStorageOpt(opts.StorageOpt)
-			if err != nil {
-				return err
-			}
-			if q.Size > 0 {
-				quota.Size = q.Size
-			}
-			if q.Inodes > 0 {
-				quota.Inodes = q.Inodes
-			}
+		quota, err := d.parseStorageOpt(opts, readOnly)
+		if err != nil {
+			return err
 		}
 		// Set container disk quota limit
 		// If it is set to 0, we will track the disk usage, but not enforce a limit
@@ -1226,8 +1197,19 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts, readOnl
 }
 
 // Parse overlay storage options
-func (d *Driver) parseStorageOpt(storageOpt map[string]string) (quota.Quota, error) {
+func (d *Driver) parseStorageOpt(opts *graphdriver.CreateOpts, readOnly bool) (quota.Quota, error) {
+	var storageOpt map[string]string = nil // Iterating over a nil map is safe
+	if opts != nil {
+		storageOpt = opts.StorageOpt
+	}
+
 	res := quota.Quota{}
+
+	if !readOnly {
+		res.Size = d.options.quota.Size
+		res.Inodes = d.options.quota.Inodes
+	}
+
 	// Read size to set the disk project quota per container
 	for key, val := range storageOpt {
 		key := strings.ToLower(key)

--- a/storage/drivers/overlay/overlay.go
+++ b/storage/drivers/overlay/overlay.go
@@ -1001,16 +1001,6 @@ func (d *Driver) CreateReadWrite(id, parent string, opts *graphdriver.CreateOpts
 // Create is used to create the upper, lower, and merge directories required for overlay fs for a given id.
 // The parent filesystem is used to configure these directories for the overlay.
 func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) (retErr error) {
-	if opts != nil && len(opts.StorageOpt) != 0 {
-		if _, ok := opts.StorageOpt["size"]; ok {
-			return fmt.Errorf("--storage-opt size is only supported for ReadWrite Layers")
-		}
-
-		if _, ok := opts.StorageOpt["inodes"]; ok {
-			return fmt.Errorf("--storage-opt inodes is only supported for ReadWrite Layers")
-		}
-	}
-
 	return d.create(id, parent, opts, true)
 }
 
@@ -1058,6 +1048,11 @@ func (d *Driver) getLayerPermissions(parent string, uidMaps, gidMaps []idtools.I
 }
 
 func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts, readOnly bool) (retErr error) {
+	quota, err := d.parseStorageOpt(opts, readOnly) // Do this even for read-only layers, to allow rejecting quota options
+	if err != nil {
+		return err
+	}
+
 	dir, homedir, _ := d.dir2(id, readOnly)
 
 	disableQuota := readOnly
@@ -1107,10 +1102,6 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts, readOnl
 	}()
 
 	if d.quotaCtl != nil && !disableQuota {
-		quota, err := d.parseStorageOpt(opts, readOnly)
-		if err != nil {
-			return err
-		}
 		// Set container disk quota limit
 		// If it is set to 0, we will track the disk usage, but not enforce a limit
 		if err := d.quotaCtl.SetQuota(dir, quota); err != nil {
@@ -1215,12 +1206,18 @@ func (d *Driver) parseStorageOpt(opts *graphdriver.CreateOpts, readOnly bool) (q
 		key := strings.ToLower(key)
 		switch key {
 		case "size":
+			if readOnly {
+				return quota.Quota{}, fmt.Errorf("--storage-opt size is only supported for ReadWrite Layers")
+			}
 			size, err := units.RAMInBytes(val)
 			if err != nil {
 				return quota.Quota{}, err
 			}
 			res.Size = uint64(size)
 		case "inodes":
+			if readOnly {
+				return quota.Quota{}, fmt.Errorf("--storage-opt inodes is only supported for ReadWrite Layers")
+			}
 			inodes, err := strconv.ParseUint(val, 10, 64)
 			if err != nil {
 				return quota.Quota{}, err


### PR DESCRIPTION
Primarily fix overlay so that it doesn’t modify callers’ `StorageOpt`.

Also report errors earlier, remove duplication, and other minor cleanups. See individual commit messages for details.

Motivated by #719; Cc: @akhilsaivenkata .