### PR TITLE
overlay: release XFS project quotas

### DIFF
--- a/storage/drivers/overlay/overlay.go
+++ b/storage/drivers/overlay/overlay.go
@@ -1107,8 +1107,14 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts, readOnl
 	defer func() {
 		// Clean up on failure
 		if retErr != nil {
+			if d.quotaCtl != nil && !disableQuota {
+				if err2 := d.quotaCtl.ReleaseQuota(dir); err2 != nil {
+					retErr = errors.Join(retErr, fmt.Errorf("releasing project quota for %q: %w", dir, err2))
+				}
+			}
 			if err2 := os.RemoveAll(dir); err2 != nil {
 				logrus.Errorf("While recovering from a failure creating a layer, error deleting %#v: %v", dir, err2)
+				retErr = errors.Join(retErr, fmt.Errorf("deleting %q after layer creation failure: %w", dir, err2))
 			}
 		}
 	}()
@@ -1403,14 +1409,14 @@ func (d *Driver) removeCommon(id string, cleanup func(string) error) error {
 
 	d.releaseAdditionalLayerByID(id)
 
+	if d.quotaCtl != nil {
+		if err := d.quotaCtl.ReleaseQuota(dir); err != nil {
+			return fmt.Errorf("releasing project quota for %q: %w", dir, err)
+		}
+	}
+
 	if err := cleanup(dir); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return err
-	}
-	if d.quotaCtl != nil {
-		d.quotaCtl.ClearQuota(dir)
-		if d.imageStore != "" {
-			d.quotaCtl.ClearQuota(d.imageStore)
-		}
 	}
 	return nil
 }

--- a/storage/drivers/quota/projectquota_supported.go
+++ b/storage/drivers/quota/projectquota_supported.go
@@ -230,18 +230,69 @@ func (q *Control) SetQuota(targetPath string, quota Quota) error {
 	return q.setProjectQuota(projectID, quota)
 }
 
+// ReleaseQuota clears the quota limits for targetPath's project ID and removes
+// targetPath from the quotas map.
+func (q *Control) ReleaseQuota(targetPath string) error {
+	projectID, ok, err := q.projectIDForPath(targetPath)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+
+	logrus.Debugf("ReleaseQuota path=%s, projectID=%d", targetPath, projectID)
+	if err := q.clearProjectQuota(projectID); err != nil {
+		return err
+	}
+	q.quotas.Delete(targetPath)
+	return nil
+}
+
 // ClearQuota removes the map entry in the quotas map for targetPath.
 // It does so to prevent the map leaking entries as directories are deleted.
+//
+// Deprecated: use ReleaseQuota to also clear the underlying project quota
+// limits.
 func (q *Control) ClearQuota(targetPath string) {
 	q.quotas.Delete(targetPath)
 }
 
-// setProjectQuota - set the quota for project id on xfs block device
-func (q *Control) setProjectQuota(projectID uint32, quota Quota) error {
+func (q *Control) projectIDForPath(targetPath string) (uint32, bool, error) {
+	value, ok := q.quotas.Load(targetPath)
+	if ok {
+		projectID, ok := value.(uint32)
+		if !ok {
+			return 0, false, fmt.Errorf("quota project ID for path %s has unexpected type %T", targetPath, value)
+		}
+		return projectID, true, nil
+	}
+
+	projectID, err := getProjectID(targetPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return 0, false, nil
+		}
+		return 0, false, err
+	}
+	if projectID == 0 {
+		return 0, false, nil
+	}
+	q.quotas.Store(targetPath, projectID)
+	return projectID, true, nil
+}
+
+func newDiskQuota(projectID uint32) C.fs_disk_quota_t {
 	var d C.fs_disk_quota_t
 	d.d_version = C.FS_DQUOT_VERSION
 	d.d_id = C.__u32(projectID)
 	d.d_flags = C.FS_PROJ_QUOTA
+	return d
+}
+
+// setProjectQuota - set the quota for project id on xfs block device
+func (q *Control) setProjectQuota(projectID uint32, quota Quota) error {
+	d := newDiskQuota(projectID)
 
 	if quota.Size > 0 {
 		d.d_fieldmask = d.d_fieldmask | C.FS_DQ_BHARD | C.FS_DQ_BSOFT
@@ -254,6 +305,17 @@ func (q *Control) setProjectQuota(projectID uint32, quota Quota) error {
 		d.d_ino_softlimit = d.d_ino_hardlimit
 	}
 
+	return q.applyProjectQuota(projectID, d)
+}
+
+func (q *Control) clearProjectQuota(projectID uint32) error {
+	d := newDiskQuota(projectID)
+	d.d_fieldmask = d.d_fieldmask | C.FS_DQ_BHARD | C.FS_DQ_BSOFT | C.FS_DQ_IHARD | C.FS_DQ_ISOFT
+
+	return q.applyProjectQuota(projectID, d)
+}
+
+func (q *Control) applyProjectQuota(projectID uint32, d C.fs_disk_quota_t) error {
 	cs := C.CString(q.backingFsBlockDev)
 	defer C.free(unsafe.Pointer(cs))
 
@@ -270,18 +332,18 @@ func (q *Control) setProjectQuota(projectID uint32, quota Quota) error {
 	if errors.Is(errno, unix.ENOENT) {
 		if _, err := makeBackingFsDev(q.basePath); err != nil {
 			return fmt.Errorf(
-				"failed to recreate missing backingFsBlockDev %s for projid %d: %w",
+				"failed to recreate missing backingFsBlockDev %s to apply quota limit for projid %d: %w",
 				q.backingFsBlockDev, projectID, err,
 			)
 		}
 
 		if errno := runQuotactl(); errno != 0 {
-			return fmt.Errorf("failed to set quota limit for projid %d on %s after backingFsBlockDev recreation: %w",
+			return fmt.Errorf("failed to apply quota limit for projid %d on %s after backingFsBlockDev recreation: %w",
 				projectID, q.backingFsBlockDev, errno)
 		}
 
 	} else if errno != 0 {
-		return fmt.Errorf("failed to set quota limit for projid %d on %s: %w",
+		return fmt.Errorf("failed to apply quota limit for projid %d on %s: %w",
 			projectID, q.backingFsBlockDev, errno)
 	}
 

--- a/storage/drivers/quota/projectquota_unsupported.go
+++ b/storage/drivers/quota/projectquota_unsupported.go
@@ -31,6 +31,15 @@ func (q *Control) GetQuota(targetPath string, quota *Quota) error {
 	return errors.New("filesystem does not support, or has not enabled quotas")
 }
 
+// ReleaseQuota clears the quota limits for targetPath's project ID and removes
+// targetPath from the quotas map.
+func (q *Control) ReleaseQuota(targetPath string) error {
+	return errors.New("filesystem does not support, or has not enabled quotas")
+}
+
 // ClearQuota removes the map entry in the quotas map for targetPath.
 // It does so to prevent the map leaking entries as directories are deleted.
+//
+// Deprecated: use ReleaseQuota to also clear the underlying project quota
+// limits.
 func (q *Control) ClearQuota(targetPath string) {}


### PR DESCRIPTION
While testing `--storage-opt size=1G` on a XFS filesystem I noticed that project quotas aren't being cleaned up.

I ran `sudo xfs_quota -x -c 'report -p' /var/lib/containers/storage/overlay` after starting, stopping and removing several podman container and saw several lingering quota's:

```
$ sudo xfs_quota -x -c 'report -p' /var/lib/containers/storage/overlay
Project quota on /var/lib/containers/storage/overlay (/dev/vdb1)
                               Blocks
Project ID       Used       Soft       Hard    Warn/Grace
---------- --------------------------------------------------
0             321136          0          0     00 [--------]
2387311991          0    1048576    1048576     00 [--------]
2387311992          0    1048576    1048576     00 [--------]
2387311993          0    1048576    1048576     00 [--------]
2387311994         12    1048576    1048576     00 [--------]
```

Here the quotas with Used 0 refer to Project ID's that are no longer used.

We are planning to run 1000's of containers per hour so would prefer to clean up stale entries eventhough they don't take up that much space.

The existing `ClearQuota` function only removes the in-memory path-to-project-ID entry after deleting the layer directory but doesn't clean up any kernel quota limits for the project ID.

In this MR we add a `ReleaseQuota` function that resolves the Project ID, reset blocks and inode hard/soft limits with Q_XSETPQLIM and then removes the map entry.

The `ClearQuota` is left because it is a public function but marked as deprecated using a comment.