### PR TITLE
json-proxy: Verify *either* manifest list or per-arch signature 

### DIFF
--- a/common/cmd/json-proxy-test-server/main.go
+++ b/common/cmd/json-proxy-test-server/main.go
@@ -4,11 +4,11 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"os"
-	"strconv"
 
-	"go.podman.io/common/pkg/json-proxy"
+	jsonproxy "go.podman.io/common/pkg/json-proxy"
 	"go.podman.io/image/v5/signature"
 	"go.podman.io/image/v5/types"
 )
@@ -21,20 +21,31 @@ func main() {
 }
 
 func run() error {
-	if len(os.Args) < 3 || os.Args[1] != "--sockfd" {
-		return fmt.Errorf("usage: %s --sockfd <fd>", os.Args[0])
-	}
-	sockfd, err := strconv.Atoi(os.Args[2])
-	if err != nil {
-		return fmt.Errorf("invalid sockfd: %v", err)
+	sockfd := flag.Int("sockfd", -1, "socket file descriptor")
+	policyPath := flag.String("policy", "", "path to policy.json (default: system default)")
+	overrideArch := flag.String("override-arch", "", "override architecture for manifest list resolution")
+	flag.Parse()
+
+	if *sockfd < 0 {
+		return fmt.Errorf("usage: %s --sockfd <fd> [--policy <path>] [--override-arch <arch>]", os.Args[0])
 	}
 
 	manager, err := jsonproxy.NewManager(
 		jsonproxy.WithSystemContext(func() (*types.SystemContext, error) {
-			return &types.SystemContext{}, nil
+			sc := &types.SystemContext{}
+			if *overrideArch != "" {
+				sc.ArchitectureChoice = *overrideArch
+			}
+			return sc, nil
 		}),
 		jsonproxy.WithPolicyContext(func() (*signature.PolicyContext, error) {
-			policy, err := signature.DefaultPolicy(nil)
+			var policy *signature.Policy
+			var err error
+			if *policyPath != "" {
+				policy, err = signature.NewPolicyFromFile(*policyPath)
+			} else {
+				policy, err = signature.DefaultPolicy(nil)
+			}
 			if err != nil {
 				return nil, err
 			}
@@ -45,5 +56,5 @@ func run() error {
 		return err
 	}
 	defer manager.Close()
-	return manager.Serve(context.Background(), sockfd)
+	return manager.Serve(context.Background(), *sockfd)
 }

--- a/common/pkg/json-proxy/handler.go
+++ b/common/pkg/json-proxy/handler.go
@@ -34,6 +34,7 @@ type handler struct {
 
 	// Internal state.
 	sysctx      *types.SystemContext
+	policyctx   *signature.PolicyContext
 	cache       types.BlobInfoCache
 	imageSerial uint64
 	images      map[uint64]*openImage
@@ -62,6 +63,13 @@ func (h *handler) close() {
 			h.logger.Warnf("Failed to close image: %v", err)
 		}
 	}
+
+	if h.policyctx != nil {
+		if err := h.policyctx.Destroy(); err != nil {
+			h.logger.Warnf("tearing down policy context: %v", err)
+		}
+		h.policyctx = nil
+	}
 }
 
 // Initialize performs one-time initialization, and returns the protocol version.
@@ -86,6 +94,12 @@ func (h *handler) Initialize(ctx context.Context, args []any) (replyBuf, error) 
 	h.sysctx = sysctx
 	h.cache = blobinfocache.DefaultCache(sysctx)
 
+	policyContext, err := h.getPolicyContext()
+	if err != nil {
+		return ret, err
+	}
+	h.policyctx = policyContext
+
 	r := replyBuf{
 		value: protocolVersion,
 	}
@@ -98,7 +112,7 @@ func (h *handler) OpenImage(ctx context.Context, args []any) (replyBuf, error) {
 	return h.openImageImpl(ctx, args, false)
 }
 
-func (h *handler) openImageImpl(ctx context.Context, args []any, allowNotFound bool) (retReplyBuf replyBuf, retErr error) {
+func (h *handler) openImageImpl(ctx context.Context, args []any, allowNotFound bool) (replyBuf, error) {
 	h.lock.Lock()
 	defer h.lock.Unlock()
 	var ret replyBuf
@@ -127,18 +141,8 @@ func (h *handler) openImageImpl(ctx context.Context, args []any, allowNotFound b
 		return ret, err
 	}
 
-	policyContext, err := h.getPolicyContext()
-	if err != nil {
-		return ret, err
-	}
-	defer func() {
-		if err := policyContext.Destroy(); err != nil {
-			retErr = noteCloseFailure(retErr, "tearing down policy context", err)
-		}
-	}()
-
 	unparsedTopLevel := image.UnparsedInstance(imgsrc, nil)
-	allowed, err := policyContext.IsRunningImageAllowed(ctx, unparsedTopLevel)
+	allowed, err := h.policyctx.IsRunningImageAllowed(ctx, unparsedTopLevel)
 	if err != nil {
 		return ret, err
 	}

--- a/common/pkg/json-proxy/handler.go
+++ b/common/pkg/json-proxy/handler.go
@@ -142,12 +142,54 @@ func (h *handler) openImageImpl(ctx context.Context, args []any, allowNotFound b
 	}
 
 	unparsedTopLevel := image.UnparsedInstance(imgsrc, nil)
-	allowed, err := h.policyctx.IsRunningImageAllowed(ctx, unparsedTopLevel)
+	// Check the signature on the toplevel (possibly multi-arch) manifest, but we don't
+	// yet propagate the error here.
+	allowed, toplevelVerificationErr := h.policyctx.IsRunningImageAllowed(ctx, unparsedTopLevel)
+	if toplevelVerificationErr == nil && !allowed {
+		return ret, errors.New("internal inconsistency: policy verification failed without returning an error")
+	}
+
+	mfest, manifestType, err := unparsedTopLevel.Manifest(ctx)
 	if err != nil {
 		return ret, err
 	}
-	if !allowed {
-		return ret, errors.New("internal inconsistency: policy verification failed without returning an error")
+	var target *image.UnparsedImage
+	if manifest.MIMETypeIsMultiImage(manifestType) {
+		manifestList, err := manifest.ListFromBlob(mfest, manifestType)
+		if err != nil {
+			return ret, err
+		}
+		instanceDigest, err := manifestList.ChooseInstance(h.sysctx)
+		if err != nil {
+			return ret, err
+		}
+		target = image.UnparsedInstance(imgsrc, &instanceDigest)
+
+		allowed, targetVerificationErr := h.policyctx.IsRunningImageAllowed(ctx, target)
+		if targetVerificationErr == nil && !allowed {
+			return ret, errors.New("internal inconsistency: policy verification failed without returning an error")
+		}
+
+		// Now, we only error if *both* the toplevel and target verification failed.
+		// If either succeeded, that's OK.  We want to support a case where the manifest
+		// list is signed, but the target is not (because we previously supported that behavior),
+		// and we want to support the case where only the target is signed (consistent with
+		// what c/image enforces).
+		if targetVerificationErr != nil && toplevelVerificationErr != nil {
+			return ret, targetVerificationErr
+		}
+	} else {
+		target = unparsedTopLevel
+
+		// We're not using a manifest list, so require verification of the single arch manifest.
+		if toplevelVerificationErr != nil {
+			return ret, toplevelVerificationErr
+		}
+	}
+
+	img, err := image.FromUnparsedImage(ctx, h.sysctx, target)
+	if err != nil {
+		return ret, err
 	}
 
 	// Note that we never return zero as an imageid; this code doesn't yet
@@ -156,6 +198,7 @@ func (h *handler) openImageImpl(ctx context.Context, args []any, allowNotFound b
 	openimg := &openImage{
 		id:  h.imageSerial,
 		src: imgsrc,
+		img: img,
 	}
 	h.images[openimg.id] = openimg
 	ret.value = openimg.id
@@ -255,43 +298,6 @@ func (h *handler) returnBytes(retval any, buf []byte) (replyBuf, error) {
 	return ret, nil
 }
 
-// cacheTargetManifest is invoked when GetManifest or GetConfig is invoked
-// the first time for a given image.  If the requested image is a manifest
-// list, this function resolves it to the image matching the calling process'
-// operating system and architecture.
-//
-// TODO: Add GetRawManifest or so that exposes manifest lists.
-func (h *handler) cacheTargetManifest(ctx context.Context, img *openImage) error {
-	if img.cachedimg != nil {
-		return nil
-	}
-	unparsedToplevel := image.UnparsedInstance(img.src, nil)
-	mfest, manifestType, err := unparsedToplevel.Manifest(ctx)
-	if err != nil {
-		return err
-	}
-	var target *image.UnparsedImage
-	if manifest.MIMETypeIsMultiImage(manifestType) {
-		manifestList, err := manifest.ListFromBlob(mfest, manifestType)
-		if err != nil {
-			return err
-		}
-		instanceDigest, err := manifestList.ChooseInstance(h.sysctx)
-		if err != nil {
-			return err
-		}
-		target = image.UnparsedInstance(img.src, &instanceDigest)
-	} else {
-		target = unparsedToplevel
-	}
-	cachedimg, err := image.FromUnparsedImage(ctx, h.sysctx, target)
-	if err != nil {
-		return err
-	}
-	img.cachedimg = cachedimg
-	return nil
-}
-
 // GetManifest returns a copy of the manifest, converted to OCI format, along with the original digest.
 // Manifest lists are resolved to the current operating system and architecture.
 func (h *handler) GetManifest(ctx context.Context, args []any) (replyBuf, error) {
@@ -311,13 +317,7 @@ func (h *handler) GetManifest(ctx context.Context, args []any) (replyBuf, error)
 		return ret, err
 	}
 
-	err = h.cacheTargetManifest(ctx, imgref)
-	if err != nil {
-		return ret, err
-	}
-	img := imgref.cachedimg
-
-	rawManifest, manifestType, err := img.Manifest(ctx)
+	rawManifest, manifestType, err := imgref.img.Manifest(ctx)
 	if err != nil {
 		return ret, err
 	}
@@ -346,7 +346,7 @@ func (h *handler) GetManifest(ctx context.Context, args []any) (replyBuf, error)
 	// docker schema and MIME types.
 	if manifestType != imgspecv1.MediaTypeImageManifest {
 		manifestUpdates := types.ManifestUpdateOptions{ManifestMIMEType: imgspecv1.MediaTypeImageManifest}
-		ociImage, err := img.UpdatedImage(ctx, manifestUpdates)
+		ociImage, err := imgref.img.UpdatedImage(ctx, manifestUpdates)
 		if err != nil {
 			return ret, err
 		}
@@ -380,13 +380,8 @@ func (h *handler) GetFullConfig(ctx context.Context, args []any) (replyBuf, erro
 	if err != nil {
 		return ret, err
 	}
-	err = h.cacheTargetManifest(ctx, imgref)
-	if err != nil {
-		return ret, err
-	}
-	img := imgref.cachedimg
 
-	config, err := img.OCIConfig(ctx)
+	config, err := imgref.img.OCIConfig(ctx)
 	if err != nil {
 		return ret, err
 	}
@@ -416,13 +411,8 @@ func (h *handler) GetConfig(ctx context.Context, args []any) (replyBuf, error) {
 	if err != nil {
 		return ret, err
 	}
-	err = h.cacheTargetManifest(ctx, imgref)
-	if err != nil {
-		return ret, err
-	}
-	img := imgref.cachedimg
 
-	config, err := img.OCIConfig(ctx)
+	config, err := imgref.img.OCIConfig(ctx)
 	if err != nil {
 		return ret, err
 	}
@@ -607,19 +597,13 @@ func (h *handler) GetLayerInfo(ctx context.Context, args []any) (replyBuf, error
 		return ret, err
 	}
 
-	err = h.cacheTargetManifest(ctx, imgref)
-	if err != nil {
-		return ret, err
-	}
-	img := imgref.cachedimg
-
-	layerInfos, err := img.LayerInfosForCopy(ctx)
+	layerInfos, err := imgref.img.LayerInfosForCopy(ctx)
 	if err != nil {
 		return ret, err
 	}
 
 	if layerInfos == nil {
-		layerInfos = img.LayerInfos()
+		layerInfos = imgref.img.LayerInfos()
 	}
 
 	layers := make([]convertedLayerInfo, 0, len(layerInfos))
@@ -655,19 +639,13 @@ func (h *handler) GetLayerInfoPiped(ctx context.Context, args []any) (replyBuf, 
 		return ret, err
 	}
 
-	err = h.cacheTargetManifest(ctx, imgref)
-	if err != nil {
-		return ret, err
-	}
-	img := imgref.cachedimg
-
-	layerInfos, err := img.LayerInfosForCopy(ctx)
+	layerInfos, err := imgref.img.LayerInfosForCopy(ctx)
 	if err != nil {
 		return ret, err
 	}
 
 	if layerInfos == nil {
-		layerInfos = img.LayerInfos()
+		layerInfos = imgref.img.LayerInfos()
 	}
 
 	layers := make([]convertedLayerInfo, 0, len(layerInfos))

--- a/common/pkg/json-proxy/proxy_test.go
+++ b/common/pkg/json-proxy/proxy_test.go
@@ -272,7 +272,7 @@ type byteFetch struct {
 	err     error
 }
 
-func newProxy(t *testing.T) *proxy {
+func newProxy(t *testing.T, extraArgs ...string) *proxy {
 	t.Helper()
 
 	proxyBinary := os.Getenv("JSON_PROXY_TEST_BINARY")
@@ -293,7 +293,8 @@ func newProxy(t *testing.T) *proxy {
 	require.True(t, ok, "expected *net.UnixConn, got %T", mysock)
 
 	// Note ExtraFiles starts at 3
-	proc := exec.Command(proxyBinary, "--sockfd", "3") //nolint:gosec
+	args := append([]string{"--sockfd", "3"}, extraArgs...)
+	proc := exec.Command(proxyBinary, args...) //nolint:gosec
 	proc.Stderr = os.Stderr
 	proc.ExtraFiles = append(proc.ExtraFiles, theirfd)
 
@@ -507,4 +508,55 @@ func TestProxyGetBlob(t *testing.T) {
 		err = fmt.Errorf("Testing GetBLob for %s: %v", knownListImage, err)
 	}
 	assert.NoError(t, err)
+}
+
+func TestProxyPolicyVerification(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		policy    string
+		image     string
+		extraArgs []string
+		wantErr   string // empty = expect success
+	}{
+		{
+			name:   "cosign-signed image accepted",
+			policy: "testdata/policy-cosign.json",
+			image:  "dir:testdata/dir-img-cosign-valid",
+		},
+		{
+			name:    "unsigned image rejected",
+			policy:  "testdata/policy-cosign.json",
+			image:   "dir:testdata/dir-img-unsigned",
+			wantErr: "signature",
+		},
+		{ // The proxy checks signatures on *either* the manifest list or per-arch manifest.
+			name:      "manifest-list with per-arch sig accepted",
+			policy:    "testdata/policy-cosign.json",
+			image:     "dir:testdata/dir-img-cosign-manifest-list-signed-arch",
+			extraArgs: []string{"--override-arch", "amd64"},
+		},
+		{
+			name:    "reject-all policy",
+			policy:  "testdata/policy-reject.json",
+			image:   "dir:testdata/dir-img-cosign-valid",
+			wantErr: "reject",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			args := append([]string{"--policy", tc.policy}, tc.extraArgs...)
+			p := newProxy(t, args...)
+			v, err := p.callNoFd("OpenImage", []any{tc.image})
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			imgID, ok := v.(float64)
+			require.True(t, ok)
+			require.NotZero(t, imgID)
+			_, err = p.callNoFd("CloseImage", []any{imgID})
+			require.NoError(t, err)
+		})
+	}
 }

--- a/common/pkg/json-proxy/testdata/cosign.pub
+++ b/common/pkg/json-proxy/testdata/cosign.pub
@@ -1,0 +1,1 @@
+../../../../image/signature/fixtures/cosign.pub

--- a/common/pkg/json-proxy/testdata/dir-img-cosign-manifest-list-signed-arch/634a8f35b5f16dcf4aaa0822adc0b1964bb786fca12f6831de8ddc45e5986a00.manifest.json
+++ b/common/pkg/json-proxy/testdata/dir-img-cosign-manifest-list-signed-arch/634a8f35b5f16dcf4aaa0822adc0b1964bb786fca12f6831de8ddc45e5986a00.manifest.json
@@ -1,0 +1,1 @@
+../dir-img-cosign-valid/manifest.json

--- a/common/pkg/json-proxy/testdata/dir-img-cosign-manifest-list-signed-arch/634a8f35b5f16dcf4aaa0822adc0b1964bb786fca12f6831de8ddc45e5986a00.signature-1
+++ b/common/pkg/json-proxy/testdata/dir-img-cosign-manifest-list-signed-arch/634a8f35b5f16dcf4aaa0822adc0b1964bb786fca12f6831de8ddc45e5986a00.signature-1
@@ -1,0 +1,1 @@
+../dir-img-cosign-valid/signature-1

--- a/common/pkg/json-proxy/testdata/dir-img-cosign-manifest-list-signed-arch/manifest.json
+++ b/common/pkg/json-proxy/testdata/dir-img-cosign-manifest-list-signed-arch/manifest.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+  "manifests": [
+    {
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "size": 428,
+      "digest": "sha256:634a8f35b5f16dcf4aaa0822adc0b1964bb786fca12f6831de8ddc45e5986a00",
+      "platform": {
+        "architecture": "amd64",
+        "os": "linux"
+      }
+    }
+  ]
+}

--- a/common/pkg/json-proxy/testdata/dir-img-cosign-valid
+++ b/common/pkg/json-proxy/testdata/dir-img-cosign-valid
@@ -1,0 +1,1 @@
+../../../../image/signature/fixtures/dir-img-cosign-valid

--- a/common/pkg/json-proxy/testdata/dir-img-unsigned
+++ b/common/pkg/json-proxy/testdata/dir-img-unsigned
@@ -1,0 +1,1 @@
+../../../../image/signature/fixtures/dir-img-unsigned

--- a/common/pkg/json-proxy/testdata/policy-cosign.json
+++ b/common/pkg/json-proxy/testdata/policy-cosign.json
@@ -1,0 +1,17 @@
+{
+    "default": [{"type": "reject"}],
+    "transports": {
+        "dir": {
+            "": [
+                {
+                    "type": "sigstoreSigned",
+                    "keyPath": "testdata/cosign.pub",
+                    "signedIdentity": {
+                        "type": "exactRepository",
+                        "dockerRepository": "192.168.64.2:5000/cosign-signed-single-sample"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/common/pkg/json-proxy/testdata/policy-reject.json
+++ b/common/pkg/json-proxy/testdata/policy-reject.json
@@ -1,0 +1,3 @@
+{
+    "default": [{"type": "reject"}]
+}

--- a/common/pkg/json-proxy/types.go
+++ b/common/pkg/json-proxy/types.go
@@ -98,9 +98,9 @@ type activePipe struct {
 // openImage is an opened image reference.
 type openImage struct {
 	// id is an opaque integer handle.
-	id        uint64
-	src       types.ImageSource
-	cachedimg types.Image
+	id  uint64
+	src types.ImageSource
+	img types.Image
 }
 
 // convertedLayerInfo is the reduced form of the OCI type BlobInfo

--- a/common/pkg/json-proxy/utils.go
+++ b/common/pkg/json-proxy/utils.go
@@ -2,7 +2,6 @@ package jsonproxy
 
 import (
 	"errors"
-	"fmt"
 
 	dockerdistributionerrcode "github.com/docker/distribution/registry/api/errcode"
 	dockerdistributionapi "github.com/docker/distribution/registry/api/v2"
@@ -10,19 +9,6 @@ import (
 	ocilayout "go.podman.io/image/v5/oci/layout"
 	"go.podman.io/image/v5/storage"
 )
-
-// noteCloseFailure helps with handling close errors in defer statements.
-func noteCloseFailure(err error, description string, closeErr error) error {
-	// We don't accept a Closer() and close it ourselves because signature.PolicyContext has .Destroy(), not .Close().
-	// This also makes it harder for a caller to do
-	//     defer noteCloseFailure(returnedErr, …)
-	// which doesn't use the right value of returnedErr, and doesn't update it.
-	if err == nil {
-		return fmt.Errorf("%s: %w", description, closeErr)
-	}
-	// In this case we prioritize the primary error for use with %w; closeErr is usually less relevant, or might be a consequence of the primary error.
-	return fmt.Errorf("%w (%s: %v)", err, description, closeErr)
-}
 
 // isNotFoundImageError checks if an error indicates that an image was not found.
 func isNotFoundImageError(err error) bool {


### PR DESCRIPTION
I didn't realize @mtrmac was working on this too in https://github.com/containers/container-libs/pull/765

---

This one also notably wires up the proxy to the existing signature tests, and adds a test case for the manifest list case.