### PR TITLE
OCPNODE-4477: docker: add blob-level mirror fallback in dockerImageSource

### DIFF
--- a/image/docker/docker_image_src.go
+++ b/image/docker/docker_image_src.go
@@ -56,11 +56,12 @@ type dockerImageSource struct {
 
 	// Mirror fallback: when a blob fetch fails with a fallback-worthy error,
 	// try remaining pull sources before giving up. Protected by mirrorMu.
-	mirrorMu         sync.Mutex
-	mirrorOverride   *mirrorSource                // If non-nil, this is the mirror and physicalRef for the override client
-	prevOverrides    []*dockerClient              // mirror clients replaced by a newer mirrorOverride; kept open because other goroutines may still be reading blobs through them, closed in Close()
-	remainingSources []sysregistriesv2.PullSource // later pull sources not yet tried, consumed front-to-back during fallback; nil when selected source is already the original source.
-	fallbackSys      *types.SystemContext
+	mirrorMu          sync.Mutex
+	mirrorOverride    *mirrorSource                // If non-nil, this is the mirror and physicalRef for the override client
+	prevOverrides     []*dockerClient              // mirror clients replaced by a newer mirrorOverride; kept open because other goroutines may still be reading blobs through them, closed in Close()
+	remainingSources  []sysregistriesv2.PullSource // later pull sources not yet tried, consumed front-to-back during fallback; nil when selected source is already the original source.
+	fallbackSys       *types.SystemContext
+	fallbackRegConfig *registryConfiguration
 }
 
 type mirrorSource struct {
@@ -72,6 +73,11 @@ type pullEndpoint struct {
 	client      *dockerClient
 	ref         dockerReference
 	endpointSys *types.SystemContext
+}
+
+type sourceAttempt struct {
+	ref reference.Named
+	err error
 }
 
 // newImageSource creates a new ImageSource for the specified image reference.
@@ -110,11 +116,7 @@ func newImageSource(ctx context.Context, sys *types.SystemContext, ref dockerRef
 	if err != nil {
 		return nil, err
 	}
-	type attempt struct {
-		ref reference.Named
-		err error
-	}
-	attempts := []attempt{}
+	attempts := []sourceAttempt{}
 	for i, pullSource := range pullSources {
 		if sys != nil && sys.DockerLogMirrorChoice {
 			logrus.Infof("Trying to access %q", pullSource.Reference)
@@ -126,11 +128,12 @@ func newImageSource(ctx context.Context, sys *types.SystemContext, ref dockerRef
 			if i+1 < len(pullSources) {
 				s.remainingSources = pullSources[i+1:]
 				s.fallbackSys = sys
+				s.fallbackRegConfig = registryConfig
 			}
 			return s, nil
 		}
 		logrus.Debugf("Accessing %q failed: %v", pullSource.Reference, err)
-		attempts = append(attempts, attempt{
+		attempts = append(attempts, sourceAttempt{
 			ref: pullSource.Reference,
 			err: err,
 		})
@@ -470,40 +473,17 @@ func (s *dockerImageSource) GetBlobAt(ctx context.Context, info types.BlobInfo, 
 	if err := info.Digest.Validate(); err != nil { // Make sure info.Digest.String() does not contain any unexpected characters
 		return nil, nil, err
 	}
-	path := fmt.Sprintf(blobsPath, reference.Path(s.physicalRef.ref), info.Digest.String())
-	logrus.Debugf("Downloading %s", path)
-	res, err := s.c.makeRequest(ctx, http.MethodGet, path, headers, nil, v2Auth, nil)
-	if err != nil {
-		return nil, nil, err
+
+	client, physRef, hasRemaining := s.getActiveSource()
+	streams, errs, err := tryGetBlobAt(ctx, client, physRef, info, chunks, headers, hasRemaining)
+	if err == nil || !hasRemaining {
+		return streams, errs, err
 	}
-
-	switch res.StatusCode {
-	case http.StatusOK:
-		// if the server replied with a 200 status code, convert the full body response to a series of
-		// streams as it would have been done with 206.
-		streams := make(chan io.ReadCloser)
-		errs := make(chan error)
-		go splitHTTP200ResponseToPartial(streams, errs, res.Body, chunks)
-		return streams, errs, nil
-	case http.StatusPartialContent:
-		mediaType, params, err := parseMediaType(res.Header.Get("Content-Type"))
-		if err != nil {
-			return nil, nil, err
-		}
-
-		streams := make(chan io.ReadCloser)
-		errs := make(chan error)
-
-		go handle206Response(streams, errs, res.Body, chunks, mediaType, params)
-		return streams, errs, nil
-	case http.StatusBadRequest:
-		res.Body.Close()
-		return nil, nil, private.BadPartialRequestError{Status: res.Status}
-	default:
-		err := registryHTTPResponseToError(res)
-		res.Body.Close()
-		return nil, nil, fmt.Errorf("fetching partial blob: %w", err)
+	if isMirrorTransientError(err) || isMirrorFallbackError(err) {
+		logrus.Debugf("Partial blob %s fetch from %q failed (%v), trying fallback sources", info.Digest, physRef.ref, err)
+		return s.getBlobAtWithMirrorFallback(ctx, info, chunks, headers, err, client)
 	}
+	return streams, errs, err
 }
 
 // GetBlob returns a stream for the specified blob, and the blob’s size (or -1 if unknown).
@@ -548,6 +528,62 @@ func tryGetBlob(ctx context.Context, client *dockerClient, physRef dockerReferen
 		reader, size, err = client.getBlob(ctx, physRef, info, cache)
 	}
 	return reader, size, err
+}
+
+// tryGetBlobAt attempts to fetch a partial blob (range request), retrying once on transient errors
+// if fallback mirrors remain. Mirrors tryGetBlob for the partial-pull (zstd:chunked) path.
+func tryGetBlobAt(ctx context.Context, client *dockerClient, physRef dockerReference,
+	info types.BlobInfo, chunks []private.ImageSourceChunk, headers map[string][]string, hasRemainingSources bool,
+) (chan io.ReadCloser, chan error, error) {
+	streams, errs, err := fetchBlobAt(ctx, client, physRef, info, chunks, headers)
+	if err != nil && hasRemainingSources && isMirrorTransientError(err) {
+		logrus.Debugf("Transient error fetching partial blob %s from %q, retrying: %v", info.Digest, physRef.ref, err)
+		delay := time.Second + rand.N(time.Second/10)
+		select {
+		case <-ctx.Done():
+			return nil, nil, fmt.Errorf("%w (while retrying after: %v)", ctx.Err(), err)
+		case <-time.After(delay):
+		}
+		streams, errs, err = fetchBlobAt(ctx, client, physRef, info, chunks, headers)
+	}
+	return streams, errs, err
+}
+
+func fetchBlobAt(ctx context.Context, client *dockerClient, physRef dockerReference,
+	info types.BlobInfo, chunks []private.ImageSourceChunk, headers map[string][]string,
+) (chan io.ReadCloser, chan error, error) {
+	path := fmt.Sprintf(blobsPath, reference.Path(physRef.ref), info.Digest.String())
+	logrus.Debugf("Downloading %s", path)
+	res, err := client.makeRequest(ctx, http.MethodGet, path, headers, nil, v2Auth, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	switch res.StatusCode {
+	case http.StatusOK:
+		// if the server replied with a 200 status code, convert the full body response to a series of
+		// streams as it would have been done with 206.
+		streams := make(chan io.ReadCloser)
+		errs := make(chan error)
+		go splitHTTP200ResponseToPartial(streams, errs, res.Body, chunks)
+		return streams, errs, nil
+	case http.StatusPartialContent:
+		mediaType, params, err := parseMediaType(res.Header.Get("Content-Type"))
+		if err != nil {
+			return nil, nil, err
+		}
+		streams := make(chan io.ReadCloser)
+		errs := make(chan error)
+		go handle206Response(streams, errs, res.Body, chunks, mediaType, params)
+		return streams, errs, nil
+	case http.StatusBadRequest:
+		res.Body.Close()
+		return nil, nil, private.BadPartialRequestError{Status: res.Status}
+	default:
+		httpErr := registryHTTPResponseToError(res)
+		res.Body.Close()
+		return nil, nil, fmt.Errorf("fetching partial blob: %w", httpErr)
+	}
 }
 
 // isMirrorFallbackError returns true for errors where the blob is not present
@@ -596,6 +632,37 @@ func isMirrorTransientError(err error) bool {
 	return errors.As(err, &netErr) && netErr.Timeout()
 }
 
+// retireStaleOverride checks if the current mirrorOverride was set by another
+// goroutine and differs from failedClient. If so, it returns the override's
+// client and ref for the caller to retry. If the override is the same client
+// that already failed, or is nil, it returns nil. Must be called with mirrorMu held.
+func (s *dockerImageSource) retireStaleOverride(failedClient *dockerClient) (*dockerClient, dockerReference, bool) {
+	if s.mirrorOverride != nil && s.mirrorOverride.client != failedClient {
+		return s.mirrorOverride.client, s.mirrorOverride.ref, true
+	}
+	return nil, dockerReference{}, false
+}
+
+// retireCurrentOverride moves the current mirrorOverride to prevOverrides.
+// Must be called with mirrorMu held.
+func (s *dockerImageSource) retireCurrentOverride() {
+	if s.mirrorOverride != nil {
+		s.prevOverrides = append(s.prevOverrides, s.mirrorOverride.client)
+		s.mirrorOverride = nil
+	}
+}
+
+func formatFallbackError(attempts []sourceAttempt, originalErr error) error {
+	if len(attempts) == 0 {
+		return originalErr
+	}
+	extras := make([]string, 0, len(attempts))
+	for _, a := range attempts {
+		extras = append(extras, fmt.Sprintf("[%s: %v]", a.ref.String(), a.err))
+	}
+	return fmt.Errorf("(Fallback sources also failed: %s): %w", strings.Join(extras, "\n"), originalErr)
+}
+
 func (s *dockerImageSource) getBlobWithMirrorFallback(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache, originalErr error, failedClient *dockerClient) (io.ReadCloser, int64, error) {
 	// Held for the full fallback loop, including network I/O. This serializes
 	// concurrent blob fetchers during fallback — only one goroutine probes
@@ -604,39 +671,25 @@ func (s *dockerImageSource) getBlobWithMirrorFallback(ctx context.Context, info 
 	s.mirrorMu.Lock()
 	defer s.mirrorMu.Unlock()
 
-	// If another goroutine already switched to a working mirror, try it first.
-	if s.mirrorOverride != nil && s.mirrorOverride.client != failedClient {
-		client, physRef := s.mirrorOverride.client, s.mirrorOverride.ref
+	if client, physRef, ok := s.retireStaleOverride(failedClient); ok {
 		reader, size, err := tryGetBlob(ctx, client, physRef, info, cache, len(s.remainingSources) > 0)
 		if err == nil {
 			return reader, size, nil
 		}
-		// Override failed — retire it so subsequent goroutines don't retry it.
-		s.prevOverrides = append(s.prevOverrides, s.mirrorOverride.client)
-		s.mirrorOverride = nil
+		s.retireCurrentOverride()
 	}
 
-	registryConf, regErr := loadRegistryConfiguration(s.fallbackSys)
-	if regErr != nil {
-		logrus.Debugf("Mirror fallback: failed to load registry config: %v", regErr)
-		return nil, 0, originalErr
-	}
-
-	type attempt struct {
-		ref reference.Named
-		err error
-	}
-	attempts := []attempt{}
+	attempts := []sourceAttempt{}
 	for len(s.remainingSources) > 0 {
 		pullSource := s.remainingSources[0]
 		s.remainingSources = s.remainingSources[1:]
 
 		logrus.Debugf("Trying to access %q", pullSource.Reference)
 
-		fallbackEndpoint, clientErr := newPullClient(s.fallbackSys, s.logicalRef, pullSource, registryConf)
+		fallbackEndpoint, clientErr := newPullClient(s.fallbackSys, s.logicalRef, pullSource, s.fallbackRegConfig)
 		if clientErr != nil {
 			logrus.Debugf("Accessing %q failed: %v", pullSource.Reference, clientErr)
-			attempts = append(attempts, attempt{ref: pullSource.Reference, err: clientErr})
+			attempts = append(attempts, sourceAttempt{ref: pullSource.Reference, err: clientErr})
 			continue
 		}
 
@@ -644,29 +697,70 @@ func (s *dockerImageSource) getBlobWithMirrorFallback(ctx context.Context, info 
 		if err != nil {
 			fallbackEndpoint.client.Close()
 			logrus.Debugf("Accessing %q failed: %v", pullSource.Reference, err)
-			attempts = append(attempts, attempt{ref: pullSource.Reference, err: err})
+			attempts = append(attempts, sourceAttempt{ref: pullSource.Reference, err: err})
 			if !isMirrorTransientError(err) && !isMirrorFallbackError(err) {
+				// non-transient errors are unlikely to be resolved by trying another source: stop probing further.
+				// break here to log the attempts and return originalErr below.
 				break
 			}
 			continue
 		}
 
-		if s.mirrorOverride != nil {
-			s.prevOverrides = append(s.prevOverrides, s.mirrorOverride.client)
-		}
+		s.retireCurrentOverride()
 		s.mirrorOverride = &mirrorSource{client: fallbackEndpoint.client, ref: fallbackEndpoint.ref}
 		logrus.Debugf("Blob fetch succeeded from fallback source %q, switching to it for future requests", pullSource.Reference)
 
 		return reader, size, nil
 	}
-	if len(attempts) > 0 {
-		extras := []string{}
-		for _, a := range attempts {
-			extras = append(extras, fmt.Sprintf("[%s: %v]", a.ref.String(), a.err))
+	return nil, 0, formatFallbackError(attempts, originalErr)
+}
+
+func (s *dockerImageSource) getBlobAtWithMirrorFallback(ctx context.Context, info types.BlobInfo, chunks []private.ImageSourceChunk, headers map[string][]string, originalErr error, failedClient *dockerClient) (chan io.ReadCloser, chan error, error) {
+	s.mirrorMu.Lock()
+	defer s.mirrorMu.Unlock()
+
+	if client, physRef, ok := s.retireStaleOverride(failedClient); ok {
+		streams, errs, err := tryGetBlobAt(ctx, client, physRef, info, chunks, headers, len(s.remainingSources) > 0)
+		if err == nil {
+			return streams, errs, nil
 		}
-		logrus.Debugf("(Fallback sources also failed: %s): %v", strings.Join(extras, "\n"), originalErr)
+		s.retireCurrentOverride()
 	}
-	return nil, 0, originalErr
+
+	attempts := []sourceAttempt{}
+	for len(s.remainingSources) > 0 {
+		pullSource := s.remainingSources[0]
+		s.remainingSources = s.remainingSources[1:]
+
+		logrus.Debugf("Trying to access %q", pullSource.Reference)
+
+		fallbackEndpoint, clientErr := newPullClient(s.fallbackSys, s.logicalRef, pullSource, s.fallbackRegConfig)
+		if clientErr != nil {
+			logrus.Debugf("Accessing %q failed: %v", pullSource.Reference, clientErr)
+			attempts = append(attempts, sourceAttempt{ref: pullSource.Reference, err: clientErr})
+			continue
+		}
+
+		streams, errs, err := tryGetBlobAt(ctx, fallbackEndpoint.client, fallbackEndpoint.ref, info, chunks, headers, len(s.remainingSources) > 0)
+		if err != nil {
+			fallbackEndpoint.client.Close()
+			logrus.Debugf("Accessing %q failed: %v", pullSource.Reference, err)
+			attempts = append(attempts, sourceAttempt{ref: pullSource.Reference, err: err})
+			if !isMirrorTransientError(err) && !isMirrorFallbackError(err) {
+				// non-transient errors are unlikely to be resolved by trying another source: stop probing further.
+				// break here to log the attempts and return originalErr below.
+				break
+			}
+			continue
+		}
+
+		s.retireCurrentOverride()
+		s.mirrorOverride = &mirrorSource{client: fallbackEndpoint.client, ref: fallbackEndpoint.ref}
+		logrus.Debugf("Partial blob fetch succeeded from fallback source %q, switching to it for future requests", pullSource.Reference)
+
+		return streams, errs, nil
+	}
+	return nil, nil, formatFallbackError(attempts, originalErr)
 }
 
 // GetSignaturesWithFormat returns the image's signatures.  It may use a remote (= slow) service.

--- a/image/docker/docker_image_src.go
+++ b/image/docker/docker_image_src.go
@@ -8,15 +8,20 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"math/rand/v2"
 	"mime"
 	"mime/multipart"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
 	"strings"
 	"sync"
+	"time"
 
+	"github.com/docker/distribution/registry/api/errcode"
+	v2 "github.com/docker/distribution/registry/api/v2"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/sirupsen/logrus"
 	"go.podman.io/image/v5/docker/reference"
@@ -48,6 +53,25 @@ type dockerImageSource struct {
 	// State
 	cachedManifest         []byte // nil if not loaded yet
 	cachedManifestMIMEType string // Only valid if cachedManifest != nil
+
+	// Mirror fallback: when a blob fetch fails with a fallback-worthy error,
+	// try remaining pull sources before giving up. Protected by mirrorMu.
+	mirrorMu         sync.Mutex
+	mirrorOverride   *mirrorSource                // If non-nil, this is the mirror and physicalRef for the override client
+	prevOverrides    []*dockerClient              // mirror clients replaced by a newer mirrorOverride; kept open because other goroutines may still be reading blobs through them, closed in Close()
+	remainingSources []sysregistriesv2.PullSource // later pull sources not yet tried, consumed front-to-back during fallback; nil when selected source is already the original source.
+	fallbackSys      *types.SystemContext
+}
+
+type mirrorSource struct {
+	client *dockerClient
+	ref    dockerReference
+}
+
+type pullEndpoint struct {
+	client      *dockerClient
+	ref         dockerReference
+	endpointSys *types.SystemContext
 }
 
 // newImageSource creates a new ImageSource for the specified image reference.
@@ -91,7 +115,7 @@ func newImageSource(ctx context.Context, sys *types.SystemContext, ref dockerRef
 		err error
 	}
 	attempts := []attempt{}
-	for _, pullSource := range pullSources {
+	for i, pullSource := range pullSources {
 		if sys != nil && sys.DockerLogMirrorChoice {
 			logrus.Infof("Trying to access %q", pullSource.Reference)
 		} else {
@@ -99,6 +123,10 @@ func newImageSource(ctx context.Context, sys *types.SystemContext, ref dockerRef
 		}
 		s, err := newImageSourceAttempt(ctx, sys, ref, pullSource, registryConfig)
 		if err == nil {
+			if i+1 < len(pullSources) {
+				s.remainingSources = pullSources[i+1:]
+				s.fallbackSys = sys
+			}
 			return s, nil
 		}
 		logrus.Debugf("Accessing %q failed: %v", pullSource.Reference, err)
@@ -131,6 +159,63 @@ func newImageSource(ctx context.Context, sys *types.SystemContext, ref dockerRef
 func newImageSourceAttempt(ctx context.Context, sys *types.SystemContext, logicalRef dockerReference, pullSource sysregistriesv2.PullSource,
 	registryConfig *registryConfiguration,
 ) (*dockerImageSource, error) {
+	endpoint, err := newPullClient(sys, logicalRef, pullSource, registryConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	s := &dockerImageSource{
+		PropertyMethodsInitialize: impl.PropertyMethods(impl.Properties{
+			HasThreadSafeGetBlob: true,
+		}),
+
+		logicalRef:  logicalRef,
+		physicalRef: endpoint.ref,
+		c:           endpoint.client,
+	}
+	s.Compat = impl.AddCompat(s)
+
+	if err := s.ensureManifestIsLoaded(ctx); err != nil {
+		endpoint.client.Close()
+		return nil, err
+	}
+
+	if h, err := sysregistriesv2.AdditionalLayerStoreAuthHelper(endpoint.endpointSys); err == nil && h != "" {
+		acf := map[string]struct {
+			Username      string `json:"username,omitempty"`
+			Password      string `json:"password,omitempty"`
+			IdentityToken string `json:"identityToken,omitempty"`
+		}{
+			endpoint.ref.ref.String(): {
+				Username:      endpoint.client.auth.Username,
+				Password:      endpoint.client.auth.Password,
+				IdentityToken: endpoint.client.auth.IdentityToken,
+			},
+		}
+		acfD, err := json.Marshal(acf)
+		if err != nil {
+			logrus.Warnf("failed to marshal auth config: %v", err)
+		} else {
+			cmd := exec.Command(h)
+			cmd.Stdin = bytes.NewReader(acfD)
+			if err := cmd.Run(); err != nil {
+				var stderr string
+				if ee, ok := err.(*exec.ExitError); ok {
+					stderr = string(ee.Stderr)
+				}
+				logrus.Warnf("Failed to call additional-layer-store-auth-helper (stderr:%s): %v", stderr, err)
+			}
+		}
+	}
+	return s, nil
+}
+
+// newPullClient creates a dockerClient, reference, and endpoint-specific SystemContext
+// for the given pull source.
+// The caller must call client.Close() when done.
+func newPullClient(sys *types.SystemContext, logicalRef dockerReference, pullSource sysregistriesv2.PullSource,
+	registryConfig *registryConfiguration,
+) (*pullEndpoint, error) {
 	physicalRef, err := newReference(pullSource.Reference, false)
 	if err != nil {
 		return nil, err
@@ -152,50 +237,7 @@ func newImageSourceAttempt(ctx context.Context, sys *types.SystemContext, logica
 	client.tlsClientConfig.InsecureSkipVerify = pullSource.Endpoint.Insecure
 	client.namespaceProxy = pullSource.Endpoint.NamespaceProxy
 
-	s := &dockerImageSource{
-		PropertyMethodsInitialize: impl.PropertyMethods(impl.Properties{
-			HasThreadSafeGetBlob: true,
-		}),
-
-		logicalRef:  logicalRef,
-		physicalRef: physicalRef,
-		c:           client,
-	}
-	s.Compat = impl.AddCompat(s)
-
-	if err := s.ensureManifestIsLoaded(ctx); err != nil {
-		client.Close()
-		return nil, err
-	}
-
-	if h, err := sysregistriesv2.AdditionalLayerStoreAuthHelper(endpointSys); err == nil && h != "" {
-		acf := map[string]struct {
-			Username      string `json:"username,omitempty"`
-			Password      string `json:"password,omitempty"`
-			IdentityToken string `json:"identityToken,omitempty"`
-		}{
-			physicalRef.ref.String(): {
-				Username:      client.auth.Username,
-				Password:      client.auth.Password,
-				IdentityToken: client.auth.IdentityToken,
-			},
-		}
-		acfD, err := json.Marshal(acf)
-		if err != nil {
-			logrus.Warnf("failed to marshal auth config: %v", err)
-		} else {
-			cmd := exec.Command(h)
-			cmd.Stdin = bytes.NewReader(acfD)
-			if err := cmd.Run(); err != nil {
-				var stderr string
-				if ee, ok := err.(*exec.ExitError); ok {
-					stderr = string(ee.Stderr)
-				}
-				logrus.Warnf("Failed to call additional-layer-store-auth-helper (stderr:%s): %v", stderr, err)
-			}
-		}
-	}
-	return s, nil
+	return &pullEndpoint{client: client, ref: physicalRef, endpointSys: endpointSys}, nil
 }
 
 // Reference returns the reference used to set up this source, _as specified by the user_
@@ -206,6 +248,18 @@ func (s *dockerImageSource) Reference() types.ImageReference {
 
 // Close removes resources associated with an initialized ImageSource, if any.
 func (s *dockerImageSource) Close() error {
+	s.mirrorMu.Lock()
+	prev := s.prevOverrides
+	override := s.mirrorOverride
+	s.prevOverrides = nil
+	s.mirrorOverride = nil
+	s.mirrorMu.Unlock()
+	for _, m := range prev {
+		m.Close()
+	}
+	if override != nil {
+		override.client.Close()
+	}
 	return s.c.Close()
 }
 
@@ -456,7 +510,163 @@ func (s *dockerImageSource) GetBlobAt(ctx context.Context, info types.BlobInfo, 
 // The Digest field in BlobInfo is guaranteed to be provided, Size may be -1 and MediaType may be optionally provided.
 // May update BlobInfoCache, preferably after it knows for certain that a blob truly exists at a specific location.
 func (s *dockerImageSource) GetBlob(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache) (io.ReadCloser, int64, error) {
-	return s.c.getBlob(ctx, s.physicalRef, info, cache)
+	client, physRef, hasRemaining := s.getActiveSource()
+	reader, size, err := tryGetBlob(ctx, client, physRef, info, cache, hasRemaining)
+	if err == nil || !hasRemaining {
+		return reader, size, err
+	}
+	if isMirrorTransientError(err) || isMirrorFallbackError(err) {
+		logrus.Debugf("Blob %s fetch from %q failed (%v), trying fallback sources", info.Digest, physRef.ref, err)
+		return s.getBlobWithMirrorFallback(ctx, info, cache, err, client)
+	}
+	return reader, size, err
+}
+
+func (s *dockerImageSource) getActiveSource() (*dockerClient, dockerReference, bool) {
+	s.mirrorMu.Lock()
+	defer s.mirrorMu.Unlock()
+	hasRemaining := len(s.remainingSources) > 0
+	if s.mirrorOverride != nil {
+		return s.mirrorOverride.client, s.mirrorOverride.ref, hasRemaining
+	}
+	return s.c, s.physicalRef, hasRemaining
+}
+
+// tryGetBlob attempts to fetch a blob, retrying once on transient errors if fallback mirrors remain.
+func tryGetBlob(ctx context.Context, client *dockerClient, physRef dockerReference,
+	info types.BlobInfo, cache types.BlobInfoCache, hasRemainingSources bool,
+) (io.ReadCloser, int64, error) {
+	reader, size, err := client.getBlob(ctx, physRef, info, cache)
+	if err != nil && hasRemainingSources && isMirrorTransientError(err) {
+		logrus.Debugf("Transient error fetching blob %s from %q, retrying: %v", info.Digest, physRef.ref, err)
+		delay := time.Second + rand.N(time.Second/10) // same as retry.IfNecessary first attempt: 1s + 10% jitter
+		select {
+		case <-ctx.Done():
+			return nil, 0, fmt.Errorf("%w (while retrying after: %v)", ctx.Err(), err)
+		case <-time.After(delay):
+		}
+		reader, size, err = client.getBlob(ctx, physRef, info, cache)
+	}
+	return reader, size, err
+}
+
+// isMirrorFallbackError returns true for errors where the blob is not present
+// on this source but may be available from another — warranting a fallback attempt.
+// All tested registries (docker.io, registry.redhat.io, quay.io, registry.access.redhat.com)
+// return BLOB_UNKNOWN for blob 404s, matching the OCI distribution spec.
+func isMirrorFallbackError(err error) bool {
+	var ec errcode.ErrorCoder
+	if errors.As(err, &ec) {
+		switch ec.ErrorCode() {
+		case v2.ErrorCodeBlobUnknown:
+			// Blob endpoint returns HTTP 404 with errcode JSON body
+			// {"errors":[{"code":"BLOB_UNKNOWN",...}]}.
+			// registryHTTPResponseToError calls handleErrorResponse → parseHTTPErrorResponse,
+			// then unwraps errcode.Errors to the first errcode.Error.
+			return true
+		case errcode.ErrorCodeTooManyRequests:
+			// makeRequestToResolvedURL already retried 5 times with exponential
+			// backoff. This source's rate limit is exhausted — skip straight to
+			// the next mirror which has its own rate limit budget.
+			return true
+		}
+	}
+
+	// UnexpectedHTTPStatusError (capital U) is NOT matched here — for regular blobs,
+	// handleErrorResponse never produces it for 4xx (only for 5xx). For external blobs,
+	// getExternalBlob() produces it via newUnexpectedHTTPStatusError() directly for any
+	// non-200 including 404, but external URLs are fixed and mirror-independent —
+	// a different registry mirror cannot serve them.
+	return false
+}
+
+// isMirrorTransientError returns true for errors that are transient; the source
+// probably has the blob but temporarily cannot serve it.
+func isMirrorTransientError(err error) bool {
+	// HTTP 5xx: handleErrorResponse returns UnexpectedHTTPStatusError for status
+	// codes outside 400–499. Server-side error, another mirror may succeed.
+	var httpErr UnexpectedHTTPStatusError
+	if errors.As(err, &httpErr) && httpErr.StatusCode >= 500 {
+		return true
+	}
+
+	// Network timeout: makeRequest returns net.Error with Timeout() == true.
+	// The mirror is reachable but slow — worth retrying on another.
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
+}
+
+func (s *dockerImageSource) getBlobWithMirrorFallback(ctx context.Context, info types.BlobInfo, cache types.BlobInfoCache, originalErr error, failedClient *dockerClient) (io.ReadCloser, int64, error) {
+	// Held for the full fallback loop, including network I/O. This serializes
+	// concurrent blob fetchers during fallback — only one goroutine probes
+	// sources while the rest block on getActiveSource(). Acceptable trade-off:
+	// fallback is rare and serialization prevents thundering-herd probing.
+	s.mirrorMu.Lock()
+	defer s.mirrorMu.Unlock()
+
+	// If another goroutine already switched to a working mirror, try it first.
+	if s.mirrorOverride != nil && s.mirrorOverride.client != failedClient {
+		client, physRef := s.mirrorOverride.client, s.mirrorOverride.ref
+		reader, size, err := tryGetBlob(ctx, client, physRef, info, cache, len(s.remainingSources) > 0)
+		if err == nil {
+			return reader, size, nil
+		}
+		// Override failed — retire it so subsequent goroutines don't retry it.
+		s.prevOverrides = append(s.prevOverrides, s.mirrorOverride.client)
+		s.mirrorOverride = nil
+	}
+
+	registryConf, regErr := loadRegistryConfiguration(s.fallbackSys)
+	if regErr != nil {
+		logrus.Debugf("Mirror fallback: failed to load registry config: %v", regErr)
+		return nil, 0, originalErr
+	}
+
+	type attempt struct {
+		ref reference.Named
+		err error
+	}
+	attempts := []attempt{}
+	for len(s.remainingSources) > 0 {
+		pullSource := s.remainingSources[0]
+		s.remainingSources = s.remainingSources[1:]
+
+		logrus.Debugf("Trying to access %q", pullSource.Reference)
+
+		fallbackEndpoint, clientErr := newPullClient(s.fallbackSys, s.logicalRef, pullSource, registryConf)
+		if clientErr != nil {
+			logrus.Debugf("Accessing %q failed: %v", pullSource.Reference, clientErr)
+			attempts = append(attempts, attempt{ref: pullSource.Reference, err: clientErr})
+			continue
+		}
+
+		reader, size, err := tryGetBlob(ctx, fallbackEndpoint.client, fallbackEndpoint.ref, info, cache, len(s.remainingSources) > 0)
+		if err != nil {
+			fallbackEndpoint.client.Close()
+			logrus.Debugf("Accessing %q failed: %v", pullSource.Reference, err)
+			attempts = append(attempts, attempt{ref: pullSource.Reference, err: err})
+			if !isMirrorTransientError(err) && !isMirrorFallbackError(err) {
+				break
+			}
+			continue
+		}
+
+		if s.mirrorOverride != nil {
+			s.prevOverrides = append(s.prevOverrides, s.mirrorOverride.client)
+		}
+		s.mirrorOverride = &mirrorSource{client: fallbackEndpoint.client, ref: fallbackEndpoint.ref}
+		logrus.Debugf("Blob fetch succeeded from fallback source %q, switching to it for future requests", pullSource.Reference)
+
+		return reader, size, nil
+	}
+	if len(attempts) > 0 {
+		extras := []string{}
+		for _, a := range attempts {
+			extras = append(extras, fmt.Sprintf("[%s: %v]", a.ref.String(), a.err))
+		}
+		logrus.Debugf("(Fallback sources also failed: %s): %v", strings.Join(extras, "\n"), originalErr)
+	}
+	return nil, 0, originalErr
 }
 
 // GetSignaturesWithFormat returns the image's signatures.  It may use a remote (= slow) service.

--- a/image/docker/docker_image_src_test.go
+++ b/image/docker/docker_image_src_test.go
@@ -3,6 +3,7 @@ package docker
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +14,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/distribution/registry/api/errcode"
+	v2 "github.com/docker/distribution/registry/api/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.podman.io/image/v5/internal/private"
@@ -79,6 +82,115 @@ location = "@REGISTRY@/with-mirror"
 		require.True(t, ok, c.input)
 		assert.Equal(t, "//"+c.input, src2.logicalRef.StringWithinTransport(), c.input)
 		assert.Equal(t, "//"+c.physical, src2.physicalRef.StringWithinTransport(), c.input)
+	}
+}
+
+// testTimeoutError is a net.Error with configurable Timeout() for testing.
+type testTimeoutError struct{ timeout bool }
+
+func (e *testTimeoutError) Error() string   { return "test timeout error" }
+func (e *testTimeoutError) Timeout() bool   { return e.timeout }
+func (e *testTimeoutError) Temporary() bool { return false }
+
+func TestIsMirrorTransientError(t *testing.T) {
+	for _, c := range []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		// UnexpectedHTTPStatusError: handleErrorResponse returns this for status codes outside 400–499.
+		// getBlob wraps it with "fetching blob: ".
+		{
+			name:     "HTTP 500 from handleErrorResponse",
+			err:      fmt.Errorf("fetching blob: %w", UnexpectedHTTPStatusError{StatusCode: 500, status: "500 Internal Server Error"}),
+			expected: true,
+		},
+		{
+			name:     "HTTP 503 from handleErrorResponse",
+			err:      fmt.Errorf("fetching blob: %w", UnexpectedHTTPStatusError{StatusCode: 503, status: "503 Service Unavailable"}),
+			expected: true,
+		},
+		{
+			name:     "HTTP 404 is not transient",
+			err:      UnexpectedHTTPStatusError{StatusCode: 404, status: "404 Not Found"},
+			expected: false,
+		},
+		{
+			name:     "HTTP 400 is not transient",
+			err:      UnexpectedHTTPStatusError{StatusCode: 400, status: "400 Bad Request"},
+			expected: false,
+		},
+		// Network timeout: makeRequest returns net.Error with Timeout() == true.
+		{
+			name:     "network timeout from makeRequest",
+			err:      &testTimeoutError{timeout: true},
+			expected: true,
+		},
+		{
+			name:     "network error without timeout",
+			err:      &testTimeoutError{timeout: false},
+			expected: false,
+		},
+		{
+			name:     "wrapped network timeout",
+			err:      fmt.Errorf("making request: %w", &testTimeoutError{timeout: true}),
+			expected: true,
+		},
+		{
+			name:     "plain error",
+			err:      fmt.Errorf("something unrelated"),
+			expected: false,
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.expected, isMirrorTransientError(c.err))
+		})
+	}
+}
+
+func TestIsMirrorFallbackError(t *testing.T) {
+	for _, c := range []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		// BLOB_UNKNOWN: registryHTTPResponseToError → handleErrorResponse → parseHTTPErrorResponse
+		// returns errcode.Error{Code: v2.ErrorCodeBlobUnknown}. getBlob wraps with "fetching blob: ".
+		{
+			name:     "BLOB_UNKNOWN from registry",
+			err:      fmt.Errorf("fetching blob: %w", errcode.Error{Code: v2.ErrorCodeBlobUnknown, Message: "blob unknown to registry"}),
+			expected: true,
+		},
+		// TOO_MANY_REQUESTS: parseHTTPErrorResponse returns this for HTTP 429,
+		// or the detailsErr path in handleErrorResponse produces it.
+		{
+			name:     "TOO_MANY_REQUESTS from registry",
+			err:      fmt.Errorf("fetching blob: %w", errcode.ErrorCodeTooManyRequests.WithMessage("rate limit exceeded")),
+			expected: true,
+		},
+		// MANIFEST_UNKNOWN should not trigger fallback — it means the image doesn't exist,
+		// not just the blob.
+		{
+			name:     "MANIFEST_UNKNOWN is not fallback",
+			err:      errcode.Error{Code: v2.ErrorCodeManifestUnknown, Message: "manifest unknown"},
+			expected: false,
+		},
+		// UnexpectedHTTPStatusError is not matched — for regular blobs, handleErrorResponse
+		// never produces it for 4xx.
+		{
+			name:     "UnexpectedHTTPStatusError 404 is not fallback",
+			err:      UnexpectedHTTPStatusError{StatusCode: 404, status: "404 Not Found"},
+			expected: false,
+		},
+		{
+			name:     "plain error",
+			err:      fmt.Errorf("something unrelated"),
+			expected: false,
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.expected, isMirrorFallbackError(c.err))
+		})
 	}
 }
 

--- a/image/docs/containers-registries.conf.5.md
+++ b/image/docs/containers-registries.conf.5.md
@@ -153,7 +153,9 @@ as-is. But other settings like insecure/blocked/mirrors will be applied to match
 The mirrors are attempted in the specified order; the first one that can be
 contacted and contains the image will be used (and if none of the mirrors contains the image,
 the primary location specified by the `registry.location` field, or using the unmodified
-user-specified reference, is tried last).
+user-specified reference, is tried last).  If individual blob fetches later fail on the
+selected source, the remaining sources are tried automatically (see **Blob-level mirror
+fallback** below).
 
 Each TOML table in the `mirror` array can contain the following fields:
 - `location`： same semantics
@@ -175,6 +177,19 @@ Referencing an image by digest ensures that the same is always used
 (whereas referencing an image by a tag may cause different registries to return
 different images if the tag mapping is out of sync).
 
+
+#### Blob-level mirror fallback
+
+After a pull source is selected based on manifest availability, individual blob
+(layer) fetches may still fail.  When a blob fetch fails with a transient error
+(HTTP 5xx, network timeout), `BLOB_UNKNOWN`, or HTTP 429 after the built-in
+retries, the remaining configured sources are tried in order.  If a working
+source is found, it is used for subsequent blob fetches in the same pull
+operation.
+
+This means that even if the selected source can serve the manifest, blob pulls
+can transparently fall back to another mirror or the primary registry without
+restarting the entire pull.
 
 *Note*: Redirection and mirrors are currently processed only when reading a single image,
 not when pushing to a registry nor when doing any other kind of lookup/search on a on a registry.
@@ -299,7 +314,9 @@ Given the above, a pull of `example.com/foo/image:latest` will try:
 2. `example-mirror-1.local/mirrors/foo/image:latest`
 3. `internal-registry-for-example.com/bar/image:latest`
 
-in order, and use the first one that exists.
+in order, and use the first one that can serve the manifest.  If a blob fetch
+subsequently fails on the selected source, the remaining sources are tried as
+described in **Blob-level mirror fallback**.
 
 Note that a mirror is associated only with the current `[[registry]]` TOML table. If using the example above, pulling the image `registry.com/image:latest` will hence only reach out to `mirror.registry.com`, and the mirrors associated with `example.com/foo` will not be considered.
 

--- a/image/docs/containers-registries.conf.5.md
+++ b/image/docs/containers-registries.conf.5.md
@@ -188,8 +188,12 @@ source is found, it is used for subsequent blob fetches in the same pull
 operation.
 
 This means that even if the selected source can serve the manifest, blob pulls
-can transparently fall back to another mirror or the primary registry without
-restarting the entire pull.
+can transparently retry on the same source once and then fall back to another
+mirror or the primary registry without restarting the entire pull.
+
+This fallback or retry operates in addition to caller-level retry (e.g. `containers-common`'s `retry` package or kubelet retries).  A single blob fetch may be retried once on the same source before
+falling back, and the caller may retry the entire pull operation on top of that.
+
 
 *Note*: Redirection and mirrors are currently processed only when reading a single image,
 not when pushing to a registry nor when doing any other kind of lookup/search on a on a registry.


### PR DESCRIPTION
## Summary

In disconnected/restricted environments, a mirror can pass the manifest
check in `newImageSource()` but then fail blob downloads (5xx, timeout,
or partial mirror returning BLOB_UNKNOWN). When this happens, the copy
fails and CRI-O propagates the error to kubelet — which retries from
scratch, picks the same broken mirror, and deadlocks.

This PR adds blob-level mirror fallback(**full** blob downloading and **partial** chunk
fetches used by lazy image pulling (zstd:chunked)) inside `dockerImageSource` so
that when a blob fetch fails, remaining configured mirrors are tried
before giving up. The fallback is transparent to all callers (CRI-O,
Podman, Buildah, Skopeo).

## Design choices

**Fallback triggers:** Only transient errors (5xx, network timeout),
blob-not-found (BLOB_UNKNOWN), and rate limiting (429) trigger
fallback. Other 4xx errors (auth failures, etc.) are fatal — they
indicate a configuration problem, not a source issue.

**Serialized mirror probing:** `getBlobWithMirrorFallback()` holds
`mirrorMu` for the entire probe loop. This is intentional: the first
goroutine to hit a failure walks the mirror list while the rest block on
`getActiveSource()`, then reuse the discovered working mirror via
`mirrorOverride`. This avoids N goroutines independently exhausting the
mirror list.

**No manifest re-fetch on fallback:** Blob digests from the original
manifest are used against fallback sources. Safe because digests are
content-addressed. Fallback uses `newPullClient()` to create only a
client and reference, skipping the manifest fetch; configured mirrors
are expected to have the image in practice, and isMirrorFallbackError
handles BLOB_UNKNOWN to move to the next source if it doesn't.

**`remainingSources` includes mirrors AND the primary location:** The
fallback loop tries whatever `pullSources` entries come after the
initially-selected source, which may include the original upstream
registry.

**Same-mirror retry on transient errors:** `tryGetBlob()` retries once
with 1s+jitter delay before moving to the next source. This handles
brief 503 spikes without immediately triggering the full fallback
machinery.

## ~~Questions~~

Re: https://github.com/podman-container-tools/container-libs/pull/845#pullrequestreview-4330576035
- Are the right errors triggering fallback in `isMirrorTransientError()` / `isMirrorFallbackError()`? Should any other error types be included or excluded?
- The full-loop lock in `getBlobWithMirrorFallback()` serializes all blob goroutines during fallback — is this acceptable, or would you prefer a different concurrency strategy?
- Should `tryGetBlob()` retry once on the same mirror before falling back, or should any failure immediately try the next source?

## Out of scope (future work from the review)

- **Mid-stream fallback** (switching mirrors after partial blob download) — current approach fails the initial request, then tries next mirror from the start. If `bodyReader`'s reconnect to the same source also fails, it could try a different mirror instead of giving up. This is tracked: https://github.com/podman-container-tools/container-libs/issues/987

Fixes: https://issues.redhat.com/browse/OCPSTRAT-3170