### PR TITLE
storage: apply go fix modernizations

### DIFF
--- a/storage/internal/tempdir/tempdir_test.go
+++ b/storage/internal/tempdir/tempdir_test.go
@@ -49,7 +49,7 @@ func TestTempDirAddMultipleFiles(t *testing.T) {
 
 	tempDir := t.TempDir()
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		testFile := filepath.Join(tempDir, fmt.Sprintf("testfile%d.txt", i))
 		err = os.WriteFile(testFile, fmt.Appendf(nil, "content %d", i), 0o644)
 		require.NoError(t, err)


### PR DESCRIPTION
Apply fixes suggested by `go fix` with Go 1.26:
- for i := 0; i < N; i++ → for i := range N

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
