### PR TITLE
Recover stale temp dirs before `MakePrivate`

### DIFF
--- a/storage/check.go
+++ b/storage/check.go
@@ -833,6 +833,7 @@ func (s *store) Repair(report CheckReport, options *RepairOptions) []error {
 				}
 				if err = s.DeleteLayer(id); err != nil {
 					err = fmt.Errorf("deleting layer %s: %w", id, err)
+				} else {
 					logrus.Debugf("deleted layer %s", id)
 				}
 			}

--- a/storage/drivers/overlay/overlay.go
+++ b/storage/drivers/overlay/overlay.go
@@ -1397,7 +1397,7 @@ func (d *Driver) removeCommon(id string, cleanup func(string) error) error {
 	if err == nil {
 		linkPath := path.Join(d.home, linkDir, string(lid))
 		if err := cleanup(linkPath); err != nil {
-			logrus.Debugf("Failed to remove link: %v", err)
+			logrus.Warnf("Failed to remove link: %v", err)
 		}
 	}
 

--- a/storage/drivers/overlay/overlay.go
+++ b/storage/drivers/overlay/overlay.go
@@ -443,6 +443,11 @@ func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) 
 		}
 	}
 
+	// Clean up stale tempdirs early, before MakePrivate.
+	if err := tempdir.RecoverStaleDirs(filepath.Join(home, tempDirName)); err != nil {
+		return nil, fmt.Errorf("overlay: recover stale temp dirs: %w", err)
+	}
+
 	if !opts.skipMountHome {
 		if err := mount.MakePrivate(home); err != nil {
 			return nil, fmt.Errorf("overlay: failed to make mount private: %w", err)

--- a/storage/layers.go
+++ b/storage/layers.go
@@ -823,15 +823,18 @@ func (r *layerStore) GarbageCollect() error {
 		}
 
 		// Remove layer and any related data of unreferenced id
+		logrus.Debugf("removing driver layer %q", id)
 		if err := r.driver.Remove(id); err != nil {
-			logrus.Debugf("removing driver layer %q", id)
 			return err
 		}
-
-		logrus.Debugf("removing %q", r.tspath(id))
-		os.Remove(r.tspath(id))
-		logrus.Debugf("removing %q", r.datadir(id))
-		os.RemoveAll(r.datadir(id))
+		// Best-effort removal of orphaned metadata; the driver layer is
+		// already gone, so warn but don't fail the overall GC.
+		if err := os.Remove(r.tspath(id)); err != nil && !errors.Is(err, os.ErrNotExist) {
+			logrus.Warnf("Failed to remove tar-split file %q: %v", r.tspath(id), err)
+		}
+		if err := os.RemoveAll(r.datadir(id)); err != nil {
+			logrus.Warnf("Failed to remove data directory %q: %v", r.datadir(id), err)
+		}
 	}
 
 	// Clean up any orphaned tar-split or data files in the layer metadata

--- a/storage/layers.go
+++ b/storage/layers.go
@@ -2118,7 +2118,6 @@ func (r *layerStore) internalDelete(id string) ([]tempdir.CleanupTempDirFunc, er
 		return cleanFunctions, err
 	}
 
-	cleanFunctions = append(cleanFunctions, tempDirectory.Cleanup)
 	if err := tempDirectory.StageDeletion(r.tspath(id)); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return cleanFunctions, err
 	}

--- a/storage/pkg/mount/mount.go
+++ b/storage/pkg/mount/mount.go
@@ -5,6 +5,8 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 )
 
 // mountError holds an error from a mount or unmount operation
@@ -89,17 +91,19 @@ func RecursiveUnmount(target string) error {
 		return -cmp.Compare(len(a.Mountpoint), len(b.Mountpoint))
 	})
 
-	for i, m := range mounts {
+	var lastErr error
+	for _, m := range mounts {
 		if !strings.HasPrefix(m.Mountpoint, target) {
 			continue
 		}
-		if err := Unmount(m.Mountpoint); err != nil && i == len(mounts)-1 {
-			return err
+		if err := Unmount(m.Mountpoint); err != nil {
 			// Ignore errors for submounts and continue trying to unmount others
 			// The final unmount should fail if there are any submounts remaining
+			logrus.Warnf("Failed to unmount %s: %v", m.Mountpoint, err)
+			lastErr = err
 		}
 	}
-	return nil
+	return lastErr
 }
 
 // ForceUnmount lazily unmounts a filesystem on supported platforms,

--- a/storage/pkg/system/rm.go
+++ b/storage/pkg/system/rm.go
@@ -36,9 +36,10 @@ func EnsureRemoveAll(dir string) error {
 		return nil
 	}
 
-	// Attempt to unmount anything beneath this dir first
+	// Best-effort: if unmounting fails, the RemoveAll loop below may
+	// still succeed (or will surface its own, more specific error).
 	if err := mount.RecursiveUnmount(dir); err != nil {
-		logrus.Debugf("RecursiveUnmount on %s failed: %v", dir, err)
+		logrus.Warnf("RecursiveUnmount on %s failed: %v", dir, err)
 	}
 
 	for {

--- a/storage/store.go
+++ b/storage/store.go
@@ -2668,7 +2668,7 @@ func (s *store) DeleteLayer(id string) (retErr error) {
 	}()
 	return s.writeToAllStores(func(rlstore rwLayerStore) error {
 		if rlstore.Exists(id) {
-			if l, err := rlstore.Get(id); err != nil {
+			if l, err := rlstore.Get(id); err == nil {
 				id = l.ID
 			}
 			layers, err := rlstore.Layers()

--- a/storage/tests/helpers.bash
+++ b/storage/tests/helpers.bash
@@ -26,8 +26,10 @@ function setup() {
         export _CONTAINERS_OVERLAY_DISABLE_IDMAP=yes
 }
 
-# Delete the unique root directory and a runroot directory.
-function teardown() {
+# Teardown the basic storage setup
+# Wipe the storage and shutdown the storage service,
+# then delete the unique root directory and a runroot directory.
+function basic_teardown() {
 	run storage wipe
 	if [[ $status -ne 0 ]] ; then
 		echo "$output"
@@ -37,6 +39,13 @@ function teardown() {
 		echo "$output"
 	fi
 	rm -fr ${TESTDIR}
+}
+
+# Provide the above as the default teardown method. Individual tests
+# can override teardown() if they need custom cleanup, but must call
+# basic_teardown explicitly in that case.
+function teardown() {
+	basic_teardown
 }
 
 # Create a file "$1" with random contents of length $2, or 256.

--- a/storage/tests/stale-tmpdir.bats
+++ b/storage/tests/stale-tmpdir.bats
@@ -1,0 +1,73 @@
+#!/usr/bin/env bats
+
+load helpers
+
+# $1: parent directory (contains temp-dir-* and lock-* for tempdir.RecoverStaleDirs)
+# Sets: staledir, lockpath, mountpath
+inject_stale_tempdir() {
+	local base=$1
+	mkdir -p "${base}"
+	staledir=${base}/temp-dir-999999999
+	lockpath=${base}/lock-999999999
+	mountpath=${staledir}/1-deadbeefdeadbeefdeadbeef/merged
+	mkdir -p "${mountpath}"
+	touch "${lockpath}"
+}
+
+function teardown() {
+	mount | awk -v t="${TESTDIR}" 'index($3, t) == 1 { print $3 }' | xargs -r umount 2>/dev/null || true
+	basic_teardown
+}
+
+@test "recover stale tempdir with mount" {
+	case "$STORAGE_DRIVER" in
+	overlay)
+		;;
+	*)
+		skip "only overlay calls MakePrivate"
+		;;
+	esac
+
+	run storage --debug=false create-layer
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+
+	# Undo the MakePrivate bind mount left by the previous command.
+	# This simulates failure of the previous storage invocation: the next
+	# storage invocation will redo the mount and create a new submount.
+	umount ${TESTDIR}/root/overlay
+
+	local base=${TESTDIR}/root/${STORAGE_DRIVER}/tempdirs
+	inject_stale_tempdir "${base}"
+	mount -t tmpfs tmpfs "${mountpath}"
+	mount | grep -q "${mountpath}"
+
+	run storage --debug=false layers
+	echo "$output"
+	[ "$status" -eq 0 ]
+
+	run test -d ${staledir}
+	[ "$status" -ne 0 ]
+
+	run test -f ${lockpath}
+	[ "$status" -ne 0 ]
+}
+
+@test "recover stale tempdir without mount" {
+	run storage --debug=false create-layer
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+
+	local base=${TESTDIR}/root/${STORAGE_DRIVER}-layers/tmp
+	inject_stale_tempdir "${base}"
+
+	run storage --debug=false layers
+	echo "$output"
+	[ "$status" -eq 0 ]
+
+	run test -d ${staledir}
+	[ "$status" -ne 0 ]
+
+	run test -f ${lockpath}
+	[ "$status" -ne 0 ]
+}


### PR DESCRIPTION
<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
Call `RecoverStaleDirs` before `MakePrivate` in overlay `Init()` so that any stale mounts under the tempdirs are still reachable by path and can be unmounted by `EnsureRemoveAll`'s `RecursiveUnmount` logic. When home is already a mountpoint, the early call is harmless.

Additionally, while auditing the removal code paths for silently dropped errors:
- Remove duplicate `tempdir.Cleanup` registration in `internalDelete`
- Upgrade silent Debug logs to Warn on cleanup failures (`RecursiveUnmount`, link removal), so they're visible at default log levels
- Fix inverted error check in `DeleteLayer` (`err != nil` -> `err == nil`)
- Fix misplaced log in `Repair` (was inside the error branch, claiming success on failure)
- Fix log placement in `GarbageCollect` (move before the error check, where it was meant to announce the action)

Fixes: https://redhat.atlassian.net/browse/RHEL-155513
Fixes: https://github.com/containers/podman/issues/27830
Fixes: https://github.com/containers/podman/issues/27035
    