### PR TITLE
storage: fix broken fgetxattr call

### DIFF
--- a/storage/drivers/overlay/overlay.go
+++ b/storage/drivers/overlay/overlay.go
@@ -2058,7 +2058,7 @@ func (g *overlayFileGetter) Get(path string) (io.ReadCloser, error) {
 	for _, d := range g.diffDirs {
 		if f, found := g.composefsMounts[d]; found {
 			cfd, err := unix.Openat2(int(f.Fd()), path, &unix.OpenHow{
-				Flags:   unix.O_CLOEXEC | unix.O_PATH,
+				Flags:   unix.O_RDONLY | unix.O_CLOEXEC,
 				Resolve: unix.RESOLVE_NO_SYMLINKS | unix.RESOLVE_BENEATH,
 			})
 			if err != nil {


### PR DESCRIPTION
As documented in the open man page O_PATH is not valid for fgetxattr() and fails with EBADF.

Fixes: 363943ac4b ("storage, overlay: use openat2 instead of using procfs")

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
