### PR TITLE
storage/pkg/chroot: fix IsRootless() init

### DIFF
--- a/storage/pkg/archive/archive_linux.go
+++ b/storage/pkg/archive/archive_linux.go
@@ -155,11 +155,17 @@ func (overlayWhiteoutConverter) ConvertReadWithHandler(hdr *tar.Header, path str
 type directHandler struct{}
 
 func (d directHandler) Setxattr(path, name string, value []byte) error {
-	return unix.Setxattr(path, name, value, 0)
+	if err := unix.Setxattr(path, name, value, 0); err != nil {
+		return &os.PathError{Op: "setxattr", Path: path, Err: err}
+	}
+	return nil
 }
 
 func (d directHandler) Mknod(path string, mode uint32, dev int) error {
-	return unix.Mknod(path, mode, dev)
+	if err := unix.Mknod(path, mode, dev); err != nil {
+		return &os.PathError{Op: "mknod", Path: path, Err: err}
+	}
+	return nil
 }
 
 func (d directHandler) Chown(path string, uid, gid int) error {

--- a/storage/pkg/chrootarchive/archive_unix.go
+++ b/storage/pkg/chrootarchive/archive_unix.go
@@ -182,7 +182,7 @@ func tar() {
 		root = src
 	}
 
-	if err := realChroot(root); err != nil {
+	if err := chroot(root); err != nil {
 		fatal(err)
 	}
 

--- a/storage/pkg/chrootarchive/chroot_linux.go
+++ b/storage/pkg/chrootarchive/chroot_linux.go
@@ -3,31 +3,14 @@ package chrootarchive
 import (
 	"fmt"
 	"net"
-	"os"
 	"os/user"
-	"path/filepath"
 
-	"github.com/moby/sys/capability"
-	"go.podman.io/storage/pkg/mount"
 	"go.podman.io/storage/pkg/unshare"
 	"golang.org/x/sys/unix"
 )
 
-// chroot on linux uses pivot_root instead of chroot
-// pivot_root takes a new root and an old root.
-// Old root must be a sub-dir of new root, it is where the current rootfs will reside after the call to pivot_root.
-// New root is where the new rootfs is set to.
-// Old root is removed after the call to pivot_root so it is no longer available under the new root.
-// This is similar to how libcontainer sets up a container's rootfs
+// chroot to the given path and do some important initialization beforehand
 func chroot(path string) (err error) {
-	caps, err := capability.NewPid2(0)
-	if err != nil {
-		return err
-	}
-	if err := caps.Load(); err != nil {
-		return err
-	}
-
 	// NOTE: this must happen before the chroot as IsRootless needs access to /proc and
 	// because IsRootless caches the result in memory this will make callers later work.
 	_ = unshare.IsRootless()
@@ -37,89 +20,8 @@ func chroot(path string) (err error) {
 	_, _ = user.Lookup("storage")
 	_, _ = net.LookupHost("localhost")
 
-	// if the process doesn't have CAP_SYS_ADMIN, but does have CAP_SYS_CHROOT, we need to use the actual chroot
-	if !caps.Get(capability.EFFECTIVE, capability.CAP_SYS_ADMIN) && caps.Get(capability.EFFECTIVE, capability.CAP_SYS_CHROOT) {
-		return realChroot(path)
-	}
-
-	if err := unix.Unshare(unix.CLONE_NEWNS); err != nil {
-		return fmt.Errorf("creating mount namespace before pivot: %w", err)
-	}
-
-	// make everything in new ns private
-	if err := mount.MakeRPrivate("/"); err != nil {
-		return err
-	}
-
-	if mounted, _ := mount.Mounted(path); !mounted {
-		if err := mount.Mount(path, path, "bind", "rbind,rw"); err != nil {
-			return realChroot(path)
-		}
-	}
-
-	// setup oldRoot for pivot_root
-	pivotDir, err := os.MkdirTemp(path, ".pivot_root")
-	if err != nil {
-		return fmt.Errorf("setting up pivot dir: %w", err)
-	}
-
-	var mounted bool
-	defer func() {
-		if mounted {
-			// make sure pivotDir is not mounted before we try to remove it
-			if errCleanup := unix.Unmount(pivotDir, unix.MNT_DETACH); errCleanup != nil {
-				if err == nil {
-					err = errCleanup
-				}
-				return
-			}
-		}
-
-		errCleanup := os.Remove(pivotDir)
-		// pivotDir doesn't exist if pivot_root failed and chroot+chdir was successful
-		// because we already cleaned it up on failed pivot_root
-		if errCleanup != nil && !os.IsNotExist(errCleanup) {
-			errCleanup = fmt.Errorf("cleaning up after pivot: %w", errCleanup)
-			if err == nil {
-				err = errCleanup
-			}
-		}
-	}()
-
-	if err := unix.PivotRoot(path, pivotDir); err != nil {
-		// If pivot fails, fall back to the normal chroot after cleaning up temp dir
-		if err := os.Remove(pivotDir); err != nil {
-			return fmt.Errorf("cleaning up after failed pivot: %w", err)
-		}
-		return realChroot(path)
-	}
-	mounted = true
-
-	// This is the new path for where the old root (prior to the pivot) has been moved to
-	// This dir contains the rootfs of the caller, which we need to remove so it is not visible during extraction
-	pivotDir = filepath.Join("/", filepath.Base(pivotDir))
-
-	if err := unix.Chdir("/"); err != nil {
-		return fmt.Errorf("changing to new root: %w", err)
-	}
-
-	// Make the pivotDir (where the old root lives) private so it can be unmounted without propagating to the host
-	if err := unix.Mount("", pivotDir, "", unix.MS_PRIVATE|unix.MS_REC, ""); err != nil {
-		return fmt.Errorf("making old root private after pivot: %w", err)
-	}
-
-	// Now unmount the old root so it's no longer visible from the new root
-	if err := unix.Unmount(pivotDir, unix.MNT_DETACH); err != nil {
-		return fmt.Errorf("while unmounting old root after pivot: %w", err)
-	}
-	mounted = false
-
-	return nil
-}
-
-func realChroot(path string) error {
 	if err := unix.Chroot(path); err != nil {
-		return fmt.Errorf("after fallback to chroot: %w", err)
+		return fmt.Errorf("chroot %q: %w", path, err)
 	}
 	if err := unix.Chdir("/"); err != nil {
 		return fmt.Errorf("changing to new root after chroot: %w", err)

--- a/storage/pkg/chrootarchive/chroot_linux.go
+++ b/storage/pkg/chrootarchive/chroot_linux.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/moby/sys/capability"
 	"go.podman.io/storage/pkg/mount"
+	"go.podman.io/storage/pkg/unshare"
 	"golang.org/x/sys/unix"
 )
 
@@ -26,6 +27,10 @@ func chroot(path string) (err error) {
 	if err := caps.Load(); err != nil {
 		return err
 	}
+
+	// NOTE: this must happen before the chroot as IsRootless needs access to /proc and
+	// because IsRootless caches the result in memory this will make callers later work.
+	_ = unshare.IsRootless()
 
 	// initialize nss libraries in Glibc so that the dynamic libraries are loaded in the host
 	// environment not in the chroot from untrusted files.

--- a/storage/pkg/chrootarchive/chroot_unix.go
+++ b/storage/pkg/chrootarchive/chroot_unix.go
@@ -2,15 +2,26 @@
 
 package chrootarchive
 
-import "golang.org/x/sys/unix"
+import (
+	"fmt"
+	"net"
+	"os/user"
 
-func realChroot(path string) error {
+	"golang.org/x/sys/unix"
+)
+
+// chroot to the given path and do some important initialization beforehand
+func chroot(path string) (err error) {
+	// initialize nss libraries in libc so that the dynamic libraries are loaded in the host
+	// environment not in the chroot from untrusted files.
+	_, _ = user.Lookup("storage")
+	_, _ = net.LookupHost("localhost")
+
 	if err := unix.Chroot(path); err != nil {
-		return err
+		return fmt.Errorf("chroot %q: %w", path, err)
 	}
-	return unix.Chdir("/")
-}
-
-func chroot(path string) error {
-	return realChroot(path)
+	if err := unix.Chdir("/"); err != nil {
+		return fmt.Errorf("changing to new root after chroot: %w", err)
+	}
+	return nil
 }


### PR DESCRIPTION
Buildah 1.44 has a new regression that was caused by me removing a bunch
of init() code out of buildah. So that the binary no longer has to do so
much extra work on each reexec.

That has however exposed a storage bug in our chrootarchive logic. The
unshare.IsRootless() calls needs access to /proc and that is not there
once we call chroot(). So the only way for IsRootless() to work is if we
execute before. Then all callers later will get the cached result which
no longer needs any /proc access.

The exact error here is because while InUserNS is part of the TarOptions
struct and passed down from the top level we end up calling
GetOverlayXattrName("opaque") to get the xattr name and that does not
have access to TarOptions and just calls IsRootless() again.
And because that failed it assumed we run as root and used the wrong
xattr which then during writing caused a EPERM and thus failed the tar
extraction.

Now we could try to fix the code path and pass the variable down the
stack but that seems a lot work work so I opted to just fix this by
calling IsRootless() before we chroot to cache the right value.

Small buildah reproducer:
```
tmp=$(mktemp -d)
unshare --map-root-user --map-auto --mount -- bin/buildah \
--root $tmp/root --runroot $tmp/runroot pull \
quay.io/devfile/python:slim@sha256:54924a2ee4a2ef17028ae076ce38e59b3f4054353a5c9f9318dfaee60377532c
```

I guess any image that uses an opaque directory should work.

Fixes: https://github.com/podman-container-tools/buildah/issues/6903