### PR TITLE
Fix TestTransportParseReference

### DIFF
--- a/image/storage/storage_test.go
+++ b/image/storage/storage_test.go
@@ -59,6 +59,12 @@ func TestMain(m *testing.M) {
 	if debug {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
+
+	// Make the tests independent of storage.conf in /usr or /etc.
+	// This must be done early, not in an individual test,
+	// because the config file is read inside a sync.Once.
+	os.Setenv("CONTAINERS_STORAGE_CONF", "/dev/null")
+
 	os.Exit(m.Run())
 }
 

--- a/image/storage/storage_transport_test.go
+++ b/image/storage/storage_transport_test.go
@@ -98,9 +98,10 @@ func TestTransportParseReference(t *testing.T) {
 	store := newStore(t)
 	driver := store.GraphDriverName()
 	root := store.GraphRoot()
+	runRoot := store.RunRoot()
 
 	for _, c := range []struct{ prefix, expectedDriver, expectedRoot, expectedRunRoot string }{
-		{"", driver, root, ""},                                                 // Implicit store location prefix
+		{"", driver, root, runRoot},                                            // Implicit store location prefix
 		{"[unterminated", "", "", ""},                                          // Unterminated store specifier
 		{"[]", "", "", ""},                                                     // Empty store specifier
 		{"[relative/path]", "", "", ""},                                        // Non-absolute graph root path

--- a/image/storage/storage_transport_test.go
+++ b/image/storage/storage_transport_test.go
@@ -100,16 +100,16 @@ func TestTransportParseReference(t *testing.T) {
 	root := store.GraphRoot()
 
 	for _, c := range []struct{ prefix, expectedDriver, expectedRoot, expectedRunRoot string }{
-		{"", driver, root, ""},                                             // Implicit store location prefix
-		{"[unterminated", "", "", ""},                                      // Unterminated store specifier
-		{"[]", "", "", ""},                                                 // Empty store specifier
-		{"[relative/path]", "", "", ""},                                    // Non-absolute graph root path
-		{"[" + driver + "@relative/path]", "", "", ""},                     // Non-absolute graph root path
-		{"[@" + root + "suffix2]", "", "", ""},                             // Empty graph driver
-		{"[" + driver + "@]", "", "", ""},                                  // Empty root path
-		{"[thisisunknown@" + root + "suffix2]", "", "", ""},                // Unknown graph driver
-		{"[" + root + "suffix1]", "", "", ""},                              // A valid root path, but no run dir
-		{"[" + driver + "@" + root + "suffix3+relative/path]", "", "", ""}, // Non-absolute run dir
+		{"", driver, root, ""},                                                 // Implicit store location prefix
+		{"[unterminated", "", "", ""},                                          // Unterminated store specifier
+		{"[]", "", "", ""},                                                     // Empty store specifier
+		{"[relative/path]", "", "", ""},                                        // Non-absolute graph root path
+		{"[" + driver + "@relative/path]", "", "", ""},                         // Non-absolute graph root path
+		{"[@" + root + "suffix2]", "", "", ""},                                 // Empty graph driver
+		{"[" + driver + "@]", "", "", ""},                                      // Empty root path
+		{"[thisisunknown@" + root + "suffix2]", "", "", ""},                    // Unknown graph driver
+		{"[" + driver + "@" + root + "suffix1]", driver, root + "suffix1", ""}, // A valid root path; no run dir = uses c/storage defaults
+		{"[" + driver + "@" + root + "suffix3+relative/path]", "", "", ""},     // Non-absolute run dir
 		{
 			"[" + driver + "@" + root + "suffix3+" + root + "suffix4]",
 			driver,


### PR DESCRIPTION
Originally, when the test was written, an empty runRoot or graphRoot was rejected by storage.GetStore, and we had a test exercising that.
    
That changed in https://github.com/containers/storage/pull/1096 , when storage.GetStore started accepting inputs with at least one of runRoot / graphRoot set, using the default path for the unspecified one.
    
But the test continued to work because the default runRoot was /run/containers/storage, (the storage.GetStore defaulting path never consulted storage.conf and only used hard-coded defaults, avoiding the code path that sets rootless defaults during normal operation) and neither Linux nor macOS could create that path; so we were still seeing a failure, just not the expected one.
    
The recent c/storage configuration redesign changed the handling of runRoot defaults: they are based on storage.conf, and do invoke the rootless defaults code.
    
So, On macOS, the default is now a temporary runtime dir in $TMPDIR, so parsing such inputs suceeds and works; that breaks the test.
    
On Linux, parsing such inputs _also_ succeeds, except that we are (as of 2026-05) running tests with /usr/share/containers/storage.conf configured with runroot = "/run/containers/storage"; this now applies even rootless, so creating /run/containers fails for the non-root user we use.
    
So, disable using the system's storage.conf entirely (it only ever affected this one code path, usually newStore() sets the graphRoot / runRoot paths explicitly), and update the test to now expect a success.

---

Also improve one other case in that test.