### PR TITLE
Use the official moby/api types for Docker progress

### DIFF
--- a/image/docker/daemon/daemon_dest.go
+++ b/image/docker/daemon/daemon_dest.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/moby/moby/api/types/jsonstream"
 	"github.com/moby/moby/client"
 	"github.com/sirupsen/logrus"
 	"go.podman.io/image/v5/docker/internal/tarfile"
@@ -95,18 +96,9 @@ func imageLoad(ctx context.Context, c *client.Client, reader *io.PipeReader) err
 	}
 	defer res.Close()
 
-	// jsonError and jsonMessage are small subsets of docker/docker/pkg/jsonmessage.JSONError and JSONMessage,
-	// copied here to minimize dependencies.
-	type jsonError struct {
-		Message string `json:"message,omitempty"`
-	}
-	type jsonMessage struct {
-		Error *jsonError `json:"errorDetail,omitempty"`
-	}
-
 	dec := json.NewDecoder(res)
 	for {
-		var msg jsonMessage
+		var msg jsonstream.Message
 		if err := dec.Decode(&msg); err != nil {
 			if err == io.EOF {
 				break

--- a/image/go.mod
+++ b/image/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/klauspost/pgzip v1.2.6
 	github.com/manifoldco/promptui v0.9.0
 	github.com/mattn/go-sqlite3 v1.14.42
+	github.com/moby/moby/api v1.54.1
 	github.com/moby/moby/client v0.4.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
@@ -75,7 +76,6 @@ require (
 	github.com/miekg/pkcs11 v1.1.1 // indirect
 	github.com/mistifyio/go-zfs/v4 v4.0.0 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
-	github.com/moby/moby/api v1.54.1 // indirect
 	github.com/moby/sys/capability v0.4.0 // indirect
 	github.com/moby/sys/mountinfo v0.7.2 // indirect
 	github.com/moby/sys/user v0.4.0 // indirect


### PR DESCRIPTION
A low-priority cleanup.

Nowadays the API type definitions are separate from code, and we indirectly import this subpackage anyway (it's used by `moby/client`, we can't avoid it), so use the official types instead of private copies.

Should not change behavior against ordinary clients; hypothetically might cause decoding errors if one of the now-decoded fields used an invalid type or value.