### PR TITLE
Remove deprecated StoreTransport.GetStoreImage, GetImage

### DIFF
--- a/common/libimage/manifests/manifests.go
+++ b/common/libimage/manifests/manifests.go
@@ -287,6 +287,7 @@ func (l *list) Reference(store storage.Store, multiple cp.ImageListSelection, in
 	}
 	if len(l.artifacts.Manifests) > 0 {
 		img, err := is.Transport.GetImage(s)
+		_, img, err := is.ResolveReference(s)
 		if err != nil {
 			return nil, fmt.Errorf("locating image %s: %w", transports.ImageName(s), err)
 		}

--- a/image/storage/storage_transport.go
+++ b/image/storage/storage_transport.go
@@ -45,29 +45,6 @@ type StoreTransport interface {
 	SetStore(storage.Store)
 	// GetStoreIfSet returns the default store for this transport, or nil if not set/determined yet.
 	GetStoreIfSet() storage.Store
-	// GetImage retrieves the image from the transport's store that's named
-	// by the reference.
-	// Deprecated: Surprisingly, with a StoreTransport reference which contains an ID,
-	// this ignores that ID; and repeated calls of GetStoreImage with the same named reference
-	// can return different images, with no way for the caller to "freeze" the storage.Image identity
-	// without discarding the name entirely.
-	//
-	// Use storage.ResolveReference instead; note that if the image is not found, ResolveReference returns
-	// c/image/v5/storage.ErrNoSuchImage, not c/storage.ErrImageUnknown.
-	GetImage(types.ImageReference) (*storage.Image, error)
-	// GetStoreImage retrieves the image from a specified store that's named
-	// by the reference.
-	//
-	// Deprecated: Surprisingly, with a StoreTransport reference which contains an ID,
-	// this ignores that ID; and repeated calls of GetStoreImage with the same named reference
-	// can return different images, with no way for the caller to "freeze" the storage.Image identity
-	// without discarding the name entirely.
-	//
-	// Also, a StoreTransport reference already contains a store, so providing another one is redundant.
-	//
-	// Use storage.ResolveReference instead; note that if the image is not found, ResolveReference returns
-	// c/image/v5/storage.ErrNoSuchImage, not c/storage.ErrImageUnknown.
-	GetStoreImage(storage.Store, types.ImageReference) (*storage.Image, error)
 	// ParseStoreReference parses a reference, overriding any store
 	// specification that it may contain.
 	ParseStoreReference(store storage.Store, reference string) (*storageReference, error)
@@ -304,46 +281,6 @@ func (s *storageTransport) ParseReference(reference string) (types.ImageReferenc
 		store = store2
 	}
 	return s.ParseStoreReference(store, reference)
-}
-
-// Deprecated: Surprisingly, with a StoreTransport reference which contains an ID,
-// this ignores that ID; and repeated calls of GetStoreImage with the same named reference
-// can return different images, with no way for the caller to "freeze" the storage.Image identity
-// without discarding the name entirely.
-//
-// Also, a StoreTransport reference already contains a store, so providing another one is redundant.
-//
-// Use storage.ResolveReference instead; note that if the image is not found, ResolveReference returns
-// c/image/v5/storage.ErrNoSuchImage, not c/storage.ErrImageUnknown.
-func (s storageTransport) GetStoreImage(store storage.Store, ref types.ImageReference) (*storage.Image, error) {
-	dref := ref.DockerReference()
-	if dref != nil {
-		if img, err := store.Image(dref.String()); err == nil {
-			return img, nil
-		}
-	}
-	if sref, ok := ref.(*storageReference); ok {
-		tmpRef := *sref
-		if img, err := tmpRef.resolveImage(nil); err == nil {
-			return img, nil
-		}
-	}
-	return nil, storage.ErrImageUnknown
-}
-
-// Deprecated: Surprisingly, with a StoreTransport reference which contains an ID,
-// this ignores that ID; and repeated calls of GetStoreImage with the same named reference
-// can return different images, with no way for the caller to "freeze" the storage.Image identity
-// without discarding the name entirely.
-//
-// Use storage.ResolveReference instead; note that if the image is not found, ResolveReference returns
-// c/image/v5/storage.ErrNoSuchImage, not c/storage.ErrImageUnknown.
-func (s *storageTransport) GetImage(ref types.ImageReference) (*storage.Image, error) {
-	store, err := s.GetStore()
-	if err != nil {
-		return nil, err
-	}
-	return s.GetStoreImage(store, ref)
 }
 
 func (s storageTransport) ValidatePolicyConfigurationScope(scope string) error {


### PR DESCRIPTION
1. common/libimage/manifests: stop using deprecated function
    
    Since July 2023 [1] StoreTransport.GetImage is deprecated in favor
    of c/storage.ResolveReference. Unfortunately, the deprecation notice
    was not written on a separate paragraph, so linters missed it.
    
    [1]: https://github.com/containers/image/pull/2056

2. image/storage: rm deprecated functions
    
    These two methods of StoreTransport, GetStoreImage and GetImage, were
    deprecated in July 2023 [1]. Unfortunately, GetImage deprecation notice
    was not written on a separate paragraph, so it was invisible for
    linters. Fortunately, I was only able to find a single user that should
    be fixed (done in previous commit).
    
    Rather than fix the deprecation notice, let's remove this entirely.