### PR TITLE
feat: pass through DestinationTimestamp when pushing manifest

### DIFF
--- a/common/libimage/manifests/manifests.go
+++ b/common/libimage/manifests/manifests.go
@@ -114,6 +114,8 @@ type PushOptions struct {
 	MaxRetries *uint
 	// RetryDelay used for the exponential back off of MaxRetries.
 	RetryDelay *time.Duration
+	// DestinationTimestamp, if set, overwrites the timestamp entries on any tar entries
+	DestinationTimestamp *time.Time
 }
 
 // Create creates a new list containing information about the specified image,
@@ -449,6 +451,7 @@ func (l *list) Push(ctx context.Context, dest types.ImageReference, options Push
 		ForceManifestMIMEType:            singleImageManifestType,
 		EnsureCompressionVariantsExist:   compressionVariants,
 		ForceCompressionFormat:           options.ForceCompressionFormat,
+		DestinationTimestamp:             options.DestinationTimestamp,
 	}
 
 	retryOptions := retry.Options{}


### PR DESCRIPTION
This allows the caller to create deterministic tarballs.