### PR TITLE
Require passt >= 0:20260526.g038c51e for pesto support

### DIFF
--- a/common/rpm/containers-common.spec
+++ b/common/rpm/containers-common.spec
@@ -68,7 +68,7 @@ Summary: Extra dependencies for Podman and Buildah
 Requires: %{name} = %{epoch}:%{version}-%{release}
 Requires: container-network-stack
 Requires: oci-runtime
-Requires: passt
+Requires: passt >= 0:0^20260526.g038c51e
 %if %{defined fedora}
 Recommends: composefs
 Recommends: crun


### PR DESCRIPTION
Pesto and pasta's -c control socket need a recent passt build; bump the containers-common-extra dependency so rootless_port_forwarder=pasta works.

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
