### PR TITLE
Make `blobcache` compression format aware

### DIFF
--- a/image/pkg/blobcache/blobcache.go
+++ b/image/pkg/blobcache/blobcache.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	digest "github.com/opencontainers/go-digest"
 	"go.podman.io/image/v5/docker/reference"
 	"go.podman.io/image/v5/internal/image"
+	"go.podman.io/image/v5/pkg/compression"
 	"go.podman.io/image/v5/transports"
 	"go.podman.io/image/v5/types"
 )
@@ -17,6 +19,37 @@ const (
 	compressedNote   = ".compressed"
 	decompressedNote = ".decompressed"
 )
+
+// "Key: <digest>, Value: <algorithm>"
+type compressionNoteContent map[string]string
+
+func (c compressionNoteContent) String() string {
+	var lines []string
+	for digestStr, algoName := range c {
+		if algoName != "" {
+			lines = append(lines, fmt.Sprintf("%s %s", digestStr, algoName))
+		} else {
+			lines = append(lines, digestStr)
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// parseCompressedNote parses the content of a .compressed sidecar note.
+// The format is one "<digest> [<algorithm>]" entry per line.
+// Old caches may have a single line with just "<digest>" (no algorithm, implies gzip).
+func parseCompressedNote(content []byte) compressionNoteContent {
+	entries := make(compressionNoteContent)
+	for _, line := range strings.Split(string(content), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		digestStr, algoName, _ := strings.Cut(line, " ")
+		entries[digestStr] = algoName
+	}
+	return entries
+}
 
 // BlobCache is an object which saves copies of blobs that are written to it while passing them
 // through to some real destination, and which can be queried directly in order to read them
@@ -29,6 +62,25 @@ type BlobCache struct {
 	// both within this process and by multiple different processes
 	directory string
 	compress  types.LayerCompression
+	// compressAlgorithm specifies compression algorithm for compressed blobs
+	// when compress is set to Compress.
+	// When compress is set to Decompress or PreserveOriginal, this field is ignored.
+	// Default compression algorithm is gzip.
+	compressAlgorithm *compression.Algorithm
+}
+
+// BlobCacheOption configures optional BlobCache behavior.
+type BlobCacheOption func(*BlobCache)
+
+// WithCompressAlgorithm sets compression algorithm for compressed blobs
+// when compress is set to Compress.
+func WithCompressAlgorithm(algo *compression.Algorithm) BlobCacheOption {
+	return func(b *BlobCache) {
+		if b.compress != types.Compress {
+			return
+		}
+		b.compressAlgorithm = algo
+	}
 }
 
 // NewBlobCache creates a new blob cache that wraps an image reference.  Any blobs which are
@@ -36,7 +88,8 @@ type BlobCache struct {
 // as-is to the specified directory or a temporary directory.
 // The compress argument controls whether or not the cache will try to substitute a compressed
 // or different version of a blob when preparing the list of layers when reading an image.
-func NewBlobCache(ref types.ImageReference, directory string, compress types.LayerCompression) (*BlobCache, error) {
+// The optional BlobCacheOption values can further refine behavior.
+func NewBlobCache(ref types.ImageReference, directory string, compress types.LayerCompression, opts ...BlobCacheOption) (*BlobCache, error) {
 	if directory == "" {
 		return nil, fmt.Errorf("error creating cache around reference %q: no directory specified", transports.ImageName(ref))
 	}
@@ -46,11 +99,15 @@ func NewBlobCache(ref types.ImageReference, directory string, compress types.Lay
 	default:
 		return nil, fmt.Errorf("unhandled LayerCompression value %v", compress)
 	}
-	return &BlobCache{
+	bc := &BlobCache{
 		reference: ref,
 		directory: directory,
 		compress:  compress,
-	}, nil
+	}
+	for _, o := range opts {
+		o(bc)
+	}
+	return bc, nil
 }
 
 func (b *BlobCache) Transport() types.ImageTransport {

--- a/image/pkg/blobcache/blobcache_test.go
+++ b/image/pkg/blobcache/blobcache_test.go
@@ -4,11 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"flag"
 	"fmt"
 	"io"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -23,6 +21,8 @@ import (
 	"go.podman.io/image/v5/internal/image"
 	"go.podman.io/image/v5/internal/private"
 	"go.podman.io/image/v5/pkg/blobinfocache/none"
+	"go.podman.io/image/v5/pkg/compression"
+	compressionTypes "go.podman.io/image/v5/pkg/compression/types"
 	"go.podman.io/image/v5/signature"
 	"go.podman.io/image/v5/types"
 	"go.podman.io/storage/pkg/archive"
@@ -66,102 +66,142 @@ func makeLayer(filename string, repeat int, compression archive.Compression) ([]
 	return compressed.Bytes(), digest.FromBytes(uncompressed.Bytes()), nil
 }
 
+func pushImageThroughCache(t *testing.T, cacheDir string, blobBytes []byte, diffID digest.Digest, layerMediaType string, desiredCompression types.LayerCompression, systemContext *types.SystemContext) (*BlobCache, string) {
+	t.Helper()
+	blobInfo := types.BlobInfo{
+		Digest: digest.FromBytes(blobBytes),
+		Size:   int64(len(blobBytes)),
+	}
+	// Create a configuration that includes the diffID for the layer and not much else.
+	config := v1.Image{
+		RootFS: v1.RootFS{
+			Type:    "layers",
+			DiffIDs: []digest.Digest{diffID},
+		},
+	}
+	configBytes, err := json.Marshal(&config)
+	if err != nil {
+		t.Fatalf("error encoding image configuration: %v", err)
+	}
+	configInfo := types.BlobInfo{
+		Digest: digest.FromBytes(configBytes),
+		Size:   int64(len(configBytes)),
+	}
+	m := v1.Manifest{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: v1.MediaTypeImageManifest,
+		Config: v1.Descriptor{
+			MediaType: v1.MediaTypeImageConfig,
+			Digest:    configInfo.Digest,
+			Size:      configInfo.Size,
+		},
+		Layers: []v1.Descriptor{{
+			MediaType: layerMediaType,
+			Digest:    blobInfo.Digest,
+			Size:      blobInfo.Size,
+		}},
+	}
+	manifestBytes, err := json.Marshal(&m)
+	if err != nil {
+		t.Fatalf("error encoding manifest: %v", err)
+	}
+
+	srcdir := t.TempDir()
+	srcRef, err := directory.NewReference(srcdir)
+	if err != nil {
+		t.Fatalf("error creating source reference: %v", err)
+	}
+	cachedRef, err := NewBlobCache(srcRef, cacheDir, desiredCompression)
+	if err != nil {
+		t.Fatalf("error creating blob cache: %v", err)
+	}
+	destImage, err := cachedRef.NewImageDestination(context.TODO(), nil)
+	if err != nil {
+		t.Fatalf("error opening destination: %v", err)
+	}
+	_, err = destImage.PutBlob(context.TODO(), bytes.NewReader(blobBytes), blobInfo, none.NoCache, false)
+	if err != nil {
+		t.Fatalf("error writing layer blob: %v", err)
+	}
+	_, err = destImage.PutBlob(context.TODO(), bytes.NewReader(configBytes), configInfo, none.NoCache, true)
+	if err != nil {
+		t.Fatalf("error writing config blob: %v", err)
+	}
+	srcImage, err := srcRef.NewImageSource(context.TODO(), systemContext)
+	if err != nil {
+		t.Fatalf("error opening source: %v", err)
+	}
+	defer srcImage.Close()
+	err = destImage.PutManifest(context.TODO(), manifestBytes, nil)
+	if err != nil {
+		t.Fatalf("error writing manifest: %v", err)
+	}
+	err = destImage.Commit(context.TODO(), image.UnparsedInstance(srcImage, nil))
+	if err != nil {
+		t.Fatalf("error committing: %v", err)
+	}
+	if err = destImage.Close(); err != nil {
+		t.Fatalf("error closing destination: %v", err)
+	}
+	return cachedRef, srcdir
+}
+
+type testCaseBlobCache struct {
+	desiredCompression types.LayerCompression
+	layerCompression   archive.Compression
+}
+
+func (tc *testCaseBlobCache) layerCompressionOCIType() (string, string) {
+	switch tc.layerCompression {
+	case archive.Gzip:
+		return v1.MediaTypeImageLayerGzip, compressionTypes.GzipAlgorithmName
+	case archive.Zstd:
+		return v1.MediaTypeImageLayerZstd, compressionTypes.ZstdAlgorithmName
+	default:
+		return v1.MediaTypeImageLayer, ""
+	}
+}
+
+func (tc *testCaseBlobCache) desiredCompressionString() string {
+	switch tc.desiredCompression {
+	case types.PreserveOriginal:
+		return "PreserveOriginal"
+	case types.Compress:
+		return "Compress"
+	case types.Decompress:
+		return "Decompress"
+	}
+	return "unknown"
+}
+
 func TestBlobCache(t *testing.T) {
 	cacheDir := t.TempDir()
 
 	systemContext := types.SystemContext{BlobInfoCacheDir: "/dev/null/this/does/not/exist"}
 
+	var testCases []testCaseBlobCache
+	for _, desiredCompression := range []types.LayerCompression{types.PreserveOriginal, types.Compress, types.Decompress} {
+		for _, layerCompression := range []archive.Compression{archive.Uncompressed, archive.Gzip, archive.Zstd} {
+			testCases = append(testCases, testCaseBlobCache{
+				desiredCompression: desiredCompression,
+				layerCompression:   layerCompression,
+			})
+		}
+	}
+
 	for _, repeat := range []int{1, 10000} {
-		for _, desiredCompression := range []types.LayerCompression{types.PreserveOriginal, types.Compress, types.Decompress} {
-			for _, layerCompression := range []archive.Compression{archive.Uncompressed, archive.Gzip} {
+		for _, tc := range testCases {
+			layerMediaType, expectedAlgoName := tc.layerCompressionOCIType()
+
+			t.Run(fmt.Sprintf("repeat=%d/desiredCompression=%s/layerCompression=%s", repeat, tc.desiredCompressionString(), expectedAlgoName), func(t *testing.T) {
 				// Create a layer with the specified layerCompression.
-				blobBytes, diffID, err := makeLayer(fmt.Sprintf("layer-content-%d", int(layerCompression)), repeat, layerCompression)
+				blobBytes, diffID, err := makeLayer(fmt.Sprintf("layer-content-%d", int(tc.layerCompression)), repeat, tc.layerCompression)
 				if err != nil {
 					t.Fatalf("error making layer: %v", err)
 				}
-				blobInfo := types.BlobInfo{
-					Digest: digest.FromBytes(blobBytes),
-					Size:   int64(len(blobBytes)),
-				}
-				// Create a configuration that includes the diffID for the layer and not much else.
-				config := v1.Image{
-					RootFS: v1.RootFS{
-						Type:    "layers",
-						DiffIDs: []digest.Digest{diffID},
-					},
-				}
-				configBytes, err := json.Marshal(&config)
-				if err != nil {
-					t.Fatalf("error encoding image configuration: %v", err)
-				}
-				configInfo := types.BlobInfo{
-					Digest: digest.FromBytes(configBytes),
-					Size:   int64(len(configBytes)),
-				}
-				// Create a manifest that uses this configuration and layer.
-				manifest := v1.Manifest{
-					Versioned: specs.Versioned{
-						SchemaVersion: 2,
-					},
-					MediaType: v1.MediaTypeImageManifest,
-					Config: v1.Descriptor{
-						MediaType: v1.MediaTypeImageConfig,
-						Digest:    configInfo.Digest,
-						Size:      configInfo.Size,
-					},
-					Layers: []v1.Descriptor{{
-						MediaType: v1.MediaTypeImageLayer,
-						Digest:    blobInfo.Digest,
-						Size:      blobInfo.Size,
-					}},
-				}
-				manifestBytes, err := json.Marshal(&manifest)
-				if err != nil {
-					t.Fatalf("error encoding image manifest: %v", err)
-				}
-				// Write this image to a "dir" destination with blob caching using this directory.
-				srcdir := t.TempDir()
-				srcRef, err := directory.NewReference(srcdir)
-				if err != nil {
-					t.Fatalf("error creating source image name reference for %q: %v", srcdir, err)
-				}
-				cachedSrcRef, err := NewBlobCache(srcRef, cacheDir, desiredCompression)
-				if err != nil {
-					t.Fatalf("failed to wrap reference in cache: %v", err)
-				}
-				destImage, err := cachedSrcRef.NewImageDestination(context.TODO(), nil)
-				if err != nil {
-					t.Fatalf("error opening source image for writing: %v", err)
-				}
-				_, err = destImage.PutBlob(context.TODO(), bytes.NewReader(blobBytes), blobInfo, none.NoCache, false)
-				if err != nil {
-					t.Fatalf("error writing layer blob to source image: %v", err)
-				}
-				_, err = destImage.PutBlob(context.TODO(), bytes.NewReader(configBytes), configInfo, none.NoCache, true)
-				if err != nil {
-					t.Fatalf("error writing config blob to source image: %v", err)
-				}
-				srcImage, err := srcRef.NewImageSource(context.TODO(), &systemContext)
-				if err != nil {
-					t.Fatalf("error opening source image: %v", err)
-				}
-				defer func() {
-					err := srcImage.Close()
-					if err != nil {
-						t.Fatalf("error closing source image: %v", err)
-					}
-				}()
-				err = destImage.PutManifest(context.TODO(), manifestBytes, nil)
-				if err != nil {
-					t.Fatalf("error writing manifest to source image: %v", err)
-				}
-				err = destImage.Commit(context.TODO(), image.UnparsedInstance(srcImage, nil))
-				if err != nil {
-					t.Fatalf("error committing source image: %v", err)
-				}
-				if err = destImage.Close(); err != nil {
-					t.Fatalf("error closing source image: %v", err)
-				}
+
+				cachedSrcRef, srcdir := pushImageThroughCache(t, cacheDir, blobBytes, diffID, layerMediaType, tc.desiredCompression, &systemContext)
+
 				// Check that the cache was populated.
 				cachedNames, err := os.ReadDir(cacheDir)
 				if err != nil {
@@ -169,27 +209,41 @@ func TestBlobCache(t *testing.T) {
 				}
 				// Expect a layer blob, a config blob, and the manifest.
 				expected := 3
-				if layerCompression != archive.Uncompressed {
+				if tc.layerCompression != archive.Uncompressed {
 					// Expect a compressed blob, an uncompressed blob, notes for each about the other, a config blob, and the manifest.
 					expected = 6
 				}
 				if len(cachedNames) != expected {
-					t.Fatalf("expected %d items in cache directory %q, got %d: %v", expected, cacheDir, len(cachedNames), cachedNames)
+					t.Fatalf("expected %d items in cache directory, got %d: %v", expected, len(cachedNames), cachedNames)
 				}
+
 				// Check that the blobs were all correctly stored.
 				for _, de := range cachedNames {
 					cachedName := de.Name()
 					if digest.Digest(cachedName).Validate() == nil {
-						cacheMember := filepath.Join(cacheDir, cachedName)
-						cacheMemberBytes, err := os.ReadFile(cacheMember)
+						cacheMemberBytes, err := os.ReadFile(filepath.Join(cacheDir, cachedName))
 						if err != nil {
 							t.Fatal(err)
 						}
 						if digest.FromBytes(cacheMemberBytes).String() != cachedName {
-							t.Fatalf("cache member %q was stored incorrectly!", cacheMember)
+							t.Fatalf("cache member %q was stored incorrectly!", cachedName)
 						}
 					}
 				}
+
+				// Verify the .compressed note records the correct algorithm.
+				if tc.layerCompression != archive.Uncompressed {
+					noteBytes, err := os.ReadFile(filepath.Join(cacheDir, diffID.String()) + compressedNote)
+					if err != nil {
+						t.Fatalf("error reading %s note: %v", compressedNote, err)
+					}
+					entries := parseCompressedNote(noteBytes)
+					blobDigest := digest.FromBytes(blobBytes).String()
+					if algoName, ok := entries[blobDigest]; !ok || algoName != expectedAlgoName {
+						t.Fatalf("expected entry %q %q in note, got: %q", blobDigest, expectedAlgoName, string(noteBytes))
+					}
+				}
+
 				// Clear out anything in the source directory that probably isn't a manifest, so that we'll
 				// have to depend on the cached copies of some of the blobs.
 				srcNames, err := os.ReadDir(srcdir)
@@ -197,17 +251,19 @@ func TestBlobCache(t *testing.T) {
 					t.Fatal(err)
 				}
 				for _, de := range srcNames {
-					name := de.Name()
-					if !strings.HasPrefix(name, "manifest") {
+					if name := de.Name(); !strings.HasPrefix(name, "manifest") {
 						os.Remove(filepath.Join(srcdir, name))
 					}
 				}
-				// Now that we've deleted some of the contents, try to copy from the source image
-				// to a second image.  It should fail because the source is missing some blobs.
-				destdir := t.TempDir()
-				destRef, err := directory.NewReference(destdir)
+
+				// Copying without the cache should fail because blobs are missing.
+				srcRef, err := directory.NewReference(srcdir)
 				if err != nil {
-					t.Fatalf("error creating destination image reference for %q: %v", destdir, err)
+					t.Fatalf("error creating source reference: %v", err)
+				}
+				destRef, err := directory.NewReference(t.TempDir())
+				if err != nil {
+					t.Fatalf("error creating destination reference: %v", err)
 				}
 				options := cp.Options{
 					SourceCtx:      &systemContext,
@@ -217,26 +273,135 @@ func TestBlobCache(t *testing.T) {
 					Default: []signature.PolicyRequirement{signature.NewPRInsecureAcceptAnything()},
 				})
 				if err != nil {
-					t.Fatalf("error creating signature policy context: %v", err)
+					t.Fatalf("error creating policy context: %v", err)
 				}
 				_, err = cp.Image(context.TODO(), policyContext, destRef, srcRef, &options)
 				if err == nil {
-					t.Fatalf("expected an error copying the image, but got success")
-				} else {
-					if errors.Is(err, fs.ErrNotExist) {
-						t.Logf("ok: got expected does-not-exist error copying the image with blobs missing: %v", err)
-					} else {
-						t.Logf("got an error copying the image with missing blobs, but not sure which error: %v", err)
-					}
+					t.Fatalf("expected an error copying without cache, but got success")
+				}
+
+				// Copying with the cache should succeed.
+				destRef, err = directory.NewReference(t.TempDir())
+				if err != nil {
+					t.Fatalf("error creating destination reference: %v", err)
 				}
 				_, err = cp.Image(context.TODO(), policyContext, destRef, cachedSrcRef, &options)
 				if err != nil {
-					t.Fatalf("unexpected error copying the image using the cache: %v", err)
+					t.Fatalf("unexpected error copying with cache: %v", err)
 				}
+
 				if err = cachedSrcRef.ClearCache(); err != nil {
 					t.Fatalf("error clearing cache: %v", err)
 				}
-			}
+			})
 		}
+	}
+}
+
+func TestBlobCacheMultipleCompressedVersions(t *testing.T) {
+	// Prepare cache with all compressed versions of the same layer.
+	cacheDir := t.TempDir()
+	systemContext := types.SystemContext{BlobInfoCacheDir: "/dev/null/this/does/not/exist"}
+
+	layerContent := "multi-compression-layer"
+
+	// uncompressed
+	uncompressedBytes, diffID, err := makeLayer(layerContent, 1, archive.Uncompressed)
+	if err != nil {
+		t.Fatalf("error making uncompressed layer: %v", err)
+	}
+	_, uncompressedSrcdir := pushImageThroughCache(t, cacheDir, uncompressedBytes, diffID, v1.MediaTypeImageLayer, types.PreserveOriginal, &systemContext)
+	uncompressedDigest := digest.FromBytes(uncompressedBytes)
+	if uncompressedDigest != diffID {
+		t.Fatalf("diffIDs should match: uncompressed=%s uncompressedDigest=%s", diffID, uncompressedDigest)
+	}
+
+	// gzip
+	gzipBytes, gzipDiffID, err := makeLayer(layerContent, 1, archive.Gzip)
+	if err != nil {
+		t.Fatalf("error making gzip layer: %v", err)
+	}
+	if diffID != gzipDiffID {
+		t.Fatalf("diffIDs should match: uncompressed=%s gzip=%s", diffID, gzipDiffID)
+	}
+	pushImageThroughCache(t, cacheDir, gzipBytes, diffID, v1.MediaTypeImageLayerGzip, types.PreserveOriginal, &systemContext)
+	gzipDigest := digest.FromBytes(gzipBytes)
+
+	// zstd
+	zstdBytes, zstdDiffID, err := makeLayer(layerContent, 1, archive.Zstd)
+	if err != nil {
+		t.Fatalf("error making zstd layer: %v", err)
+	}
+	if gzipDiffID != zstdDiffID {
+		t.Fatalf("diffIDs should match: gzip=%s zstd=%s", diffID, zstdDiffID)
+	}
+	pushImageThroughCache(t, cacheDir, zstdBytes, diffID, v1.MediaTypeImageLayerZstd, types.PreserveOriginal, &systemContext)
+	zstdDigest := digest.FromBytes(zstdBytes)
+
+	// Verify the .compressed note has both entries.
+	compressionNoteContent, err := os.ReadFile(filepath.Join(cacheDir, diffID.String()) + compressedNote)
+	if err != nil {
+		t.Fatalf("error reading compressed note: %v", err)
+	}
+	entries := parseCompressedNote(compressionNoteContent)
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries in compressed note, got %d: %q", len(entries), string(compressionNoteContent))
+	}
+	if algo, ok := entries[gzipDigest.String()]; !ok || algo != compressionTypes.GzipAlgorithmName {
+		t.Fatalf("missing or wrong gzip entry in compressed note; note content: %q", string(compressionNoteContent))
+	}
+	if algo, ok := entries[zstdDigest.String()]; !ok || algo != compressionTypes.ZstdAlgorithmName {
+		t.Fatalf("missing or wrong zstd entry in compressed note; note content: %q", string(compressionNoteContent))
+	}
+
+	// Search for the blobs in the cache.
+	for _, tc := range []struct {
+		name         string
+		compress     types.LayerCompression
+		algo         *compression.Algorithm
+		expectDigest digest.Digest
+		expectMedia  string
+	}{
+		{"search for gzip", types.Compress, &compression.Gzip, gzipDigest, v1.MediaTypeImageLayerGzip},
+		{"search for zstd", types.Compress, &compression.Zstd, zstdDigest, v1.MediaTypeImageLayerZstd},
+		{"search for default compression", types.Compress, nil, gzipDigest, v1.MediaTypeImageLayerGzip},
+		{"search for uncompressed", types.Decompress, nil, diffID, v1.MediaTypeImageLayer},
+		{"search for preserve original", types.PreserveOriginal, nil, diffID, v1.MediaTypeImageLayer},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ref, err := directory.NewReference(uncompressedSrcdir)
+			if err != nil {
+				t.Fatalf("error creating directory reference: %v", err)
+			}
+			var opts []BlobCacheOption
+			if tc.algo != nil {
+				opts = append(opts, WithCompressAlgorithm(tc.algo))
+			}
+			cachedRef, err := NewBlobCache(ref, cacheDir, tc.compress, opts...)
+			if err != nil {
+				t.Fatalf("error creating blob cache: %v", err)
+			}
+			src, err := cachedRef.NewImageSource(context.TODO(), &systemContext)
+			if err != nil {
+				t.Fatalf("error opening image source: %v", err)
+			}
+			defer src.Close()
+
+			layerInfos, err := src.LayerInfosForCopy(context.TODO(), nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(layerInfos) != 1 {
+				t.Fatalf("expected 1 layer info, got %d", len(layerInfos))
+			}
+
+			result := layerInfos[0]
+			if result.Digest != tc.expectDigest {
+				t.Fatalf("expected digest %s, got %s", tc.expectDigest.String(), result.Digest.String())
+			}
+			if result.MediaType != tc.expectMedia {
+				t.Fatalf("expected media type %s, got %s", tc.expectMedia, result.MediaType)
+			}
+		})
 	}
 }

--- a/image/pkg/blobcache/dest.go
+++ b/image/pkg/blobcache/dest.go
@@ -1,10 +1,11 @@
 package blobcache
 
 import (
-	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sync"
@@ -17,6 +18,7 @@ import (
 	"go.podman.io/image/v5/internal/private"
 	"go.podman.io/image/v5/internal/signature"
 	"go.podman.io/image/v5/manifest"
+	"go.podman.io/image/v5/pkg/compression"
 	"go.podman.io/image/v5/transports"
 	"go.podman.io/image/v5/types"
 	"go.podman.io/storage/pkg/archive"
@@ -77,8 +79,8 @@ func (d *blobCacheDestination) IgnoresEmbeddedDockerReference() bool {
 // Decompress and save the contents of the decompressReader stream into the passed-in temporary
 // file.  If we successfully save all of the data, rename the file to match the digest of the data,
 // and make notes about the relationship between the file that holds a copy of the compressed data
-// and this new file.
-func (d *blobCacheDestination) saveStream(decompressReader io.ReadCloser, tempFile *os.File, compressedFilename string, compressedDigest digest.Digest, isConfig bool, alternateDigest *digest.Digest) {
+// and this new file, including which compression algorithm was used.
+func (d *blobCacheDestination) saveStream(decompressReader io.ReadCloser, tempFile *os.File, compressedFilename string, compressedDigest digest.Digest, isConfig bool, algorithmName string, alternateDigest *digest.Digest) {
 	defer decompressReader.Close()
 
 	succeeded := false
@@ -125,9 +127,18 @@ func (d *blobCacheDestination) saveStream(decompressReader io.ReadCloser, tempFi
 	}
 	succeeded = true
 	*alternateDigest = digester.Digest()
+	// Update the .compressed note with this entry, preserving any existing entries
+	// for other compression algorithms. The format is one "<digest> <algorithm>" per line.
+	rawCompressedNote, err := os.ReadFile(decompressedFilename + compressedNote)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		logrus.Debugf("error reading compressed note for %q: %v", decompressedFilename, err)
+		return
+	}
+	compressedNoteContent := parseCompressedNote(rawCompressedNote)
+	compressedNoteContent[compressedDigest.String()] = algorithmName
 	// Note the relationship between the two files.
-	if err := ioutils.AtomicWriteFile(decompressedFilename+compressedNote, []byte(compressedDigest.String()), 0o600); err != nil {
-		logrus.Debugf("error noting that the compressed version of %q is %q: %v", digester.Digest().String(), compressedDigest.String(), err)
+	if err := ioutils.AtomicWriteFile(decompressedFilename+compressedNote, []byte(compressedNoteContent.String()), 0o600); err != nil {
+		logrus.Debugf("error noting that the compressed version of %q is %q: %v", digester.Digest().String(), compressedNoteContent.String(), err)
 	}
 	if err := ioutils.AtomicWriteFile(compressedFilename+decompressedNote, []byte(digester.Digest().String()), 0o600); err != nil {
 		logrus.Debugf("error noting that the decompressed version of %q is %q: %v", compressedDigest.String(), digester.Digest().String(), err)
@@ -156,11 +167,9 @@ func (d *blobCacheDestination) NoteOriginalOCIConfig(ociConfig *imgspecv1.Image,
 func (d *blobCacheDestination) PutBlobWithOptions(ctx context.Context, stream io.Reader, inputInfo types.BlobInfo, options private.PutBlobOptions) (private.UploadedBlob, error) {
 	var tempfile *os.File
 	var err error
-	var n int
 	var alternateDigest digest.Digest
 	var closer io.Closer
 	wg := new(sync.WaitGroup)
-	compression := archive.Uncompressed
 	if inputInfo.Digest != "" {
 		filename, err2 := d.reference.blobPath(inputInfo.Digest, options.IsConfig)
 		if err2 != nil {
@@ -188,18 +197,12 @@ func (d *blobCacheDestination) PutBlobWithOptions(ctx context.Context, stream io
 			logrus.Debugf("error while creating a temporary file under %q to hold blob %q: %v", filepath.Dir(filename), inputInfo.Digest.String(), err)
 		}
 		if !options.IsConfig {
-			initial := make([]byte, 8)
-			n, err = stream.Read(initial)
-			if n > 0 {
-				// Build a Reader that will still return the bytes that we just
-				// read, for PutBlob()'s sake.
-				stream = io.MultiReader(bytes.NewReader(initial[:n]), stream)
-				if n >= len(initial) {
-					compression = archive.DetectCompression(initial[:n])
-				}
-				if compression == archive.Gzip {
-					// The stream is compressed, so create a file which we'll
-					// use to store a decompressed copy.
+			algo, _, updatedStream, err2 := compression.DetectCompressionFormat(stream)
+			if err2 != nil {
+				logrus.Debugf("error detecting compression of blob %q: %v", inputInfo.Digest.String(), err2)
+			} else {
+				stream = updatedStream
+				if algo.Name() != "" {
 					decompressedTemp, err2 := os.CreateTemp(filepath.Dir(filename), filepath.Base(filename))
 					if err2 != nil {
 						logrus.Debugf("error while creating a temporary file under %q to hold decompressed blob %q: %v", filepath.Dir(filename), inputInfo.Digest.String(), err2)
@@ -212,7 +215,7 @@ func (d *blobCacheDestination) PutBlobWithOptions(ctx context.Context, stream io
 						stream = io.TeeReader(stream, decompressWriter)
 						// Let saveStream() close the reading end and handle the temporary file.
 						wg.Go(func() {
-							d.saveStream(decompressReader, decompressedTemp, filename, inputInfo.Digest, options.IsConfig, &alternateDigest)
+							d.saveStream(decompressReader, decompressedTemp, filename, inputInfo.Digest, options.IsConfig, algo.Name(), &alternateDigest)
 						})
 					}
 				}

--- a/image/pkg/blobcache/src.go
+++ b/image/pkg/blobcache/src.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"maps"
 	"math"
 	"os"
 	"sync"
@@ -18,8 +19,10 @@ import (
 	"go.podman.io/image/v5/internal/private"
 	"go.podman.io/image/v5/internal/signature"
 	"go.podman.io/image/v5/pkg/compression"
+	compressionTypes "go.podman.io/image/v5/pkg/compression/types"
 	"go.podman.io/image/v5/transports"
 	"go.podman.io/image/v5/types"
+	chunkedToc "go.podman.io/storage/pkg/chunked/toc"
 )
 
 type blobCacheSource struct {
@@ -119,58 +122,130 @@ func (s *blobCacheSource) GetSignaturesWithFormat(ctx context.Context, instanceD
 
 // layerInfoForCopy returns a possibly-updated version of info for LayerInfosForCopy
 func (s *blobCacheSource) layerInfoForCopy(info types.BlobInfo) (types.BlobInfo, error) {
-	var replaceDigestBytes []byte
 	blobFile, err := s.reference.blobPath(info.Digest, false)
 	if err != nil {
 		return types.BlobInfo{}, err
 	}
+
 	switch s.reference.compress {
 	case types.Compress:
-		replaceDigestBytes, err = os.ReadFile(blobFile + compressedNote)
+		noteContent, err := os.ReadFile(blobFile + compressedNote)
+		if err != nil {
+			return info, nil
+		}
+		// The .compressed note may contain multiple entries (one per line),
+		// each "<digest> [<algorithm>]". Try each until we find one that
+		// is compatible with the layer's media type and, if the caller
+		// requested a specific algorithm, matches that algorithm.
+
+		requestedCompressedAlgo := compression.Gzip
+		if s.reference.compressAlgorithm != nil {
+			requestedCompressedAlgo = *s.reference.compressAlgorithm
+		}
+		for digestStr, algoName := range parseCompressedNote(noteContent) {
+			replaceDigest, err := digest.Parse(digestStr)
+			if err != nil {
+				continue
+			}
+			alternate, err := s.reference.blobPath(replaceDigest, false)
+			if err != nil {
+				return types.BlobInfo{}, err
+			}
+			fileInfo, err := os.Stat(alternate)
+			if err != nil {
+				continue
+			}
+
+			// Fall back to gzip for backward compatibility with old caches
+			// that did not record the algorithm.
+			compressedAlgo := compression.Gzip
+			if algoName != "" {
+				a, err := compression.AlgorithmByName(algoName)
+				if err != nil {
+					logrus.Debugf("skipping cached blob with unknown compression algorithm %q: %v", algoName, err)
+					continue
+				}
+				compressedAlgo = a
+			}
+
+			if compressedAlgo.Name() != requestedCompressedAlgo.Name() {
+				logrus.Debugf("skipping cached blob %q: algorithm %q does not match requested %q", replaceDigest.String(), compressedAlgo.Name(), requestedCompressedAlgo.Name())
+				continue
+			}
+
+			result := info
+			switch info.MediaType {
+			case v1.MediaTypeImageLayer, v1.MediaTypeImageLayerGzip, v1.MediaTypeImageLayerZstd:
+				switch compressedAlgo.Name() {
+				case compressionTypes.GzipAlgorithmName:
+					result.MediaType = v1.MediaTypeImageLayerGzip
+				case compressionTypes.ZstdAlgorithmName, compressionTypes.ZstdChunkedAlgorithmName:
+					result.MediaType = v1.MediaTypeImageLayerZstd
+				default:
+					logrus.Debugf("not suggesting cached blob for digest %q: unsupported compression algorithm %q for OCI media type %q", info.Digest.String(), compressedAlgo.Name(), info.MediaType)
+					continue
+				}
+			case manifest.DockerV2SchemaLayerMediaTypeUncompressed, manifest.DockerV2Schema2LayerMediaType, manifest.DockerV2SchemaLayerMediaTypeZstd:
+				if compressedAlgo.Name() != compressionTypes.GzipAlgorithmName {
+					logrus.Debugf("not suggesting cached blob for digest %q: Docker schema does not support compression algorithm %q", info.Digest.String(), compressedAlgo.Name())
+					continue
+				}
+				result.MediaType = manifest.DockerV2Schema2LayerMediaType
+			default:
+				continue
+			}
+
+			result.CompressionAlgorithm = &compressedAlgo
+			result.CompressionOperation = s.reference.compress
+			result.Digest = replaceDigest
+			result.Size = fileInfo.Size()
+			logrus.Debugf("suggesting cached blob with digest %q, type %q, and compression %v in place of blob with digest %q", result.Digest.String(), result.MediaType, s.reference.compress, info.Digest.String())
+			logrus.Debugf("info = %#v", result)
+			return result, nil
+		}
+		return info, nil
+
 	case types.Decompress:
-		replaceDigestBytes, err = os.ReadFile(blobFile + decompressedNote)
-	}
-	if err != nil {
-		return info, nil
-	}
-	replaceDigest, err := digest.Parse(string(replaceDigestBytes))
-	if err != nil {
-		return info, nil
-	}
-	alternate, err := s.reference.blobPath(replaceDigest, false)
-	if err != nil {
-		return types.BlobInfo{}, err
-	}
-	fileInfo, err := os.Stat(alternate)
-	if err != nil {
+		noteBytes, err := os.ReadFile(blobFile + decompressedNote)
+		if err != nil {
+			return info, nil
+		}
+		replaceDigest, err := digest.Parse(string(noteBytes))
+		if err != nil {
+			return info, nil
+		}
+		alternate, err := s.reference.blobPath(replaceDigest, false)
+		if err != nil {
+			return types.BlobInfo{}, err
+		}
+		fileInfo, err := os.Stat(alternate)
+		if err != nil {
+			return info, nil
+		}
+
+		switch info.MediaType {
+		case v1.MediaTypeImageLayer, v1.MediaTypeImageLayerGzip, v1.MediaTypeImageLayerZstd:
+			info.MediaType = v1.MediaTypeImageLayer
+			info.CompressionAlgorithm = nil
+			if info.Annotations != nil {
+				info.Annotations = maps.Clone(info.Annotations)
+				for k := range chunkedToc.ChunkedAnnotations {
+					delete(info.Annotations, k)
+				}
+			}
+		case manifest.DockerV2SchemaLayerMediaTypeUncompressed, manifest.DockerV2Schema2LayerMediaType, manifest.DockerV2SchemaLayerMediaTypeZstd:
+			// Docker schema does not support suggesting decompressed layers.
+			return info, nil
+		}
+
+		logrus.Debugf("suggesting cached blob with digest %q, type %q, and compression %v in place of blob with digest %q", replaceDigest.String(), info.MediaType, s.reference.compress, info.Digest.String())
+		info.CompressionOperation = s.reference.compress
+		info.Digest = replaceDigest
+		info.Size = fileInfo.Size()
+		logrus.Debugf("info = %#v", info)
 		return info, nil
 	}
 
-	switch info.MediaType {
-	case v1.MediaTypeImageLayer, v1.MediaTypeImageLayerGzip:
-		switch s.reference.compress {
-		case types.Compress:
-			info.MediaType = v1.MediaTypeImageLayerGzip
-			info.CompressionAlgorithm = &compression.Gzip
-		case types.Decompress: // FIXME: This should remove zstd:chunked annotations (but those annotations being left with incorrect values should not break pulls)
-			info.MediaType = v1.MediaTypeImageLayer
-			info.CompressionAlgorithm = nil
-		}
-	case manifest.DockerV2SchemaLayerMediaTypeUncompressed, manifest.DockerV2Schema2LayerMediaType:
-		switch s.reference.compress {
-		case types.Compress:
-			info.MediaType = manifest.DockerV2Schema2LayerMediaType
-			info.CompressionAlgorithm = &compression.Gzip
-		case types.Decompress:
-			// nope, not going to suggest anything, it's not allowed by the spec
-			return info, nil
-		}
-	}
-	logrus.Debugf("suggesting cached blob with digest %q, type %q, and compression %v in place of blob with digest %q", replaceDigest.String(), info.MediaType, s.reference.compress, info.Digest.String())
-	info.CompressionOperation = s.reference.compress
-	info.Digest = replaceDigest
-	info.Size = fileInfo.Size()
-	logrus.Debugf("info = %#v", info)
 	return info, nil
 }
 


### PR DESCRIPTION
Record the compression algorithm in the `.compressed` sidecar note alongside the digest, so cached blobs are no longer assumed to be gzip-only. Update `layerInfoForCopy` to select the correct media type and strip `zstd:chunked` annotations on decompression.

Part of: https://github.com/containers/container-libs/issues/205

Related to: https://github.com/containers/buildah/issues/6660

Fixes: https://redhat.atlassian.net/browse/RUN-1124

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
