### PR TITLE
common/pkg/config: turn rosetta off by default

### DIFF
--- a/common/docs/containers.conf.5.md
+++ b/common/docs/containers.conf.5.md
@@ -1022,12 +1022,12 @@ is interpreted as the default provider for the current host OS.
 | Mac      | "" ("libkrun": Launch machine via libkrun platform, optimized for sharing GPU with the machine) | "applehv" (Apple Hypervisor) |
 
 
-**rosetta**="false"
+**rosetta**=false
 
 Rosetta supports running x86_64 Linux binaries on a Podman machine on Apple silicon.
 The default value is `false`. Supported on AppleHV(arm64) machines only.
 
-**import_native_ca**="false"
+**import_native_ca**=false
 
 Import the host's trusted CA certificates into the machine.
 When set to true, the certificates from the host system are imported during machine startup.

--- a/common/docs/containers.conf.5.md
+++ b/common/docs/containers.conf.5.md
@@ -1022,10 +1022,10 @@ is interpreted as the default provider for the current host OS.
 | Mac      | "" ("libkrun": Launch machine via libkrun platform, optimized for sharing GPU with the machine) | "applehv" (Apple Hypervisor) |
 
 
-**rosetta**="true"
+**rosetta**="false"
 
 Rosetta supports running x86_64 Linux binaries on a Podman machine on Apple silicon.
-The default value is `true`. Supported on AppleHV(arm64) machines only.
+The default value is `false`. Supported on AppleHV(arm64) machines only.
 
 **import_native_ca**="false"
 

--- a/common/pkg/config/config_local_test.go
+++ b/common/pkg/config/config_local_test.go
@@ -572,12 +572,12 @@ var _ = Describe("Config Local", func() {
 		// Given
 		config, err := newLocked(&Options{}, testConfigPath(""))
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
-		gomega.Expect(config.Machine.Rosetta).To(gomega.BeTrue())
+		gomega.Expect(config.Machine.Rosetta).To(gomega.BeFalse())
 		// When
 		config2, err := newLocked(&Options{}, testConfigPath("testdata/containers_default.conf"))
 		// Then
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
-		gomega.Expect(config2.Machine.Rosetta).To(gomega.BeFalse())
+		gomega.Expect(config2.Machine.Rosetta).To(gomega.BeTrue())
 	})
 	It("Get ImportNativeCA value", func() {
 		// Given

--- a/common/pkg/config/containers.conf
+++ b/common/pkg/config/containers.conf
@@ -936,9 +936,9 @@ default_sysctls = [
 #provider = ""
 
 # Rosetta supports running x86_64 Linux binaries on a Podman machine on Apple silicon.
-# The default value is `true`. Supported on AppleHV(arm64) machines only.
+# The default value is `false`. Supported on AppleHV(arm64) machines only.
 #
-#rosetta=true
+#rosetta=false
 
 # Import the host's trusted CA certificates into the machine.
 # When set to true, the certificates from the host system are imported during machine startup.

--- a/common/pkg/config/default.go
+++ b/common/pkg/config/default.go
@@ -274,7 +274,7 @@ func defaultMachineConfig() MachineConfig {
 		Memory:   2048,
 		User:     getDefaultMachineUser(),
 		Volumes:  configfile.NewSlice(getDefaultMachineVolumes()),
-		Rosetta:  true,
+		Rosetta:  false,
 	}
 }
 

--- a/common/pkg/config/testdata/containers_default.conf
+++ b/common/pkg/config/testdata/containers_default.conf
@@ -341,8 +341,8 @@ image = "https://example.com/$OS/$ARCH/foobar.ami"
 memory=1024
 
 # Rosetta supports running x86_64 Linux binaries on a Podman machine on Apple silicon.
-# The default value is `true`. Supported on AppleHV(arm64) machines only.
-rosetta=false
+# The default value is `false`. Supported on AppleHV(arm64) machines only.
+rosetta=true
 
 # Import the host's trusted CA certificates into the machine.
 import_native_ca=true


### PR DESCRIPTION
Since rosetta is broken on some older macos versions we had to hot fix a
turn off via a marker file in podman-machine-os[1].

However we never updated the docs as they still said it is enabled by
default. Lets fix that and correctly make rosetta disabled by default
(which it effectively already is).

Given that we can drop the marker file from podman-machine-os for
Podman 6 and have users again be able to just switch this config knob.
This will allow external tools such as PD to properly enable/disable it
again without having to create/remove said marker file inside the
machine[2].

[1] https://github.com/containers/podman-machine-os/commit/24e14c6017038510c060ee22f54bf771f1a31f71
[2] https://github.com/containers/podman-machine-os/issues/212