### PR TITLE
image/docker: use unified configfile search for cert directories

### DIFF
--- a/image/docker/docker_client.go
+++ b/image/docker/docker_client.go
@@ -33,8 +33,9 @@ import (
 	"go.podman.io/image/v5/pkg/sysregistriesv2"
 	"go.podman.io/image/v5/pkg/tlsclientconfig"
 	"go.podman.io/image/v5/types"
+	"go.podman.io/storage/pkg/configfile"
 	"go.podman.io/storage/pkg/fileutils"
-	"go.podman.io/storage/pkg/homedir"
+	"go.podman.io/storage/pkg/unshare"
 	"golang.org/x/sync/semaphore"
 )
 
@@ -58,19 +59,6 @@ const (
 	backoffNumIterations = 5
 	backoffInitialDelay  = 2 * time.Second
 	backoffMaxDelay      = 60 * time.Second
-)
-
-type certPath struct {
-	path     string
-	absolute bool
-}
-
-var (
-	homeCertDir     = filepath.FromSlash(".config/containers/certs.d")
-	perHostCertDirs = []certPath{
-		{path: etcDir + "/containers/certs.d", absolute: true},
-		{path: etcDir + "/docker/certs.d", absolute: true},
-	}
 )
 
 // extensionSignature and extensionSignatureList come from github.com/openshift/origin/pkg/dockerregistry/server/signaturedispatcher.go:
@@ -167,22 +155,35 @@ func dockerCertDir(sys *types.SystemContext, hostPort string) (string, error) {
 		return filepath.Join(sys.DockerPerHostCertDirPath, hostPort), nil
 	}
 
-	var (
-		hostCertDir     string
-		fullCertDirPath string
-	)
+	rootForImplicitAbsolutePaths := ""
+	if sys != nil {
+		rootForImplicitAbsolutePaths = sys.RootForImplicitAbsolutePaths
+	}
 
-	for _, perHostCertDir := range append([]certPath{{path: filepath.Join(homedir.Get(), homeCertDir), absolute: false}}, perHostCertDirs...) {
-		if sys != nil && sys.RootForImplicitAbsolutePaths != "" && perHostCertDir.absolute {
-			hostCertDir = filepath.Join(sys.RootForImplicitAbsolutePaths, perHostCertDir.path)
-		} else {
-			hostCertDir = perHostCertDir.path
-		}
+	paths, err := configfile.GetSearchPaths(&configfile.File{
+		Name:                           "certs",
+		Extension:                      "d",
+		DoNotUseExtensionForConfigName: true,
+		UserId:                         unshare.GetRootlessUID(),
+		RootForImplicitAbsolutePaths:   rootForImplicitAbsolutePaths,
+	})
+	if err != nil {
+		return "", err
+	}
 
-		fullCertDirPath = filepath.Join(hostCertDir, hostPort)
-		err := fileutils.Exists(fullCertDirPath)
+	candidates := make([]string, 0, len(paths.DropInDirectories)+1)
+	candidates = append(candidates, paths.DropInDirectories...)
+	perHostCertDir := etcDir + "/docker/certs.d"
+	if rootForImplicitAbsolutePaths != "" {
+		perHostCertDir = filepath.Join(rootForImplicitAbsolutePaths, perHostCertDir)
+	}
+	candidates = append(candidates, perHostCertDir)
+
+	for _, baseDir := range candidates {
+		fullCertDirPath := filepath.Join(baseDir, hostPort)
+		err = fileutils.Exists(fullCertDirPath)
 		if err == nil {
-			break
+			return fullCertDirPath, nil
 		}
 		if os.IsNotExist(err) {
 			continue
@@ -193,7 +194,7 @@ func dockerCertDir(sys *types.SystemContext, hostPort string) (string, error) {
 		}
 		return "", err
 	}
-	return fullCertDirPath, nil
+	return "", nil
 }
 
 // newDockerClientFromRef returns a new dockerClient instance for refHostname (a host a specified in the Docker image reference, not canonicalized to dockerRegistry)
@@ -263,8 +264,10 @@ func newDockerClient(sys *types.SystemContext, registry, reference string) (*doc
 	if err != nil {
 		return nil, err
 	}
-	if err := tlsclientconfig.SetupCertificates(certDir, tlsClientConfig); err != nil {
-		return nil, err
+	if certDir != "" {
+		if err := tlsclientconfig.SetupCertificates(certDir, tlsClientConfig); err != nil {
+			return nil, err
+		}
 	}
 
 	// Check if TLS verification shall be skipped (default=false) which can

--- a/image/docker/docker_client_test.go
+++ b/image/docker/docker_client_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -21,26 +22,46 @@ import (
 )
 
 func TestDockerCertDir(t *testing.T) {
-	const nondefaultFullPath = "/this/is/not/the/default/full/path"
-	const nondefaultPerHostDir = "/this/is/not/the/default/certs.d"
-	const variableReference = "$HOME"
-	const rootPrefix = "/root/prefix"
-	const registryHostPort = "thishostdefinitelydoesnotexist:5000"
+	tempRoot := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tempRoot, "xdg"))
 
-	systemPerHostResult := filepath.Join(perHostCertDirs[len(perHostCertDirs)-1].path, registryHostPort)
+	nondefaultFullPath := filepath.Join(tempRoot, "nondefault", "full", "path")
+	nondefaultPerHostDir := filepath.Join(tempRoot, "nondefault", "certs.d")
+	const variableReference = "$HOME"
+	rootPrefix := filepath.Join(tempRoot, "rootprefix")
+	const registryHostPort = "thishostdefinitelydoesnotexist:5000"
+	const registryHostPortVendorOverDocker = "thishostdefinitelydoesnotexist:5001"
+	const registryHostPortDockerOnly = "thishostdefinitelydoesnotexist:5002"
+
+	hostDirs := []string{
+		"/etc/containers/certs.d",
+		"/etc/docker/certs.d",
+	}
+
+	// Create RootForImplicitAbsolutePaths-prefixed locations.
+	for _, d := range hostDirs {
+		require.NoError(t, os.MkdirAll(filepath.Join(rootPrefix, d, registryHostPort), 0o755))
+	}
+	require.NoError(t, os.MkdirAll(filepath.Join(rootPrefix, "/etc/docker/certs.d", registryHostPortVendorOverDocker), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(rootPrefix, "/usr/share/containers/certs.d", registryHostPortVendorOverDocker), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(rootPrefix, "/etc/docker/certs.d", registryHostPortDockerOnly), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(nondefaultPerHostDir, registryHostPort), 0o755))
+
 	for _, c := range []struct {
 		sys      *types.SystemContext
+		hostPort string
 		expected string
 	}{
-		// The common case
-		{nil, systemPerHostResult},
-		// There is a context, but it does not override the path.
-		{&types.SystemContext{}, systemPerHostResult},
+		// Work with nil SystemContext.
+		{nil, registryHostPort, ""},
+		// Work with empty SystemContext.
+		{&types.SystemContext{}, registryHostPort, ""},
 		// Full path overridden
-		{&types.SystemContext{DockerCertPath: nondefaultFullPath}, nondefaultFullPath},
+		{&types.SystemContext{DockerCertPath: nondefaultFullPath}, registryHostPort, nondefaultFullPath},
 		// Per-host path overridden
 		{
 			&types.SystemContext{DockerPerHostCertDirPath: nondefaultPerHostDir},
+			registryHostPort,
 			filepath.Join(nondefaultPerHostDir, registryHostPort),
 		},
 		// Both overridden
@@ -49,12 +70,24 @@ func TestDockerCertDir(t *testing.T) {
 				DockerCertPath:           nondefaultFullPath,
 				DockerPerHostCertDirPath: nondefaultPerHostDir,
 			},
+			registryHostPort,
 			nondefaultFullPath,
 		},
 		// Root overridden
 		{
 			&types.SystemContext{RootForImplicitAbsolutePaths: rootPrefix},
-			filepath.Join(rootPrefix, systemPerHostResult),
+			registryHostPort,
+			filepath.Join(rootPrefix, "/etc/containers/certs.d", registryHostPort),
+		},
+		{
+			&types.SystemContext{RootForImplicitAbsolutePaths: rootPrefix},
+			registryHostPortVendorOverDocker,
+			filepath.Join(rootPrefix, "/usr/share/containers/certs.d", registryHostPortVendorOverDocker),
+		},
+		{
+			&types.SystemContext{RootForImplicitAbsolutePaths: rootPrefix},
+			registryHostPortDockerOnly,
+			filepath.Join(rootPrefix, "/etc/docker/certs.d", registryHostPortDockerOnly),
 		},
 		// Root and path overrides present simultaneously,
 		{
@@ -62,6 +95,7 @@ func TestDockerCertDir(t *testing.T) {
 				DockerCertPath:               nondefaultFullPath,
 				RootForImplicitAbsolutePaths: rootPrefix,
 			},
+			registryHostPort,
 			nondefaultFullPath,
 		},
 		{
@@ -69,6 +103,7 @@ func TestDockerCertDir(t *testing.T) {
 				DockerPerHostCertDirPath:     nondefaultPerHostDir,
 				RootForImplicitAbsolutePaths: rootPrefix,
 			},
+			registryHostPort,
 			filepath.Join(nondefaultPerHostDir, registryHostPort),
 		},
 		// … and everything at once
@@ -78,16 +113,18 @@ func TestDockerCertDir(t *testing.T) {
 				DockerPerHostCertDirPath:     nondefaultPerHostDir,
 				RootForImplicitAbsolutePaths: rootPrefix,
 			},
+			registryHostPort,
 			nondefaultFullPath,
 		},
 		// No environment expansion happens in the overridden paths
-		{&types.SystemContext{DockerCertPath: variableReference}, variableReference},
+		{&types.SystemContext{DockerCertPath: variableReference}, registryHostPort, variableReference},
 		{
 			&types.SystemContext{DockerPerHostCertDirPath: variableReference},
+			registryHostPort,
 			filepath.Join(variableReference, registryHostPort),
 		},
 	} {
-		path, err := dockerCertDir(c.sys, registryHostPort)
+		path, err := dockerCertDir(c.sys, c.hostPort)
 		require.Equal(t, nil, err)
 		assert.Equal(t, c.expected, path)
 	}

--- a/image/docs/containers-certs.d.5.md
+++ b/image/docs/containers-certs.d.5.md
@@ -4,8 +4,26 @@
 containers-certs.d - Directory for storing custom container-registry TLS configurations
 
 # DESCRIPTION
-A custom TLS configuration for a container registry can be configured by creating a directory under `$HOME/.config/containers/certs.d` or `/etc/containers/certs.d`.
-The name of the directory must correspond to the `host`[`:port`] of the registry (e.g., `my-registry.com:5000`).
+A custom TLS configuration for a container registry can be configured by creating a directory named after the registry `host`[`:port`] (for example, `my-registry.com:5000`) in one of the following locations.
+Directories are consulted in this order (highest priority first):
+
+- For both rootful and rootless:
+  - `$XDG_CONFIG_HOME/containers/certs.d/` (or `$HOME/.config/containers/certs.d/` if `XDG_CONFIG_HOME` is unset)
+  - `/etc/containers/certs.d/`
+- For rootful (UID == 0):
+  - `/etc/containers/certs.rootful.d/`
+- For rootless (UID > 0):
+  - `/etc/containers/certs.rootless.d/`
+  - `/etc/containers/certs.rootless.d/<UID>/`
+- For both rootful and rootless:
+  - `/usr/share/containers/certs.d/`
+- For rootful (UID == 0):
+  - `/usr/share/containers/certs.rootful.d/`
+- For rootless (UID > 0):
+  - `/usr/share/containers/certs.rootless.d/`
+  - `/usr/share/containers/certs.rootless.d/<UID>/`
+- Compatibility fallback:
+  - `/etc/docker/certs.d/`
 
 The port part presence / absence must precisely match the port usage in image references,
 e.g. to affect `podman pull registry.example/foo`,


### PR DESCRIPTION
Switch `dockerCertDir` to use the new
`configfile.ContainersResourceDirs` for resolving certificate directories.

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
