### PR TITLE
Fix error handling in fs-verity measurement

### DIFF
--- a/storage/pkg/chunked/storage_linux.go
+++ b/storage/pkg/chunked/storage_linux.go
@@ -858,12 +858,13 @@ func (c *chunkedDiffer) recordFsVerity(path string, roFile *os.File) error {
 	// enabled on the file.
 	err := fsverity.EnableVerity(path, int(roFile.Fd()))
 	if err != nil {
-		if c.useFsVerity == graphdriver.DifferFsVerityRequired {
+		switch {
+		case c.useFsVerity == graphdriver.DifferFsVerityRequired:
 			return err
-		}
 
 		// If it is not required, ignore the error if the filesystem does not support it.
-		if errors.Is(err, unix.ENOTSUP) || errors.Is(err, unix.ENOTTY) {
+		case c.useFsVerity == graphdriver.DifferFsVerityIfAvailable &&
+			(errors.Is(err, unix.ENOTSUP) || errors.Is(err, unix.ENOTTY)):
 			return nil
 		}
 	}

--- a/storage/pkg/chunked/storage_linux.go
+++ b/storage/pkg/chunked/storage_linux.go
@@ -866,6 +866,9 @@ func (c *chunkedDiffer) recordFsVerity(path string, roFile *os.File) error {
 		case c.useFsVerity == graphdriver.DifferFsVerityIfAvailable &&
 			(errors.Is(err, unix.ENOTSUP) || errors.Is(err, unix.ENOTTY)):
 			return nil
+
+		default:
+			return err
 		}
 	}
 	verity, err := fsverity.MeasureVerity(path, int(roFile.Fd()))


### PR DESCRIPTION
Don’t ignore errors enabling it on a file, only to fail with a less informative `ENODATA` when measuring.

Warning: absolutely untested.

Cc: @giuseppe 