### PR TITLE
Manpage: remove slirp4netns/boltdb references

### DIFF
--- a/common/docs/containers.conf.5.md
+++ b/common/docs/containers.conf.5.md
@@ -485,8 +485,7 @@ default_subnet_pools = [
 
 **default_rootless_network_cmd**="pasta"
 
-Configure which rootless network program to use by default. Valid options are
-`slirp4netns` and `pasta` (default).
+Configure which rootless network program to use by default. The only valid option is `pasta` (default).
 
 **network_config_dir**="/etc/containers/networks"
 
@@ -591,15 +590,6 @@ conmon_path=[
 ]
 ```
 
-**database_backend**=""
-
-The database backend of Podman.  Supported values are "" (default), "boltdb"
-and "sqlite". An empty value means it will check whenever a boltdb already
-exists and use it when it does, otherwise it will use sqlite as default
-(e.g. new installs). This allows for backwards compatibility with older versions.
-Please run `podman-system-reset` prior to changing the database
-backend of an existing deployment, to make sure Podman can operate correctly.
-
 **detach_keys**="ctrl-p,ctrl-q"
 
 Keys sequence used for detaching a container.
@@ -677,7 +667,6 @@ The following binaries are searched in these directories:
  - catatonit
  - netavark
  - pasta
- - slirp4netns
 
 Podman machine uses it for these binaries:
  - gvproxy
@@ -777,24 +766,6 @@ only containers and pods that were created in the same namespace, and will
 create new containers and pods in that namespace. The default namespace is "",
 which corresponds to no namespace. When no namespace is set, all containers
 and pods are visible.
-
-**network_cmd_options**=[]
-
-Default options to pass to the slirp4netns binary.
-
-Valid options values are:
-
-  - **allow_host_loopback=true|false**: Allow the slirp4netns to reach the host loopback IP (`10.0.2.2`). Default is false.
-  - **mtu=MTU**: Specify the MTU to use for this network. (Default is `65520`).
-  - **cidr=CIDR**: Specify ip range to use for this network. (Default is `10.0.2.0/24`).
-  - **enable_ipv6=true|false**: Enable IPv6. Default is true. (Required for `outbound_addr6`).
-  - **outbound_addr=INTERFACE**: Specify the outbound interface slirp should bind to (ipv4 traffic only).
-  - **outbound_addr=IPv4**: Specify the outbound ipv4 address slirp should bind to.
-  - **outbound_addr6=INTERFACE**: Specify the outbound interface slirp should bind to (ipv6 traffic only).
-  - **outbound_addr6=IPv6**: Specify the outbound ipv6 address slirp should bind to.
-  - **port_handler=rootlesskit**: Use rootlesskit for port forwarding. Default.
-  Note: Rootlesskit changes the source IP address of incoming packets to a IP address in the container network namespace, usually `10.0.2.100`. If your application requires the real source IP address, e.g. web server logs, use the slirp4netns port handler. The rootlesskit port handler is also used for rootless containers when connected to user-defined networks.
-  - **port_handler=slirp4netns**: Use the slirp4netns port forwarding, it is slower than rootlesskit but preserves the correct source IP address. This port handler cannot be used for user-defined networks.
 
 **no_pivot_root**=false
 

--- a/common/pkg/config/containers.conf
+++ b/common/pkg/config/containers.conf
@@ -405,8 +405,8 @@ default_sysctls = [
 
 
 
-# Configure which rootless network program to use by default. Valid options are
-# `slirp4netns` and `pasta` (default).
+# Configure which rootless network program to use by default.
+# The only valid option is `pasta` (default).
 #
 #default_rootless_network_cmd = "pasta"
 
@@ -509,15 +509,6 @@ default_sysctls = [
 # REST API. Note that this will ignore unqualified-search-registries and
 # short-name aliases defined in containers-registries.conf(5).
 #compat_api_enforce_docker_hub = true
-
-# The database backend of Podman.  Supported values are "" (default), "boltdb"
-# and "sqlite". An empty value means it will check whenever a boltdb already
-# exists and use it when it does, otherwise it will use sqlite as default
-# (e.g. new installs). This allows for backwards compatibility with older versions.
-# Please run `podman-system-reset` prior to changing the database
-# backend of an existing deployment, to make sure Podman can operate correctly.
-#
-#database_backend = ""
 
 # Specify the keys sequence used to detach a container.
 # Format is a single character [a-Z] or a comma separated sequence of
@@ -662,28 +653,6 @@ default_sysctls = [
 # namespace is set, all containers and pods are visible.
 #
 #namespace = ""
-
-# Default options to pass to the slirp4netns binary.
-# Valid options values are:
-#
-# - allow_host_loopback=true|false: Allow the slirp4netns to reach the host loopback IP (`10.0.2.2`).
-#   Default is false.
-# - mtu=MTU: Specify the MTU to use for this network. (Default is `65520`).
-# - cidr=CIDR: Specify ip range to use for this network. (Default is `10.0.2.0/24`).
-# - enable_ipv6=true|false: Enable IPv6. Default is true. (Required for `outbound_addr6`).
-# - outbound_addr=INTERFACE: Specify the outbound interface slirp should bind to (ipv4 traffic only).
-# - outbound_addr=IPv4: Specify the outbound ipv4 address slirp should bind to.
-# - outbound_addr6=INTERFACE: Specify the outbound interface slirp should bind to (ipv6 traffic only).
-# - outbound_addr6=IPv6: Specify the outbound ipv6 address slirp should bind to.
-# - port_handler=rootlesskit: Use rootlesskit for port forwarding. Default.
-#   Note: Rootlesskit changes the source IP address of incoming packets to a IP address in the container
-#   network namespace, usually `10.0.2.100`. If your application requires the real source IP address,
-#   e.g. web server logs, use the slirp4netns port handler. The rootlesskit port handler is also used for
-#   rootless containers when connected to user-defined networks.
-# - port_handler=slirp4netns: Use the slirp4netns port forwarding, it is slower than rootlesskit but
-#   preserves the correct source IP address. This port handler cannot be used for user-defined networks.
-#
-#network_cmd_options = []
 
 # Whether to use chroot instead of pivot_root in the runtime
 #

--- a/common/pkg/config/containers.conf-freebsd
+++ b/common/pkg/config/containers.conf-freebsd
@@ -35,15 +35,6 @@
 #
 #container_name_as_hostname = false
 
-# The database backend of Podman.  Supported values are "" (default), "boltdb"
-# and "sqlite". An empty value means it will check whenever a boltdb already
-# exists and use it when it does, otherwise it will use sqlite as default
-# (e.g. new installs). This allows for backwards compatibility with older versions.
-# Please run `podman-system-reset` prior to changing the database
-# backend of an existing deployment, to make sure Podman can operate correctly.
-#
-#database_backend = ""
-
 # List of default capabilities for containers. If it is empty or commented out,
 # the default capabilities defined in the container engine will be added.
 #
@@ -495,28 +486,6 @@ default_sysctls = [
 # namespace is set, all containers and pods are visible.
 #
 #namespace = ""
-
-# Default options to pass to the slirp4netns binary.
-# Valid options values are:
-#
-# - allow_host_loopback=true|false: Allow the slirp4netns to reach the host loopback IP (`10.0.2.2`).
-#   Default is false.
-# - mtu=MTU: Specify the MTU to use for this network. (Default is `65520`).
-# - cidr=CIDR: Specify ip range to use for this network. (Default is `10.0.2.0/24`).
-# - enable_ipv6=true|false: Enable IPv6. Default is true. (Required for `outbound_addr6`).
-# - outbound_addr=INTERFACE: Specify the outbound interface slirp should bind to (ipv4 traffic only).
-# - outbound_addr=IPv4: Specify the outbound ipv4 address slirp should bind to.
-# - outbound_addr6=INTERFACE: Specify the outbound interface slirp should bind to (ipv6 traffic only).
-# - outbound_addr6=IPv6: Specify the outbound ipv6 address slirp should bind to.
-# - port_handler=rootlesskit: Use rootlesskit for port forwarding. Default.
-#   Note: Rootlesskit changes the source IP address of incoming packets to a IP address in the container
-#   network namespace, usually `10.0.2.100`. If your application requires the real source IP address,
-#   e.g. web server logs, use the slirp4netns port handler. The rootlesskit port handler is also used for
-#   rootless containers when connected to user-defined networks.
-# - port_handler=slirp4netns: Use the slirp4netns port forwarding, it is slower than rootlesskit but
-#   preserves the correct source IP address. This port handler cannot be used for user-defined networks.
-#
-#network_cmd_options = []
 
 # Whether to use chroot instead of pivot_root in the runtime
 #


### PR DESCRIPTION
For slirp4netns, one entire option was removed, plus two options no longer mention slirp as a valid setting.

For boltdb, one entire option was removed.

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
