### PR TITLE
libartifact: add CloseEventChannel to cleanly stop event streams

### DIFF
--- a/common/pkg/libartifact/store.go
+++ b/common/pkg/libartifact/store.go
@@ -94,6 +94,16 @@ func (as *ArtifactStore) EventChannel() chan *Event {
 	return as.eventChannel
 }
 
+// CloseEventChannel closes the event channel to signal listeners that
+// the artifact store has stopped emitting events.
+// WARNING: EventChannel and CloseEventChannel are not safe for concurrent use.
+func (as *ArtifactStore) CloseEventChannel() {
+	if as.eventChannel != nil {
+		close(as.eventChannel)
+		as.eventChannel = nil
+	}
+}
+
 // lookupArtifactLocked looks up an artifact by fully qualified name,
 // or name@digest, full ID, or partial ID.
 // note: lookupArtifactLocked must be called while under a store lock

--- a/common/pkg/libartifact/store_test.go
+++ b/common/pkg/libartifact/store_test.go
@@ -971,29 +971,34 @@ func TestArtifactStore_withLockedLayout(t *testing.T) {
 }
 
 func TestArtifactStore_EventChannel(t *testing.T) {
-	as, _ := setupTestStore(t)
-	ch := as.EventChannel()
-	require.NotNil(t, ch)
-
 	t.Run("Add", func(t *testing.T) {
+		as, _ := setupTestStore(t)
+		ch := as.EventChannel()
+		require.NotNil(t, ch)
+
 		refName := "quay.io/test/event-add:v1"
 		fileNames := map[string]int{"add.txt": 64}
 
 		digest, _ := helperAddArtifact(t, as, refName, fileNames, nil)
 
-		event := <-as.eventChannel
+		event := <-ch
 		require.NotNil(t, event)
 		assert.Equal(t, EventTypeArtifactAdd, event.Type)
 		assert.Equal(t, refName, event.Name)
 		assert.Equal(t, digest.String(), event.ID)
 		assert.NoError(t, event.Error)
+		as.CloseEventChannel()
 	})
 
 	t.Run("Remove", func(t *testing.T) {
+		as, _ := setupTestStore(t)
+		ch := as.EventChannel()
+		require.NotNil(t, ch)
+
 		refName := "quay.io/test/event-remove:v1"
 		fileNames := map[string]int{"remove.txt": 32}
 		digest, _ := helperAddArtifact(t, as, refName, fileNames, nil)
-		<-as.eventChannel // consume AddEvent
+		<-ch // consume AddEvent
 
 		asr, err := NewArtifactStorageReference(refName)
 		require.NoError(t, err)
@@ -1002,11 +1007,34 @@ func TestArtifactStore_EventChannel(t *testing.T) {
 		assert.Equal(t, digest, removedDigest)
 		require.NoError(t, err)
 
-		event := <-as.eventChannel
+		event := <-ch
 		require.NotNil(t, event)
 		assert.Equal(t, EventTypeArtifactRemove, event.Type)
 		assert.Equal(t, refName, event.Name)
 		assert.Equal(t, digest.String(), event.ID)
 		assert.NoError(t, event.Error)
+		as.CloseEventChannel()
+	})
+
+	t.Run("Close the event channel", func(t *testing.T) {
+		as, _ := setupTestStore(t)
+		ch := as.EventChannel()
+		require.NotNil(t, ch)
+
+		refName := "quay.io/test/event-add:v1"
+		fileNames := map[string]int{"add.txt": 64}
+
+		helperAddArtifact(t, as, refName, fileNames, nil)
+
+		event := <-ch
+		require.NotNil(t, event)
+		assert.NoError(t, event.Error)
+
+		as.CloseEventChannel()
+		assert.Nil(t, as.eventChannel)
+
+		event, ok := <-ch
+		assert.False(t, ok)
+		assert.Nil(t, event)
 	})
 }


### PR DESCRIPTION
Fixes https://github.com/containers/container-libs/issues/465

We need a way to cleanly close the event channel from the sender side to prevent resource leaks. 
This requirement was identified while implementing artifact event handling in Podman (https://github.com/containers/podman/pull/28662).