### PR TITLE
fix: prevent static IP assignment matching subnet gateway

### DIFF
--- a/common/libnetwork/netavark/ipam.go
+++ b/common/libnetwork/netavark/ipam.go
@@ -111,6 +111,12 @@ func (n *netavarkNetwork) allocIPs(opts *types.NetworkOptions) error {
 
 						// convert to 4 byte ipv4 if needed
 						util.NormalizeIP(&staticIP)
+
+						// Ensure the requested IP is not the subnet's Gateway
+						if subnet.Gateway != nil && staticIP.Equal(subnet.Gateway) {
+							return newIPAMError(nil, "address already in use: requested static IP %s matches the subnet gateway", staticIP.String())
+						}
+
 						id := subnetBkt.Get(staticIP)
 						if id != nil {
 							return newIPAMError(nil, "requested ip address %s is already allocated to container ID %s", staticIP.String(), string(id))

--- a/common/libnetwork/netavark/ipam_test.go
+++ b/common/libnetwork/netavark/ipam_test.go
@@ -96,6 +96,38 @@ var _ = Describe("IPAM", func() {
 		Expect(err.Error()).To(Equal("IPAM error: requested ip address 10.88.0.2 is already allocated to container ID someContainerID"))
 	})
 
+	It("ipam static ip matching gateway should fail", func() {
+		s, _ := types.ParseCIDR("10.0.0.1/24")
+		network, err := networkInterface.NetworkCreate(
+			types.Network{
+				Subnets: []types.Subnet{
+					{
+						Subnet: s,
+					},
+				},
+			},
+			nil,
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		netName := network.Name
+
+		// 10.0.0.1 is the gateway for this subnet — requesting it as a static IP should fail
+		opts := &types.NetworkOptions{
+			ContainerID: "someContainerID",
+			Networks: []types.NamedPerNetworkOptions{{
+				Name: netName,
+				PerNetworkOptions: types.PerNetworkOptions{
+					StaticIPs: []net.IP{net.ParseIP("10.0.0.1")},
+				},
+			}},
+		}
+
+		err = networkInterface.allocIPs(opts)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("IPAM error: address already in use: requested static IP 10.0.0.1 matches the subnet gateway"))
+	})
+
 	It("ipam try to alloc more ips as in range", func() {
 		s, _ := types.ParseCIDR("10.0.0.1/24")
 		network, err := networkInterface.NetworkCreate(


### PR DESCRIPTION
### What does this PR do?
This adds a validation step to the Netavark IPAM logic to immediately reject static IP requests that conflict with the subnet's gateway IP. 

Previously, if a container was started with a static IP matching the gateway, Netavark would accept it. The container would start successfully but suffer from silent internal networking failures, specifically resulting in "connection refused" errors on internal sockets. 

By failing fast inside `allocIPs` with an "address already in use" error, Podman's behavior now mirrors Docker's standard behavior and prevents this ghost networking state.

### Fixes Issue
Fixes https://github.com/containers/podman/issues/28863

### How was this tested?
- Compiled `containers/common` locally and linked it to a fresh build of Podman.
- Passed local `go fmt`, `go vet`, and `go test`.