### PR TITLE
fix(pasta): assign map-host-loopback for rootless bridges

### DIFF
--- a/common/libnetwork/pasta/pasta_linux.go
+++ b/common/libnetwork/pasta/pasta_linux.go
@@ -36,6 +36,8 @@ const (
 	// mapGuestAddrIpv4 static ip used as forwarder address inside the netns to reach the host,
 	// given this is a "link local" ip it should be very unlikely that it causes conflicts.
 	mapGuestAddrIpv4 = "169.254.1.2"
+
+	mapHostLoopbackOpt = "--map-host-loopback"
 )
 
 type SetupOptions struct {
@@ -273,6 +275,19 @@ func createPastaArgs(opts *SetupOptions) ([]string, []string, []string, error) {
 		// for our own host.containers.internal host entry.
 		cmdArgs = append(cmdArgs, mapGuestAddrOpt, mapGuestAddrIpv4)
 		mapGuestAddrIPs = append(mapGuestAddrIPs, mapGuestAddrIpv4)
+	}
+
+	// outbound counterpart: without this the /etc/hosts entry podman writes for
+	// host.containers.internal is unreachable from bridge containers
+	hasMapHostLoopback := false
+	for _, opt := range cmdArgs {
+		if opt == mapHostLoopbackOpt {
+			hasMapHostLoopback = true
+			break
+		}
+	}
+	if !hasMapHostLoopback {
+		cmdArgs = append(cmdArgs, mapHostLoopbackOpt, mapGuestAddrIpv4)
 	}
 
 	return cmdArgs, dnsForwardIPs, mapGuestAddrIPs, nil

--- a/common/libnetwork/pasta/pasta_linux_test.go
+++ b/common/libnetwork/pasta/pasta_linux_test.go
@@ -37,7 +37,7 @@ func Test_createPastaArgs(t *testing.T) {
 			wantArgs: []string{
 				"--config-net", "--dns-forward", dnsForwardIpv4, "-t", "none", "-u", "none",
 				"-T", "none", "-U", "none", "--no-map-gw", "--quiet", "--netns", "netns123",
-				mapGuestAddrOpt, mapGuestAddrIpv4,
+				mapGuestAddrOpt, mapGuestAddrIpv4, mapHostLoopbackOpt, mapGuestAddrIpv4,
 			},
 			wantDNSForward:   []string{dnsForwardIpv4},
 			wantMapGuestAddr: []string{mapGuestAddrIpv4},
@@ -52,7 +52,7 @@ func Test_createPastaArgs(t *testing.T) {
 			wantArgs: []string{
 				"--config-net", "-t", "80-80:80-80", "--dns-forward", dnsForwardIpv4, "-u", "none",
 				"-T", "none", "-U", "none", "--no-map-gw", "--quiet", "--netns", "netns123",
-				mapGuestAddrOpt, mapGuestAddrIpv4,
+				mapGuestAddrOpt, mapGuestAddrIpv4, mapHostLoopbackOpt, mapGuestAddrIpv4,
 			},
 			wantDNSForward:   []string{dnsForwardIpv4},
 			wantMapGuestAddr: []string{mapGuestAddrIpv4},
@@ -67,7 +67,7 @@ func Test_createPastaArgs(t *testing.T) {
 			wantArgs: []string{
 				"--config-net", "-t", "80-82:80-82", "--dns-forward", dnsForwardIpv4, "-u", "none",
 				"-T", "none", "-U", "none", "--no-map-gw", "--quiet", "--netns", "netns123",
-				mapGuestAddrOpt, mapGuestAddrIpv4,
+				mapGuestAddrOpt, mapGuestAddrIpv4, mapHostLoopbackOpt, mapGuestAddrIpv4,
 			},
 			wantDNSForward:   []string{dnsForwardIpv4},
 			wantMapGuestAddr: []string{mapGuestAddrIpv4},
@@ -82,7 +82,7 @@ func Test_createPastaArgs(t *testing.T) {
 			wantArgs: []string{
 				"--config-net", "-t", "80-80:60-60", "--dns-forward", dnsForwardIpv4, "-u", "none",
 				"-T", "none", "-U", "none", "--no-map-gw", "--quiet", "--netns", "netns123",
-				mapGuestAddrOpt, mapGuestAddrIpv4,
+				mapGuestAddrOpt, mapGuestAddrIpv4, mapHostLoopbackOpt, mapGuestAddrIpv4,
 			},
 			wantDNSForward:   []string{dnsForwardIpv4},
 			wantMapGuestAddr: []string{mapGuestAddrIpv4},
@@ -100,7 +100,7 @@ func Test_createPastaArgs(t *testing.T) {
 			wantArgs: []string{
 				"--config-net", "-t", "80-80:60-60", "-u", "100-100:100-100", "--dns-forward",
 				dnsForwardIpv4, "-T", "none", "-U", "none", "--no-map-gw", "--quiet", "--netns", "netns123",
-				mapGuestAddrOpt, mapGuestAddrIpv4,
+				mapGuestAddrOpt, mapGuestAddrIpv4, mapHostLoopbackOpt, mapGuestAddrIpv4,
 			},
 			wantDNSForward:   []string{dnsForwardIpv4},
 			wantMapGuestAddr: []string{mapGuestAddrIpv4},
@@ -118,7 +118,7 @@ func Test_createPastaArgs(t *testing.T) {
 			wantArgs: []string{
 				"--config-net", "-t", "80-80:60-60", "-t", "100-100:100-100", "--dns-forward",
 				dnsForwardIpv4, "-u", "none", "-T", "none", "-U", "none", "--no-map-gw", "--quiet", "--netns", "netns123",
-				mapGuestAddrOpt, mapGuestAddrIpv4,
+				mapGuestAddrOpt, mapGuestAddrIpv4, mapHostLoopbackOpt, mapGuestAddrIpv4,
 			},
 			wantDNSForward:   []string{dnsForwardIpv4},
 			wantMapGuestAddr: []string{mapGuestAddrIpv4},
@@ -144,7 +144,7 @@ func Test_createPastaArgs(t *testing.T) {
 			wantArgs: []string{
 				"--config-net", "-i", "eth0", "-n", "24", "--dns-forward", dnsForwardIpv4,
 				"-t", "none", "-u", "none", "-T", "none", "-U", "none", "--no-map-gw", "--quiet", "--netns", "netns123",
-				mapGuestAddrOpt, mapGuestAddrIpv4,
+				mapGuestAddrOpt, mapGuestAddrIpv4, mapHostLoopbackOpt, mapGuestAddrIpv4,
 			},
 			wantDNSForward:   []string{dnsForwardIpv4},
 			wantMapGuestAddr: []string{mapGuestAddrIpv4},
@@ -159,7 +159,7 @@ func Test_createPastaArgs(t *testing.T) {
 			wantArgs: []string{
 				"--config-net", "-i", "eth0", "-n", "24", "--dns-forward", dnsForwardIpv4,
 				"-t", "none", "-u", "none", "-T", "none", "-U", "none", "--no-map-gw", "--quiet", "--netns", "netns123",
-				mapGuestAddrOpt, mapGuestAddrIpv4,
+				mapGuestAddrOpt, mapGuestAddrIpv4, mapHostLoopbackOpt, mapGuestAddrIpv4,
 			},
 			wantDNSForward:   []string{dnsForwardIpv4},
 			wantMapGuestAddr: []string{mapGuestAddrIpv4},
@@ -174,7 +174,7 @@ func Test_createPastaArgs(t *testing.T) {
 			wantArgs: []string{
 				"--config-net", "-T", "80", "--dns-forward", dnsForwardIpv4,
 				"-t", "none", "-u", "none", "-U", "none", "--no-map-gw", "--quiet", "--netns", "netns123",
-				mapGuestAddrOpt, mapGuestAddrIpv4,
+				mapGuestAddrOpt, mapGuestAddrIpv4, mapHostLoopbackOpt, mapGuestAddrIpv4,
 			},
 			wantDNSForward:   []string{dnsForwardIpv4},
 			wantMapGuestAddr: []string{mapGuestAddrIpv4},
@@ -189,7 +189,7 @@ func Test_createPastaArgs(t *testing.T) {
 			wantArgs: []string{
 				"--config-net", "--tcp-ns", "80", "--dns-forward", dnsForwardIpv4,
 				"-t", "none", "-u", "none", "-U", "none", "--no-map-gw", "--quiet", "--netns", "netns123",
-				mapGuestAddrOpt, mapGuestAddrIpv4,
+				mapGuestAddrOpt, mapGuestAddrIpv4, mapHostLoopbackOpt, mapGuestAddrIpv4,
 			},
 			wantDNSForward:   []string{dnsForwardIpv4},
 			wantMapGuestAddr: []string{mapGuestAddrIpv4},
@@ -204,7 +204,7 @@ func Test_createPastaArgs(t *testing.T) {
 			wantArgs: []string{
 				"--config-net", "--dns-forward", dnsForwardIpv4, "-t", "none",
 				"-u", "none", "-T", "none", "-U", "none", "--quiet", "--netns", "netns123",
-				mapGuestAddrOpt, mapGuestAddrIpv4,
+				mapGuestAddrOpt, mapGuestAddrIpv4, mapHostLoopbackOpt, mapGuestAddrIpv4,
 			},
 			wantDNSForward:   []string{dnsForwardIpv4},
 			wantMapGuestAddr: []string{mapGuestAddrIpv4},
@@ -219,7 +219,7 @@ func Test_createPastaArgs(t *testing.T) {
 			wantArgs: []string{
 				"--config-net", "-T", "80", "--dns-forward", dnsForwardIpv4,
 				"-t", "none", "-u", "none", "-U", "none", "--quiet", "--netns", "netns123",
-				mapGuestAddrOpt, mapGuestAddrIpv4,
+				mapGuestAddrOpt, mapGuestAddrIpv4, mapHostLoopbackOpt, mapGuestAddrIpv4,
 			},
 			wantDNSForward:   []string{dnsForwardIpv4},
 			wantMapGuestAddr: []string{mapGuestAddrIpv4},
@@ -234,7 +234,7 @@ func Test_createPastaArgs(t *testing.T) {
 			wantArgs: []string{
 				"--config-net", "-T", "80", "--dns-forward", dnsForwardIpv4,
 				"-t", "none", "-u", "none", "-U", "none", "--quiet", "--netns", "netns123",
-				mapGuestAddrOpt, mapGuestAddrIpv4,
+				mapGuestAddrOpt, mapGuestAddrIpv4, mapHostLoopbackOpt, mapGuestAddrIpv4,
 			},
 			wantDNSForward:   []string{dnsForwardIpv4},
 			wantMapGuestAddr: []string{mapGuestAddrIpv4},
@@ -249,7 +249,7 @@ func Test_createPastaArgs(t *testing.T) {
 			wantArgs: []string{
 				"--config-net", "--dns-forward", "192.168.255.255", "-t", "none",
 				"-u", "none", "-T", "none", "-U", "none", "--no-map-gw", "--quiet", "--netns", "netns123",
-				mapGuestAddrOpt, mapGuestAddrIpv4,
+				mapGuestAddrOpt, mapGuestAddrIpv4, mapHostLoopbackOpt, mapGuestAddrIpv4,
 			},
 			wantDNSForward:   []string{"192.168.255.255"},
 			wantMapGuestAddr: []string{mapGuestAddrIpv4},
@@ -264,7 +264,7 @@ func Test_createPastaArgs(t *testing.T) {
 			wantArgs: []string{
 				"--config-net", "--dns-forward", "192.168.255.255", "--dns-forward", "::1", "-t", "none",
 				"-u", "none", "-T", "none", "-U", "none", "--no-map-gw", "--quiet", "--netns", "netns123",
-				mapGuestAddrOpt, mapGuestAddrIpv4,
+				mapGuestAddrOpt, mapGuestAddrIpv4, mapHostLoopbackOpt, mapGuestAddrIpv4,
 			},
 			wantDNSForward:   []string{"192.168.255.255", "::1"},
 			wantMapGuestAddr: []string{mapGuestAddrIpv4},
@@ -279,7 +279,7 @@ func Test_createPastaArgs(t *testing.T) {
 			wantArgs: []string{
 				"--config-net", "-i", "eth0", "-t", "80-80:80-80", "--dns-forward", dnsForwardIpv4,
 				"-u", "none", "-T", "none", "-U", "none", "--no-map-gw", "--quiet", "--netns", "netns123",
-				mapGuestAddrOpt, mapGuestAddrIpv4,
+				mapGuestAddrOpt, mapGuestAddrIpv4, mapHostLoopbackOpt, mapGuestAddrIpv4,
 			},
 			wantDNSForward:   []string{dnsForwardIpv4},
 			wantMapGuestAddr: []string{mapGuestAddrIpv4},
@@ -294,7 +294,7 @@ func Test_createPastaArgs(t *testing.T) {
 			wantArgs: []string{
 				"--config-net", "--log-file=/tmp/log", "--trace", "--debug",
 				"--dns-forward", dnsForwardIpv4, "-t", "none", "-u", "none", "-T", "none", "-U", "none",
-				"--no-map-gw", "--netns", "netns123", mapGuestAddrOpt, mapGuestAddrIpv4,
+				"--no-map-gw", "--netns", "netns123", mapGuestAddrOpt, mapGuestAddrIpv4, mapHostLoopbackOpt, mapGuestAddrIpv4,
 			},
 			wantDNSForward:   []string{dnsForwardIpv4},
 			wantMapGuestAddr: []string{mapGuestAddrIpv4},
@@ -309,7 +309,7 @@ func Test_createPastaArgs(t *testing.T) {
 			wantArgs: []string{
 				"--config-net", mapGuestAddrOpt, "192.168.255.255", dnsForwardOpt, dnsForwardIpv4,
 				"-t", "none", "-u", "none", "-T", "none", "-U", "none", "--no-map-gw", "--quiet",
-				"--netns", "netns123",
+				"--netns", "netns123", mapHostLoopbackOpt, mapGuestAddrIpv4,
 			},
 			wantDNSForward:   []string{dnsForwardIpv4},
 			wantMapGuestAddr: []string{"192.168.255.255"},
@@ -324,7 +324,7 @@ func Test_createPastaArgs(t *testing.T) {
 			wantArgs: []string{
 				"--config-net", mapGuestAddrOpt, "192.168.255.255", mapGuestAddrOpt, "::1",
 				dnsForwardOpt, dnsForwardIpv4, "-t", "none", "-u", "none", "-T", "none",
-				"-U", "none", "--no-map-gw", "--quiet", "--netns", "netns123",
+				"-U", "none", "--no-map-gw", "--quiet", "--netns", "netns123", mapHostLoopbackOpt, mapGuestAddrIpv4,
 			},
 			wantDNSForward:   []string{dnsForwardIpv4},
 			wantMapGuestAddr: []string{"192.168.255.255", "::1"},


### PR DESCRIPTION
Fixes containers/podman#28718 - Ensures the outbound counterpart --map-host-loopback is supplied so host.containers.internal is reachable from rootless bridge containers.