### PR TITLE
common/pkg/netns: fix netns path with uid 0

### DIFF
--- a/common/pkg/netns/netns_linux.go
+++ b/common/pkg/netns/netns_linux.go
@@ -249,7 +249,7 @@ func (ns *netNS) Do(toRun func(NetNS) error) error {
 // GetNSRunDir returns the dir of where to create the netNS. When running
 // rootless, it needs to be at a location writable by user.
 func GetNSRunDir() (string, error) {
-	if unshare.IsRootless() {
+	if unshare.GetRootlessUID() > 0 {
 		rootlessDir, err := homedir.GetRuntimeDir()
 		if err != nil {
 			return "", err


### PR DESCRIPTION
When running inside a nested container we might be uid 0 but are also in an user namespace, i.e. when running inside LXC.

In this case using the userns check to determine the netns path means we end up using GetRuntimeDir() which will create the /run/user/0 path. That is bad because systemd also uses that as a user session tmpfs path when root logs in.

If that happens systemd will happily mount a fresh tmpfs on /run/user/0 shadowing all existing files we created here and thus break network cleanup as the netns path no longer exists when podman tries to open it.

To avoid this inconsistent behavior check by the uid only to know that as uid 0 we always usr /run/netns. This matches what other callers in this repo do, i.e. see usePerUserStorage().

Fixes: containers/podman#28504

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
