### PR TITLE
common: provide empty mounts.conf for non-RHEL systems

### DIFF
--- a/common/contrib/redhat/mounts.conf
+++ b/common/contrib/redhat/mounts.conf
@@ -1,0 +1,1 @@
+/usr/share/rhel/secrets:/run/secrets

--- a/common/pkg/subscriptions/mounts.conf
+++ b/common/pkg/subscriptions/mounts.conf
@@ -1,1 +1,0 @@
-/usr/share/rhel/secrets:/run/secrets

--- a/common/rpm/containers-common.spec
+++ b/common/rpm/containers-common.spec
@@ -139,7 +139,7 @@ done
 ln -s containerignore.5 %{buildroot}%{_mandir}/man5/.containerignore.5
 
 # install config files for mounts, containers and seccomp
-install -m0644 common/pkg/subscriptions/mounts.conf %{buildroot}%{_datadir}/containers/mounts.conf
+install -m0644 common/contrib/redhat/mounts.conf %{buildroot}%{_datadir}/containers/mounts.conf
 install -m0644 common/pkg/seccomp/seccomp.json %{buildroot}%{_datadir}/containers/seccomp.json
 install -m0644 common/pkg/config/containers.conf %{buildroot}%{_datadir}/containers/containers.conf
 


### PR DESCRIPTION
Provide an empty mounts.conf for non-RHEL systems and an additional rhel-mounts.conf for RHEL systems. This makes packaging easier for distros where RHEL-specific mount entries don't apply.

Fixes: #807