### PR TITLE
Fix tests on non-Linux

### DIFF
--- a/common/pkg/apparmor/internal/supported/supported_test.go
+++ b/common/pkg/apparmor/internal/supported/supported_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package supported
 
 import (


### PR DESCRIPTION
2d3d55df98a37576e0e83e55c667cdcb11ee6a37 made the supported.go file Linux-only, but not the tests; thus they caused compilation errors on other platforms.

Make the tests Linux-only as well.