### PR TITLE
docs: Update godoc badge link in image/README.md #435

### DIFF
--- a/image/README.md
+++ b/image/README.md
@@ -1,4 +1,4 @@
-[![Go Reference](https://pkg.go.dev/badge/github.com/containers/image/v5.svg)](https://pkg.go.dev/github.com/containers/image/v5) [![Build Status](https://api.cirrus-ci.com/github/containers/image.svg)](https://cirrus-ci.com/github/containers/image)
+[![Go Reference](https://pkg.go.dev/badge/go.podman.io/image/v5.svg)](https://pkg.go.dev/go.podman.io/image/v5) [![Build Status](https://api.cirrus-ci.com/github/containers/image.svg)](https://cirrus-ci.com/github/containers/image)
 =
 
 `image` is a set of Go libraries aimed at working in various way with


### PR DESCRIPTION
I've updated the Godoc badge link [image/README.md](https://github.com/containers/container-libs/blob/abe824d0032c907a4640bb5a937f60da921ec297/image/README.md) to reflect the correct current URL (i.e. `go.podman.io`).

Fixes: #435
