### PR TITLE
seccomp: block AF_ALG sockets

### DIFF
--- a/common/pkg/seccomp/default_linux.go
+++ b/common/pkg/seccomp/default_linux.go
@@ -836,6 +836,21 @@ func DefaultProfile() *Seccomp {
 				"socket",
 			},
 			Action:   ActErrno,
+			Errno:    "EPERM",
+			ErrnoRet: &eperm,
+			Args: []*Arg{
+				{
+					Index: 0,
+					Value: unix.AF_ALG,
+					Op:    OpEqualTo,
+				},
+			},
+		},
+		{
+			Names: []string{
+				"socket",
+			},
+			Action:   ActErrno,
 			Errno:    "EINVAL",
 			ErrnoRet: &einval,
 			Args: []*Arg{

--- a/common/pkg/seccomp/seccomp.json
+++ b/common/pkg/seccomp/seccomp.json
@@ -984,6 +984,25 @@
 			"args": [
 				{
 					"index": 0,
+					"value": 38,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_EQ"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {},
+			"errnoRet": 1,
+			"errno": "EPERM"
+		},
+		{
+			"names": [
+				"socket"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"args": [
+				{
+					"index": 0,
 					"value": 16,
 					"valueTwo": 0,
 					"op": "SCMP_CMP_EQ"


### PR DESCRIPTION
- Block socket(AF_ALG) in the default profile, mirroring the existing AF_VSOCK deny in eaec878beb
- AF_ALG is the kernel crypto API interface; rarely needed inside containers; recurring CVE family (most recent CVE-2026-31431)
- JSON was regenerated via cmd/seccomp/generate.go and go test ./pkg/seccomp/... passes
- Following @Luap99's reply to a private report on [security@lists.podman.io](mailto:security@lists.podman.io), filed publicly here.