### PR TITLE
common: re-expose ModuleDirectories paths

### DIFF
--- a/common/pkg/config/modules.go
+++ b/common/pkg/config/modules.go
@@ -1,5 +1,7 @@
 package config
 
+import "go.podman.io/storage/pkg/configfile"
+
 // LoadedModules returns absolute paths to loaded containers.conf modules.
 func (c *Config) LoadedModules() []string {
 	// Required for conmon's callback to Podman's cleanup.
@@ -12,6 +14,9 @@ func (c *Config) LoadedModules() []string {
 // 2) /etc/
 // 3) /usr/share.
 func ModuleDirectories() ([]string, error) { // Public API for shell completions in Podman
-	// FIXME: expose this again
-	return nil, nil
+	conf := defaultConfigFileOpts()
+	// API needs us to pass an non empty string to trigger module path resolution
+	conf.Modules = []string{""}
+	paths, err := configfile.GetSearchPaths(conf)
+	return paths.ModuleDirectories, err
 }

--- a/common/pkg/config/modules_test.go
+++ b/common/pkg/config/modules_test.go
@@ -93,4 +93,13 @@ var _ = Describe("Config Modules", func() {
 		gomega.Expect(c.Containers.Env.Get()).To(gomega.Equal([]string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "usr share only", "override conf always wins"}))
 		gomega.Expect(c.Containers.Volumes.Get()).To(gomega.Equal([]string{"volume four", "home second"}))
 	})
+
+	It("new config with modules and env variables", func() {
+		paths, err := ModuleDirectories()
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		gomega.Expect(paths).To(gomega.HaveLen(3))
+		for _, path := range paths {
+			gomega.Expect(path).To(gomega.HaveSuffix("containers.conf.modules"))
+		}
+	})
 })


### PR DESCRIPTION
Now that we have GetSearchPaths() API use that to add back the module paths so it can be used in podman for shell completion.

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
