### PR TITLE
image/copy: Fix missing progress reporting for chunked layers

### DIFF
--- a/image/copy/blob.go
+++ b/image/copy/blob.go
@@ -12,13 +12,14 @@ import (
 	"go.podman.io/image/v5/types"
 )
 
-// copyBlobFromStream copies a blob with srcInfo (with known Digest and Annotations and possibly known Size) from srcReader to dest,
-// perhaps sending a copy to an io.Writer if getOriginalLayerCopyWriter != nil,
-// perhaps (de/re/)compressing it if canModifyBlob,
-// and returns a complete blobInfo of the copied blob.
+// copyBlobFromStream copies a blob with srcInfo (with known Digest and Annotations and possibly known Size)
+// from srcReader to dest, perhaps sending a copy to an io.Writer if getOriginalLayerCopyWriter != nil,
+// perhaps (de/re/)compressing it if canModifyBlob, and returns a complete blobInfo of the copied blob.
+// The caller is responsible for calling reporter.reportSuccess() on success.
 func (ic *imageCopier) copyBlobFromStream(ctx context.Context, srcReader io.Reader, srcInfo types.BlobInfo,
 	getOriginalLayerCopyWriter func(decompressor compressiontypes.DecompressorFunc) io.Writer,
 	isConfig bool, toEncrypt bool, bar *progressBar, layerIndex int, emptyLayer bool,
+	reporter progressReporter,
 ) (types.BlobInfo, error) {
 	// The copying happens through a pipeline of connected io.Readers;
 	// that pipeline is built by updating stream.
@@ -84,16 +85,13 @@ func (ic *imageCopier) copyBlobFromStream(ctx context.Context, srcReader io.Read
 		return types.BlobInfo{}, err
 	}
 
-	// === Report progress using the ic.c.options.Progress channel, if required.
+	// === Report progress using the reporter, if required.
 	if ic.c.options.Progress != nil && ic.c.options.ProgressInterval > 0 {
-		progressReader := newProgressReader(
-			stream.reader,
-			ic.c.options.Progress,
-			ic.c.options.ProgressInterval,
-			srcInfo,
-		)
-		defer progressReader.reportDone()
-		stream.reader = progressReader
+		// Note: the reporter can be a no-op if the condition above evaluates
+		// false and in that case we prefer not to wrap the reader,
+		// so that we don’t inhibit users that benefit from optional
+		// interface special cases (e.g. io.WriterTo).
+		stream.reader = newProgressReader(stream.reader, reporter)
 	}
 
 	// === Finally, send the layer stream to dest.

--- a/image/copy/progress.go
+++ b/image/copy/progress.go
@@ -1,0 +1,44 @@
+package copy
+
+import (
+	"context"
+	"io"
+	"math"
+	"time"
+
+	"go.podman.io/image/v5/internal/private"
+	"go.podman.io/image/v5/types"
+)
+
+// blobChunkAccessorProxy wraps a BlobChunkAccessor to update a *progressBar
+// and progressReporter with the number of received bytes.
+type blobChunkAccessorProxy struct {
+	wrapped  private.BlobChunkAccessor // The underlying BlobChunkAccessor
+	bar      *progressBar              // A progress bar updated with the number of bytes read so far
+	reporter progressReporter          // A progress reporter updated with the number of bytes read so far
+}
+
+// GetBlobAt returns a sequential channel of readers that contain data for the requested
+// blob chunks, and a channel that might get a single error value.
+// The specified chunks must be not overlapping and sorted by their offset.
+// The readers must be fully consumed, in the order they are returned, before blocking
+// to read the next chunk.
+// If the Length for the last chunk is set to math.MaxUint64, then it
+// fully fetches the remaining data from the offset to the end of the blob.
+func (s *blobChunkAccessorProxy) GetBlobAt(ctx context.Context, info types.BlobInfo, chunks []private.ImageSourceChunk) (chan io.ReadCloser, chan error, error) {
+	start := time.Now()
+	rc, errs, err := s.wrapped.GetBlobAt(ctx, info, chunks)
+	if err == nil {
+		total := int64(0)
+		for _, c := range chunks {
+			// do not update the progress bar if there is a chunk with unknown length.
+			if c.Length == math.MaxUint64 {
+				return rc, errs, err
+			}
+			total += int64(c.Length)
+		}
+		s.reporter.reportRead(uint64(total))
+		s.bar.EwmaIncrInt64(total, time.Since(start))
+	}
+	return rc, errs, err
+}

--- a/image/copy/progress_bars.go
+++ b/image/copy/progress_bars.go
@@ -1,15 +1,11 @@
 package copy
 
 import (
-	"context"
 	"fmt"
 	"io"
-	"math"
-	"time"
 
 	"github.com/vbauerster/mpb/v8"
 	"github.com/vbauerster/mpb/v8/decor"
-	"go.podman.io/image/v5/internal/private"
 	"go.podman.io/image/v5/types"
 )
 
@@ -143,35 +139,4 @@ func (bar *progressBar) mark100PercentComplete() {
 		// That means that we are both _allowed_ to call SetTotal, and we _have to_.
 		bar.SetTotal(-1, true) // total < 0 = set it to bar.Current(), report it; and mark the bar as complete.
 	}
-}
-
-// blobChunkAccessorProxy wraps a BlobChunkAccessor and updates a *progressBar
-// with the number of received bytes.
-type blobChunkAccessorProxy struct {
-	wrapped private.BlobChunkAccessor // The underlying BlobChunkAccessor
-	bar     *progressBar              // A progress bar updated with the number of bytes read so far
-}
-
-// GetBlobAt returns a sequential channel of readers that contain data for the requested
-// blob chunks, and a channel that might get a single error value.
-// The specified chunks must be not overlapping and sorted by their offset.
-// The readers must be fully consumed, in the order they are returned, before blocking
-// to read the next chunk.
-// If the Length for the last chunk is set to math.MaxUint64, then it
-// fully fetches the remaining data from the offset to the end of the blob.
-func (s *blobChunkAccessorProxy) GetBlobAt(ctx context.Context, info types.BlobInfo, chunks []private.ImageSourceChunk) (chan io.ReadCloser, chan error, error) {
-	start := time.Now()
-	rc, errs, err := s.wrapped.GetBlobAt(ctx, info, chunks)
-	if err == nil {
-		total := int64(0)
-		for _, c := range chunks {
-			// do not update the progress bar if there is a chunk with unknown length.
-			if c.Length == math.MaxUint64 {
-				return rc, errs, err
-			}
-			total += int64(c.Length)
-		}
-		s.bar.EwmaIncrInt64(total, time.Since(start))
-	}
-	return rc, errs, err
 }

--- a/image/copy/progress_channel.go
+++ b/image/copy/progress_channel.go
@@ -7,73 +7,134 @@ import (
 	"go.podman.io/image/v5/types"
 )
 
-// progressReader is a reader that reports its progress to a types.ProgressProperties channel on an interval.
-type progressReader struct {
-	source       io.Reader
-	channel      chan<- types.ProgressProperties
-	interval     time.Duration
-	artifact     types.BlobInfo
-	lastUpdate   time.Time
-	offset       uint64
-	offsetUpdate uint64
+// progressReporter is an interface for reporting progress about a single blob.
+type progressReporter interface {
+	// reportRead reports progress with the number of `bytesRead`.
+	reportRead(bytesRead uint64)
+	// reportSuccess reports successful completion.
+	reportSuccess()
+	// reset resets the reporter's progress.
+	reset()
 }
 
-// newProgressReader creates a new progress reader for:
-// `source`:   The source when internally reading bytes
-// `channel`:  The reporter channel to which the progress will be sent
-// `interval`: The update interval to indicate how often the progress should update
-// `artifact`: The blob metadata which is currently being progressed
-func newProgressReader(
-	source io.Reader,
+// noopProgressReporter is a no-op implementation of progressReporter.
+type noopProgressReporter struct{}
+
+func (r *noopProgressReporter) reportRead(uint64) {}
+func (r *noopProgressReporter) reportSuccess()    {}
+func (r *noopProgressReporter) reset()            {}
+
+// channelProgressReporter reports progress about a single blob to a
+// types.ProgressProperties channel and supports re-starting from zero
+// without reporting the progress through the channel unless
+// it's higher than the offset reached before the restart to
+// avoid confusing behavior in consumers of the events
+// (skipping back).
+type channelProgressReporter struct {
+	channel           chan<- types.ProgressProperties // The reporter channel to which the progress will be sent
+	interval          time.Duration                   // The update interval to indicate how often the progress should update
+	artifact          types.BlobInfo                  // The blob metadata which is currently being progressed
+	lastUpdate        time.Time                       // The last time a progress channel event was sent
+	offset            uint64                          // The currently downloaded size in bytes
+	maxReportedOffset uint64                          // The high-water mark for offset already sent to the channel
+}
+
+// newProgressReporter returns a channelProgressReporter if a progress channel
+// and interval are configured, otherwise a noopProgressReporter.
+func newProgressReporter(
 	channel chan<- types.ProgressProperties,
 	interval time.Duration,
 	artifact types.BlobInfo,
-) *progressReader {
-	// The progress reader constructor informs the progress channel
-	// that a new artifact will be read
+) progressReporter {
+	if channel == nil || interval <= 0 {
+		return &noopProgressReporter{}
+	}
+	return newChannelProgressReporter(channel, interval, artifact)
+}
+
+// newChannelProgressReporter creates a new progress reporter
+// and immediately reports a new artifact event.
+func newChannelProgressReporter(
+	channel chan<- types.ProgressProperties,
+	interval time.Duration,
+	artifact types.BlobInfo,
+) progressReporter {
 	channel <- types.ProgressProperties{
 		Event:    types.ProgressEventNewArtifact,
 		Artifact: artifact,
 	}
-	return &progressReader{
-		source:       source,
-		channel:      channel,
-		interval:     interval,
-		artifact:     artifact,
-		lastUpdate:   time.Now(),
-		offset:       0,
-		offsetUpdate: 0,
+	return &channelProgressReporter{
+		channel:           channel,
+		interval:          interval,
+		artifact:          artifact,
+		lastUpdate:        time.Now(),
+		offset:            0,
+		maxReportedOffset: 0,
 	}
 }
 
-// reportDone indicates to the internal channel that the progress has been
-// finished
-func (r *progressReader) reportDone() {
-	r.channel <- types.ProgressProperties{
-		Event:        types.ProgressEventDone,
-		Artifact:     r.artifact,
-		Offset:       r.offset,
-		OffsetUpdate: r.offsetUpdate,
-	}
+// reset resets the reporter's progress.
+//
+// It's meant to be used on error when
+// the processing has to be re-started
+// (e.g. ErrFallbackToOrdinaryLayerDownload).
+func (r *channelProgressReporter) reset() {
+	r.offset = 0
 }
 
-// Read continuously reads bytes into the progress reader and reports the
-// status via the internal channel
-func (r *progressReader) Read(p []byte) (int, error) {
-	n, err := r.source.Read(p)
-	r.offset += uint64(n)
-	r.offsetUpdate += uint64(n)
-
-	// Fire the progress reader in the provided interval
-	if time.Since(r.lastUpdate) > r.interval {
+// reportRead reports progress with the number of `bytesRead`
+// while keeping track of a current high-water mark in case
+// of reset(). It never skips back below the already reported
+// offset and does not report the progress unless
+// the configured `interval` elapses.
+func (r *channelProgressReporter) reportRead(bytesRead uint64) {
+	r.offset += bytesRead
+	if r.offset > r.maxReportedOffset && time.Since(r.lastUpdate) > r.interval {
 		r.channel <- types.ProgressProperties{
 			Event:        types.ProgressEventRead,
 			Artifact:     r.artifact,
 			Offset:       r.offset,
-			OffsetUpdate: r.offsetUpdate,
+			OffsetUpdate: r.offset - r.maxReportedOffset,
 		}
+		r.maxReportedOffset = r.offset
 		r.lastUpdate = time.Now()
-		r.offsetUpdate = 0
 	}
+}
+
+// reportSuccess reports successful completion.
+func (r *channelProgressReporter) reportSuccess() {
+	offset := max(r.offset, r.maxReportedOffset)
+	r.channel <- types.ProgressProperties{
+		Event:        types.ProgressEventDone,
+		Artifact:     r.artifact,
+		Offset:       offset,
+		OffsetUpdate: offset - r.maxReportedOffset,
+	}
+}
+
+// progressReader extends a wrapped io.Reader
+// with additional reporting of its progress.
+type progressReader struct {
+	source io.Reader
+	progressReporter
+}
+
+// newProgressReader creates a new progress reader that wraps source
+// and reports progress through the given reporter.
+func newProgressReader(
+	source io.Reader,
+	reporter progressReporter,
+) *progressReader {
+	return &progressReader{
+		source:           source,
+		progressReporter: reporter,
+	}
+}
+
+// Read continuously reads bytes into the progress reader and reports the
+// status via the internal channel.
+func (r *progressReader) Read(p []byte) (int, error) {
+	n, err := r.source.Read(p)
+	r.reportRead(uint64(n))
 	return n, err
 }

--- a/image/copy/progress_channel_test.go
+++ b/image/copy/progress_channel_test.go
@@ -256,12 +256,12 @@ func TestNewProgressReader(t *testing.T) {
 	sut := newSUT(t, nil, time.Second, channel)
 	assert.NotNil(t, sut)
 
-	// When/Then
-	go func() {
-		res := <-channel
-		assert.Equal(t, res.Event, types.ProgressEventDone)
-	}()
+	// When
 	sut.reportSuccess()
+
+	// Then
+	res := <-channel
+	assert.Equal(t, res.Event, types.ProgressEventDone)
 }
 
 func TestReadWithoutEvent(t *testing.T) {
@@ -273,7 +273,7 @@ func TestReadWithoutEvent(t *testing.T) {
 
 	// When
 	b := []byte{0, 1, 2, 3, 4}
-	read, err := reader.Read(b)
+	read, err := sut.Read(b)
 
 	// Then
 	assert.Nil(t, err)
@@ -288,14 +288,15 @@ func TestReadWithEvent(t *testing.T) {
 	assert.NotNil(t, sut)
 	b := []byte{0, 1, 2, 3, 4}
 
-	// When/Then
-	go func() {
-		res := <-channel
-		assert.Equal(t, res.Event, types.ProgressEventRead)
-		assert.Equal(t, res.Offset, uint64(5))
-		assert.Equal(t, res.OffsetUpdate, uint64(5))
-	}()
-	read, err := reader.Read(b)
+	// When
+	read, err := sut.Read(b)
+
+	// Then
 	assert.Equal(t, read, 5)
 	assert.Nil(t, err)
+
+	res := <-channel
+	assert.Equal(t, res.Event, types.ProgressEventRead)
+	assert.Equal(t, res.Offset, uint64(5))
+	assert.Equal(t, res.OffsetUpdate, uint64(5))
 }

--- a/image/copy/progress_channel_test.go
+++ b/image/copy/progress_channel_test.go
@@ -4,11 +4,235 @@ import (
 	"bytes"
 	"io"
 	"testing"
+	"testing/synctest"
 	"time"
 
+	digest "github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
 	"go.podman.io/image/v5/types"
 )
+
+// consumeNonblocking drains all currently buffered events
+// from a channel and returns them. It never blocks.
+func consumeNonblocking(channel <-chan types.ProgressProperties) []types.ProgressProperties {
+	var result []types.ProgressProperties
+	for {
+		select {
+		case p := <-channel:
+			result = append(result, p)
+		default:
+			return result
+		}
+	}
+}
+
+// TestNewProgressReporter verifies that constructing a reporter
+// signals a new artifact event.
+func TestNewProgressReporter(t *testing.T) {
+	const (
+		artifactDigest = digest.Digest("sha256:7173b809ca12ec5dee4506cd86be934c4596dd234ee82c0662eac04a8c2c71dc")
+		artifactSize   = 1024
+	)
+	channel := make(chan types.ProgressProperties, 10)
+	artifact := types.BlobInfo{Digest: artifactDigest, Size: artifactSize}
+
+	r := newChannelProgressReporter(channel, time.Second, artifact)
+	assert.NotNil(t, r, "newChannelProgressReporter should return a progress reporter")
+
+	// Verify only a new artifact event was received.
+	events := consumeNonblocking(channel)
+	assert.Equal(t, []types.ProgressProperties{{
+		Event:    types.ProgressEventNewArtifact,
+		Artifact: types.BlobInfo{Digest: artifactDigest, Size: artifactSize},
+	}}, events, "constructor should send exactly one new artifact event")
+}
+
+// TestProgressReporterReportRead verifies that a read event is sent
+// after the interval elapses and not before.
+func TestProgressReporterReportRead(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const (
+			artifactDigest = digest.Digest("sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4")
+			artifactSize   = 2048
+		)
+		channel := make(chan types.ProgressProperties, 10)
+		artifact := types.BlobInfo{Digest: artifactDigest, Size: artifactSize}
+		interval := 5 * time.Second
+
+		// Create a reporter and consume the new artifact event.
+		r := newChannelProgressReporter(channel, interval, artifact)
+		assert.NotEmpty(t, consumeNonblocking(channel), "should send new artifact event")
+
+		// Verify that before the interval elapses: no event is sent.
+		r.reportRead(5)
+		assert.Empty(t, consumeNonblocking(channel), "should not send before interval")
+
+		// Verify that after the interval: read event is sent.
+		time.Sleep(2 * interval)
+		r.reportRead(10)
+		events := consumeNonblocking(channel)
+		assert.Equal(t, []types.ProgressProperties{{
+			Event:        types.ProgressEventRead,
+			Artifact:     types.BlobInfo{Digest: artifactDigest, Size: artifactSize},
+			Offset:       15,
+			OffsetUpdate: 15,
+		}}, events, "should send a read event after interval elapses")
+	})
+}
+
+// TestProgressReporterReportDone verifies that a done event
+// includes the accumulated offset and the not-yet-reported offset update.
+func TestProgressReporterReportDone(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const (
+			artifactDigest = digest.Digest("sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+			artifactSize   = 4096
+		)
+		channel := make(chan types.ProgressProperties, 10)
+		artifact := types.BlobInfo{Digest: artifactDigest, Size: artifactSize}
+		interval := 5 * time.Second
+
+		// Create a reporter and consume the new artifact event.
+		r := newChannelProgressReporter(channel, interval, artifact)
+		assert.NotEmpty(t, consumeNonblocking(channel), "should send new artifact event")
+
+		// Simulate progress with three reported reads.
+		const (
+			read1 = 30
+			read2 = 20
+			read3 = 15
+		)
+		r.reportRead(read1)
+		assert.Empty(t, consumeNonblocking(channel), "should not send before interval")
+		time.Sleep(2 * interval)
+		r.reportRead(read2)
+		assert.NotEmpty(t, consumeNonblocking(channel), "should send after interval elapses")
+		r.reportRead(read3)
+
+		// Verify that the done event includes the
+		// accumulated offset from all three reads
+		// and the OffsetUpdate is the final read
+		// that happened before the update interval
+		// elapsed.
+		r.reportSuccess()
+		events := consumeNonblocking(channel)
+		assert.Equal(t, []types.ProgressProperties{{
+			Event:        types.ProgressEventDone,
+			Artifact:     types.BlobInfo{Digest: artifactDigest, Size: artifactSize},
+			Offset:       read1 + read2 + read3,
+			OffsetUpdate: read3,
+		}}, events, "should send a done event with accumulated offsets")
+	})
+}
+
+// TestProgressReporterReset verifies that reset does not report
+// negative progress and suppresses reports until the offset
+// exceeds the previously reported high-water mark.
+func TestProgressReporterReset(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const (
+			artifactDigest = digest.Digest("sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae")
+			artifactSize   = 8192
+		)
+		channel := make(chan types.ProgressProperties, 10)
+		artifact := types.BlobInfo{Digest: artifactDigest, Size: artifactSize}
+		interval := 5 * time.Second
+
+		// Create a reporter and consume the new artifact event.
+		r := newChannelProgressReporter(channel, interval, artifact)
+		assert.NotEmpty(t, consumeNonblocking(channel), "should send new artifact event")
+
+		// reportRead(10): no event before interval.
+		r.reportRead(10)
+		assert.Empty(t, consumeNonblocking(channel))
+
+		// After interval, reportRead(10): reports +20=20.
+		time.Sleep(2 * interval)
+		r.reportRead(10)
+		events := consumeNonblocking(channel)
+		assert.Equal(t, []types.ProgressProperties{{
+			Event:        types.ProgressEventRead,
+			Artifact:     types.BlobInfo{Digest: artifactDigest, Size: artifactSize},
+			Offset:       20,
+			OffsetUpdate: 20,
+		}}, events)
+
+		// reportRead(10): no event (interval not elapsed).
+		r.reportRead(10)
+		assert.Empty(t, consumeNonblocking(channel))
+
+		// reset: no event sent.
+		r.reset()
+		assert.Empty(t, consumeNonblocking(channel), "reset should not send an event")
+
+		// After interval, reportRead(15): nothing (15 < 20 already reported).
+		time.Sleep(2 * interval)
+		r.reportRead(15)
+		assert.Empty(t, consumeNonblocking(channel), "should not report below high-water mark")
+
+		// After interval, reportRead(10): reports +5=25.
+		time.Sleep(2 * interval)
+		r.reportRead(10)
+		events = consumeNonblocking(channel)
+		assert.Equal(t, []types.ProgressProperties{{
+			Event:        types.ProgressEventRead,
+			Artifact:     types.BlobInfo{Digest: artifactDigest, Size: artifactSize},
+			Offset:       25,
+			OffsetUpdate: 5,
+		}}, events)
+	})
+}
+
+// TestProgressReporterResetIntervalNotElapsed verifies that reportSuccess
+// reports accumulated bytes above the high-water mark
+// when called immediately after reportRead without waiting for the interval.
+func TestProgressReporterResetIntervalNotElapsed(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const (
+			artifactDigest = digest.Digest("sha256:fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9")
+			artifactSize   = 16384
+		)
+		channel := make(chan types.ProgressProperties, 10)
+		artifact := types.BlobInfo{Digest: artifactDigest, Size: artifactSize}
+		interval := 5 * time.Second
+
+		// Create a reporter and consume the new artifact event.
+		r := newChannelProgressReporter(channel, interval, artifact)
+		assert.NotEmpty(t, consumeNonblocking(channel), "should send new artifact event")
+
+		// Accumulate to 20.
+		r.reportRead(10)
+		time.Sleep(2 * interval)
+		r.reportRead(10)
+		assert.NotEmpty(t, consumeNonblocking(channel), "should send read event")
+
+		// Reset, accumulate above the high-water mark and immediately report success.
+		r.reset()
+		r.reportRead(25)
+		r.reportSuccess()
+		events := consumeNonblocking(channel)
+
+		// Verify that the accumulated offset is reported together with the done event.
+		assert.Equal(t, []types.ProgressProperties{{
+			Event:        types.ProgressEventDone,
+			Artifact:     types.BlobInfo{Digest: artifactDigest, Size: artifactSize},
+			Offset:       25,
+			OffsetUpdate: 5,
+		}}, events)
+	})
+}
+
+// TestNoopProgressReporter verifies that
+// a noopProgressReporter can be called without panicking.
+func TestNoopProgressReporter(t *testing.T) {
+	r := &noopProgressReporter{}
+
+	// Make sure that no progressReporter method panics.
+	r.reportRead(100)
+	r.reset()
+	r.reportRead(50)
+	r.reportSuccess()
+}
 
 func newSUT(
 	t *testing.T,
@@ -18,19 +242,17 @@ func newSUT(
 ) *progressReader {
 	artifact := types.BlobInfo{Size: 10}
 
-	go func() {
-		res := <-channel
-		assert.Equal(t, res.Event, types.ProgressEventNewArtifact)
-		assert.Equal(t, res.Artifact, artifact)
-	}()
-	res := newProgressReader(reader, channel, duration, artifact)
+	reporter := newChannelProgressReporter(channel, duration, artifact)
+	res := <-channel
+	assert.Equal(t, res.Event, types.ProgressEventNewArtifact)
+	assert.Equal(t, res.Artifact, artifact)
 
-	return res
+	return newProgressReader(reader, reporter)
 }
 
 func TestNewProgressReader(t *testing.T) {
 	// Given
-	channel := make(chan types.ProgressProperties)
+	channel := make(chan types.ProgressProperties, 1)
 	sut := newSUT(t, nil, time.Second, channel)
 	assert.NotNil(t, sut)
 
@@ -39,12 +261,12 @@ func TestNewProgressReader(t *testing.T) {
 		res := <-channel
 		assert.Equal(t, res.Event, types.ProgressEventDone)
 	}()
-	sut.reportDone()
+	sut.reportSuccess()
 }
 
 func TestReadWithoutEvent(t *testing.T) {
 	// Given
-	channel := make(chan types.ProgressProperties)
+	channel := make(chan types.ProgressProperties, 1)
 	reader := bytes.NewReader([]byte{0, 1, 2})
 	sut := newSUT(t, reader, time.Second, channel)
 	assert.NotNil(t, sut)
@@ -60,7 +282,7 @@ func TestReadWithoutEvent(t *testing.T) {
 
 func TestReadWithEvent(t *testing.T) {
 	// Given
-	channel := make(chan types.ProgressProperties)
+	channel := make(chan types.ProgressProperties, 1)
 	reader := bytes.NewReader([]byte{0, 1, 2, 3, 4, 5, 6})
 	sut := newSUT(t, reader, time.Nanosecond, channel)
 	assert.NotNil(t, sut)

--- a/image/copy/single.go
+++ b/image/copy/single.go
@@ -634,12 +634,14 @@ func (ic *imageCopier) copyConfig(ctx context.Context, src types.Image) error {
 				return types.BlobInfo{}, fmt.Errorf("reading config blob %s: %w", srcInfo.Digest, err)
 			}
 
-			destInfo, err := ic.copyBlobFromStream(ctx, bytes.NewReader(configBlob), srcInfo, nil, true, false, bar, -1, false)
+			reporter := newProgressReporter(ic.c.options.Progress, ic.c.options.ProgressInterval, srcInfo)
+			destInfo, err := ic.copyBlobFromStream(ctx, bytes.NewReader(configBlob), srcInfo, nil, true, false, bar, -1, false, reporter)
 			if err != nil {
 				return types.BlobInfo{}, err
 			}
 
 			bar.mark100PercentComplete()
+			reporter.reportSuccess()
 			return destInfo, nil
 		}()
 		if err != nil {
@@ -785,6 +787,8 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 		}
 	}
 
+	reporter := newProgressReporter(ic.c.options.Progress, ic.c.options.ProgressInterval, srcInfo)
+
 	// A partial pull is managed by the destination storage, that decides what portions
 	// of the source file are not known yet and must be fetched.
 	// Attempt a partial only when the source allows to retrieve a blob partially and
@@ -801,8 +805,9 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 			}()
 
 			proxy := blobChunkAccessorProxy{
-				wrapped: ic.c.rawSource,
-				bar:     bar,
+				wrapped:  ic.c.rawSource,
+				bar:      bar,
+				reporter: reporter,
 			}
 			uploadedBlob, err := ic.c.dest.PutBlobPartial(ctx, &proxy, srcInfo, private.PutBlobPartialOptions{
 				Cache:      ic.c.blobInfoCache,
@@ -815,7 +820,9 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 					bar.SetCurrent(srcInfo.Size)
 					bar.SetRefill(refill)
 				}
+
 				bar.mark100PercentComplete()
+				reporter.reportSuccess()
 				hideProgressBar = false
 				logrus.Debugf("Retrieved partial blob %v", srcInfo.Digest)
 				return true, updatedBlobInfoFromUpload(srcInfo, uploadedBlob), nil
@@ -823,6 +830,8 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 			// On a "partial content not available" error, ignore it and retrieve the whole layer.
 			var perr private.ErrFallbackToOrdinaryLayerDownload
 			if errors.As(err, &perr) {
+				// Reset progress, the reporter is reused for the fallback.
+				reporter.reset()
 				logrus.Debugf("Failed to retrieve partial blob: %v", err)
 				return false, types.BlobInfo{}, nil
 			}
@@ -850,7 +859,7 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 		}
 		defer srcStream.Close()
 
-		blobInfo, diffIDChan, err := ic.copyLayerFromStream(ctx, srcStream, types.BlobInfo{Digest: srcInfo.Digest, Size: srcBlobSize, MediaType: srcInfo.MediaType, Annotations: srcInfo.Annotations}, diffIDIsNeeded, toEncrypt, bar, layerIndex, emptyLayer)
+		blobInfo, diffIDChan, err := ic.copyLayerFromStream(ctx, srcStream, types.BlobInfo{Digest: srcInfo.Digest, Size: srcBlobSize, MediaType: srcInfo.MediaType, Annotations: srcInfo.Annotations}, diffIDIsNeeded, toEncrypt, bar, layerIndex, emptyLayer, reporter)
 		if err != nil {
 			return types.BlobInfo{}, "", err
 		}
@@ -880,6 +889,7 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 			}
 		}
 
+		reporter.reportSuccess()
 		bar.mark100PercentComplete()
 		return blobInfo, diffID, nil
 	}()
@@ -925,10 +935,12 @@ func updatedBlobInfoFromReuse(inputInfo types.BlobInfo, reusedBlob private.Reuse
 
 // copyLayerFromStream is an implementation detail of copyLayer; mostly providing a separate “defer” scope.
 // it copies a blob with srcInfo (with known Digest and Annotations and possibly known Size) from srcStream to dest,
-// perhaps (de/re/)compressing the stream,
-// and returns a complete blobInfo of the copied blob and perhaps a <-chan diffIDResult if diffIDIsNeeded, to be read by the caller.
+// perhaps (de/re/)compressing the stream, and returns a complete blobInfo of the copied blob and
+// perhaps a <-chan diffIDResult if diffIDIsNeeded, to be read by the caller.
+// The caller is responsible for calling reporter.reportSuccess() on success.
 func (ic *imageCopier) copyLayerFromStream(ctx context.Context, srcStream io.Reader, srcInfo types.BlobInfo,
 	diffIDIsNeeded bool, toEncrypt bool, bar *progressBar, layerIndex int, emptyLayer bool,
+	reporter progressReporter,
 ) (types.BlobInfo, <-chan diffIDResult, error) {
 	var getDiffIDRecorder func(compressiontypes.DecompressorFunc) io.Writer // = nil
 	var diffIDChan chan diffIDResult
@@ -954,7 +966,7 @@ func (ic *imageCopier) copyLayerFromStream(ctx context.Context, srcStream io.Rea
 		}
 	}
 
-	blobInfo, err := ic.copyBlobFromStream(ctx, srcStream, srcInfo, getDiffIDRecorder, false, toEncrypt, bar, layerIndex, emptyLayer) // Sets err to nil on success
+	blobInfo, err := ic.copyBlobFromStream(ctx, srcStream, srcInfo, getDiffIDRecorder, false, toEncrypt, bar, layerIndex, emptyLayer, reporter) // Sets err to nil on success
 	return blobInfo, diffIDChan, err
 	// We need the defer … pipeWriter.CloseWithError() to happen HERE so that the caller can block on reading from diffIDChan
 }

--- a/image/types/types.go
+++ b/image/types/types.go
@@ -707,7 +707,8 @@ type SystemContext struct {
 type ProgressEvent uint
 
 const (
-	// ProgressEventNewArtifact will be fired on progress reader setup
+	// ProgressEventNewArtifact will be fired when starting to process
+	// a new artifact
 	ProgressEventNewArtifact ProgressEvent = iota
 
 	// ProgressEventRead indicates that the artifact download is currently in
@@ -719,7 +720,7 @@ const (
 	ProgressEventDone
 
 	// ProgressEventSkipped is fired when the artifact has been skipped because
-	// its already available at the destination
+	// it's already available at the destination
 	ProgressEventSkipped
 )
 


### PR DESCRIPTION
The `PutBlobPartial` code path only updated a progress bar, but it did not report its progress to the `copy.Options.Progress` channel for chunked layers. 
This PR adds missing reporting and refactors parts shared with `progressReader`.

The Podman REST API `images/pull` with the `pullProgress` flag introduced in https://github.com/containers/podman/pull/28224 did not get progress updates from the channel and the output stream lacked events for partial blobs.

**Test added in:** https://github.com/containers/podman/pull/28713

**Fixes**: #469

## API pullProgress stream with this fix
```
➜  bin/podman system service --log-level=trace --time=0 tcp://localhost:8888 2> >(grep -i partial >&2)
time="2026-05-14T15:18:48Z" level=debug msg="Retrieved partial blob sha256:0ea8cd0810b88e14631c1064bc882a6ff5e664860ff768c70102716ab64e7f0b"
time="2026-05-14T15:18:49Z" level=debug msg="Retrieved partial blob sha256:da9bf6c3f7cfad233b1e4de2f6dbf010d48a73dfc14395bf634f45a413e4dbb0"
time="2026-05-14T15:18:49Z" level=debug msg="Retrieved partial blob sha256:8ad5c254127956ee8bea277ea593be376859bff00be2e987b4e6905c2e8d5538"
time="2026-05-14T15:18:49Z" level=debug msg="Retrieved partial blob sha256:7fd8aa9622b5f5f23bee3c4035235d929a4fe5da860b52bdda81ff432cb82b51"
time="2026-05-14T15:18:49Z" level=debug msg="Retrieved partial blob sha256:fc285a90f91602992c8cb458431ffe63fcb61295489191d153e366704885d936"
time="2026-05-14T15:18:49Z" level=debug msg="Retrieved partial blob sha256:400129928e227203c8f2146c61b5142a362ba9afdbd37fb459d61f7829983fe4"
```

```
➜  ~ podman rmi -f localhost:15000/chunked-test
Untagged: localhost:15000/chunked-test:latest
Deleted: be9027b559bccd87b7e10e472e464beadace2012e4dd69615a3a72682d83f006
➜  ~ curl --silent -X POST 'http://localhost:8888/v6.0.0/libpod/images/pull?reference=localhost:15000/chunked-test:latest&pullProgress=true' | jq .
{
  "status": "pulling",
  "stream": "Trying to pull localhost:15000/chunked-test:latest...\n"
}
{
  "status": "pulling",
  "stream": "Getting image source signatures\n"
}
{
  "status": "pulling",
  "stream": "Copying blob sha256:8ad5c254127956ee8bea277ea593be376859bff00be2e987b4e6905c2e8d5538\n"
}
{
  "status": "pulling",
  "stream": "Copying blob sha256:400129928e227203c8f2146c61b5142a362ba9afdbd37fb459d61f7829983fe4\n"
}
{
  "status": "pulling",
  "stream": "Copying blob sha256:09aa76a8de5384893277e1a0ba676ed7d063e4089c5b2966362e4de9eb37efb6\n"
}
{
  "status": "pulling",
  "stream": "Copying blob sha256:0ea8cd0810b88e14631c1064bc882a6ff5e664860ff768c70102716ab64e7f0b\n"
}
{
  "status": "pulling",
  "stream": "Copying blob sha256:7fd8aa9622b5f5f23bee3c4035235d929a4fe5da860b52bdda81ff432cb82b51\n"
}
{
  "status": "pulling",
  "stream": "Copying blob sha256:da9bf6c3f7cfad233b1e4de2f6dbf010d48a73dfc14395bf634f45a413e4dbb0\n"
}
{
  "status": "pulling",
  "stream": "Starting to pull artifact",
  "pullProgress": {
    "status": "pulling",
    "total": 10499078,
    "progressComponentID": "sha256:8ad5c254127956ee8bea277ea593be376859bff00be2e987b4e6905c2e8d5538"
  }
}
{
  "status": "pulling",
  "stream": "Starting to pull artifact",
  "pullProgress": {
    "status": "pulling",
    "total": 5250753,
    "progressComponentID": "sha256:400129928e227203c8f2146c61b5142a362ba9afdbd37fb459d61f7829983fe4"
  }
}
{
  "status": "pulling",
  "stream": "Starting to pull artifact",
  "pullProgress": {
    "status": "pulling",
    "total": 6299391,
    "progressComponentID": "sha256:0ea8cd0810b88e14631c1064bc882a6ff5e664860ff768c70102716ab64e7f0b"
  }
}
{
  "status": "pulling",
  "stream": "Starting to pull artifact",
  "pullProgress": {
    "status": "pulling",
    "total": 6299400,
    "progressComponentID": "sha256:7fd8aa9622b5f5f23bee3c4035235d929a4fe5da860b52bdda81ff432cb82b51"
  }
}
{
  "status": "pulling",
  "stream": "Starting to pull artifact",
  "pullProgress": {
    "status": "pulling",
    "total": 5250775,
    "progressComponentID": "sha256:da9bf6c3f7cfad233b1e4de2f6dbf010d48a73dfc14395bf634f45a413e4dbb0"
  }
}
{
  "status": "pulling",
  "stream": "Artifact already exists",
  "pullProgress": {
    "status": "skipped",
    "progressComponentID": "sha256:09aa76a8de5384893277e1a0ba676ed7d063e4089c5b2966362e4de9eb37efb6"
  }
}
{
  "status": "pulling",
  "stream": "Copying blob sha256:fc285a90f91602992c8cb458431ffe63fcb61295489191d153e366704885d936\n"
}
{
  "status": "pulling",
  "stream": "Starting to pull artifact",
  "pullProgress": {
    "status": "pulling",
    "total": 6299404,
    "progressComponentID": "sha256:fc285a90f91602992c8cb458431ffe63fcb61295489191d153e366704885d936"
  }
}
{
  "status": "pulling",
  "stream": "Pulling artifact",
  "pullProgress": {
    "status": "pulling",
    "current": 6086,
    "total": 6299391,
    "progressComponentID": "sha256:0ea8cd0810b88e14631c1064bc882a6ff5e664860ff768c70102716ab64e7f0b"
  }
}
{
  "status": "pulling",
  "stream": "Pulling artifact",
  "pullProgress": {
    "status": "pulling",
    "current": 10246,
    "total": 10499078,
    "progressComponentID": "sha256:8ad5c254127956ee8bea277ea593be376859bff00be2e987b4e6905c2e8d5538"
  }
}
{
  "status": "pulling",
  "stream": "Pulling artifact",
  "pullProgress": {
    "status": "pulling",
    "current": 6042,
    "total": 5250753,
    "progressComponentID": "sha256:400129928e227203c8f2146c61b5142a362ba9afdbd37fb459d61f7829983fe4"
  }
}
{
  "status": "pulling",
  "stream": "Pulling artifact",
  "pullProgress": {
    "status": "pulling",
    "current": 6089,
    "total": 6299400,
    "progressComponentID": "sha256:7fd8aa9622b5f5f23bee3c4035235d929a4fe5da860b52bdda81ff432cb82b51"
  }
}
{
  "status": "pulling",
  "stream": "Pulling artifact",
  "pullProgress": {
    "status": "pulling",
    "current": 6058,
    "total": 5250775,
    "progressComponentID": "sha256:da9bf6c3f7cfad233b1e4de2f6dbf010d48a73dfc14395bf634f45a413e4dbb0"
  }
}
{
  "status": "pulling",
  "stream": "Pulling artifact",
  "pullProgress": {
    "status": "pulling",
    "current": 6086,
    "total": 6299404,
    "progressComponentID": "sha256:fc285a90f91602992c8cb458431ffe63fcb61295489191d153e366704885d936"
  }
}
{
  "status": "pulling",
  "stream": "Pulling artifact",
  "pullProgress": {
    "status": "pulling",
    "current": 6299225,
    "total": 6299391,
    "progressComponentID": "sha256:0ea8cd0810b88e14631c1064bc882a6ff5e664860ff768c70102716ab64e7f0b"
  }
}
{
  "status": "pulling",
  "stream": "Pulling artifact",
  "pullProgress": {
    "status": "pulling",
    "current": 10498912,
    "total": 10499078,
    "progressComponentID": "sha256:8ad5c254127956ee8bea277ea593be376859bff00be2e987b4e6905c2e8d5538"
  }
}
{
  "status": "pulling",
  "stream": "Pulling artifact",
  "pullProgress": {
    "status": "pulling",
    "current": 6299234,
    "total": 6299400,
    "progressComponentID": "sha256:7fd8aa9622b5f5f23bee3c4035235d929a4fe5da860b52bdda81ff432cb82b51"
  }
}
{
  "status": "pulling",
  "stream": "Pulling artifact",
  "pullProgress": {
    "status": "pulling",
    "current": 6299237,
    "total": 6299404,
    "progressComponentID": "sha256:fc285a90f91602992c8cb458431ffe63fcb61295489191d153e366704885d936"
  }
}
{
  "status": "pulling",
  "stream": "Pulling artifact",
  "pullProgress": {
    "status": "pulling",
    "current": 5250586,
    "total": 5250753,
    "progressComponentID": "sha256:400129928e227203c8f2146c61b5142a362ba9afdbd37fb459d61f7829983fe4"
  }
}
{
  "status": "pulling",
  "stream": "Artifact pulled successfully",
  "pullProgress": {
    "status": "success",
    "current": 6299225,
    "total": 6299391,
    "progressComponentID": "sha256:0ea8cd0810b88e14631c1064bc882a6ff5e664860ff768c70102716ab64e7f0b"
  }
}
{
  "status": "pulling",
  "stream": "Pulling artifact",
  "pullProgress": {
    "status": "pulling",
    "current": 5250607,
    "total": 5250775,
    "progressComponentID": "sha256:da9bf6c3f7cfad233b1e4de2f6dbf010d48a73dfc14395bf634f45a413e4dbb0"
  }
}
{
  "status": "pulling",
  "stream": "Artifact pulled successfully",
  "pullProgress": {
    "status": "success",
    "current": 5250607,
    "total": 5250775,
    "progressComponentID": "sha256:da9bf6c3f7cfad233b1e4de2f6dbf010d48a73dfc14395bf634f45a413e4dbb0"
  }
}
{
  "status": "pulling",
  "stream": "Artifact pulled successfully",
  "pullProgress": {
    "status": "success",
    "current": 10498912,
    "total": 10499078,
    "progressComponentID": "sha256:8ad5c254127956ee8bea277ea593be376859bff00be2e987b4e6905c2e8d5538"
  }
}
{
  "status": "pulling",
  "stream": "Artifact pulled successfully",
  "pullProgress": {
    "status": "success",
    "current": 6299234,
    "total": 6299400,
    "progressComponentID": "sha256:7fd8aa9622b5f5f23bee3c4035235d929a4fe5da860b52bdda81ff432cb82b51"
  }
}
{
  "status": "pulling",
  "stream": "Artifact pulled successfully",
  "pullProgress": {
    "status": "success",
    "current": 6299237,
    "total": 6299404,
    "progressComponentID": "sha256:fc285a90f91602992c8cb458431ffe63fcb61295489191d153e366704885d936"
  }
}
{
  "status": "pulling",
  "stream": "Artifact pulled successfully",
  "pullProgress": {
    "status": "success",
    "current": 5250586,
    "total": 5250753,
    "progressComponentID": "sha256:400129928e227203c8f2146c61b5142a362ba9afdbd37fb459d61f7829983fe4"
  }
}
{
  "status": "pulling",
  "stream": "Copying config sha256:be9027b559bccd87b7e10e472e464beadace2012e4dd69615a3a72682d83f006\n"
}
{
  "status": "pulling",
  "stream": "Starting to pull artifact",
  "pullProgress": {
    "status": "pulling",
    "total": 1859,
    "progressComponentID": "sha256:be9027b559bccd87b7e10e472e464beadace2012e4dd69615a3a72682d83f006"
  }
}
{
  "status": "pulling",
  "stream": "Artifact pulled successfully",
  "pullProgress": {
    "status": "success",
    "current": 1859,
    "total": 1859,
    "progressComponentID": "sha256:be9027b559bccd87b7e10e472e464beadace2012e4dd69615a3a72682d83f006"
  }
}
{
  "status": "pulling",
  "stream": "Writing manifest to image destination\n"
}
{
  "status": "success",
  "images": [
    "be9027b559bccd87b7e10e472e464beadace2012e4dd69615a3a72682d83f006"
  ]
```


