### PR TITLE
common: move machine marker file

### DIFF
--- a/common/pkg/machine/machine.go
+++ b/common/pkg/machine/machine.go
@@ -1,6 +1,8 @@
 package machine
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 	"strings"
 	"sync"
@@ -12,45 +14,55 @@ type Marker struct {
 }
 
 const (
-	markerFile = "/etc/containers/podman-machine"
-	Wsl        = "wsl"
-	Qemu       = "qemu"
-	AppleHV    = "applehv"
-	HyperV     = "hyperv"
+	// New marker file as of podman 6.0 since /etc/containers get overmounted.
+	markerFile = "/etc/podman-machine"
+	// Marker file prior to podman 6.0.
+	markerFileOld = "/etc/containers/podman-machine"
+	Wsl           = "wsl"
+	Qemu          = "qemu"
+	AppleHV       = "applehv"
+	HyperV        = "hyperv"
 )
 
-var (
-	markerSync sync.Once
-	marker     *Marker
-)
+var readMarkerOnce = sync.OnceValue(func() *Marker {
+	return loadMachineMarker(markerFile, markerFileOld)
+})
 
-func loadMachineMarker(file string) {
-	var kind string
-	enabled := false
-
+func loadMachineMarker(file, fallbackFile string) *Marker {
 	if content, err := os.ReadFile(file); err == nil {
-		enabled = true
-		kind = strings.TrimSpace(string(content))
+		return &Marker{Enabled: true, Type: strings.TrimSpace(string(content))}
+	} else if errors.Is(err, fs.ErrNotExist) {
+		if content, err := os.ReadFile(fallbackFile); err == nil {
+			return &Marker{Enabled: true, Type: strings.TrimSpace(string(content))}
+		}
 	}
+	return &Marker{}
+}
 
-	marker = &Marker{enabled, kind}
+func (m *Marker) IsPodmanMachine() bool {
+	return m.Enabled
 }
 
 func IsPodmanMachine() bool {
-	return GetMachineMarker().Enabled
+	return GetMachineMarker().IsPodmanMachine()
+}
+
+func (m *Marker) HostType() string {
+	return m.Type
 }
 
 func HostType() string {
-	return GetMachineMarker().Type
+	return GetMachineMarker().HostType()
+}
+
+func (m *Marker) IsGvProxyBased() bool {
+	return m.IsPodmanMachine() && m.HostType() != Wsl
 }
 
 func IsGvProxyBased() bool {
-	return IsPodmanMachine() && HostType() != Wsl
+	return GetMachineMarker().IsGvProxyBased()
 }
 
 func GetMachineMarker() *Marker {
-	markerSync.Do(func() {
-		loadMachineMarker(markerFile)
-	})
-	return marker
+	return readMarkerOnce()
 }

--- a/common/pkg/machine/machine_test.go
+++ b/common/pkg/machine/machine_test.go
@@ -6,56 +6,59 @@ import (
 )
 
 var _ = Describe("Machine", func() {
-	BeforeEach(func() {
-		// disable normal init for testing
-		markerSync.Do(func() {})
-	})
-
 	It("not a machine", func() {
-		loadMachineMarker("testdata/does-not-exist")
+		marker := loadMachineMarker("testdata/does-not-exist", "testdata/does-not-exist")
 
-		gomega.Expect(IsPodmanMachine()).To(gomega.BeFalse())
-		gomega.Expect(HostType()).To(gomega.BeEmpty())
-		gomega.Expect(IsGvProxyBased()).To(gomega.BeFalse())
+		gomega.Expect(marker.IsPodmanMachine()).To(gomega.BeFalse())
+		gomega.Expect(marker.HostType()).To(gomega.BeEmpty())
+		gomega.Expect(marker.IsGvProxyBased()).To(gomega.BeFalse())
 	})
 
 	It("generic machine", func() {
-		loadMachineMarker("testdata/empty-machine")
+		marker := loadMachineMarker("testdata/empty-machine", "testdata/does-not-exist")
 
-		gomega.Expect(IsPodmanMachine()).To(gomega.BeTrue())
-		gomega.Expect(HostType()).To(gomega.BeEmpty())
-		gomega.Expect(IsGvProxyBased()).To(gomega.BeTrue())
+		gomega.Expect(marker.IsPodmanMachine()).To(gomega.BeTrue())
+		gomega.Expect(marker.HostType()).To(gomega.BeEmpty())
+		gomega.Expect(marker.IsGvProxyBased()).To(gomega.BeTrue())
 	})
 
 	It("wsl machine", func() {
-		loadMachineMarker("testdata/wsl-machine")
+		marker := loadMachineMarker("testdata/wsl-machine", "testdata/does-not-exist")
 
-		gomega.Expect(IsPodmanMachine()).To(gomega.BeTrue())
-		gomega.Expect(HostType()).To(gomega.Equal(Wsl))
-		gomega.Expect(IsGvProxyBased()).To(gomega.BeFalse())
+		gomega.Expect(marker.IsPodmanMachine()).To(gomega.BeTrue())
+		gomega.Expect(marker.HostType()).To(gomega.Equal(Wsl))
+		gomega.Expect(marker.IsGvProxyBased()).To(gomega.BeFalse())
 	})
 
 	It("qemu machine", func() {
-		loadMachineMarker("testdata/qemu-machine")
+		marker := loadMachineMarker("testdata/qemu-machine", "testdata/does-not-exist")
 
-		gomega.Expect(IsPodmanMachine()).To(gomega.BeTrue())
-		gomega.Expect(HostType()).To(gomega.Equal(Qemu))
-		gomega.Expect(IsGvProxyBased()).To(gomega.BeTrue())
+		gomega.Expect(marker.IsPodmanMachine()).To(gomega.BeTrue())
+		gomega.Expect(marker.HostType()).To(gomega.Equal(Qemu))
+		gomega.Expect(marker.IsGvProxyBased()).To(gomega.BeTrue())
 	})
 
 	It("applehv machine", func() {
-		loadMachineMarker("testdata/applehv-machine")
+		marker := loadMachineMarker("testdata/applehv-machine", "testdata/does-not-exist")
 
-		gomega.Expect(IsPodmanMachine()).To(gomega.BeTrue())
-		gomega.Expect(HostType()).To(gomega.Equal(AppleHV))
-		gomega.Expect(IsGvProxyBased()).To(gomega.BeTrue())
+		gomega.Expect(marker.IsPodmanMachine()).To(gomega.BeTrue())
+		gomega.Expect(marker.HostType()).To(gomega.Equal(AppleHV))
+		gomega.Expect(marker.IsGvProxyBased()).To(gomega.BeTrue())
 	})
 
 	It("hyperv machine", func() {
-		loadMachineMarker("testdata/hyperv-machine")
+		marker := loadMachineMarker("testdata/hyperv-machine", "testdata/does-not-exist")
 
-		gomega.Expect(IsPodmanMachine()).To(gomega.BeTrue())
-		gomega.Expect(HostType()).To(gomega.Equal(HyperV))
-		gomega.Expect(IsGvProxyBased()).To(gomega.BeTrue())
+		gomega.Expect(marker.IsPodmanMachine()).To(gomega.BeTrue())
+		gomega.Expect(marker.HostType()).To(gomega.Equal(HyperV))
+		gomega.Expect(marker.IsGvProxyBased()).To(gomega.BeTrue())
+	})
+
+	It("fallback path", func() {
+		marker := loadMachineMarker("testdata/does-not-exist", "testdata/hyperv-machine")
+
+		gomega.Expect(marker.IsPodmanMachine()).To(gomega.BeTrue())
+		gomega.Expect(marker.HostType()).To(gomega.Equal(HyperV))
+		gomega.Expect(marker.IsGvProxyBased()).To(gomega.BeTrue())
 	})
 })


### PR DESCRIPTION
Move the marker file location to /etc/podman-machine. Because we want to overmount /etc/containers it means the /etc/containers/podman-machine file created by ignition gets shadowed otherwise.

However because ignition runs only once we should still support machines created on 5.X so keep a fallback that checks the older file as well if the first one is not found.

Also rework the logic to use sync.OnceValue and make it better unit testable.


