### PR TITLE
common: abort load on ENOSPC and output clear error

### DIFF
--- a/common/libimage/errno_unix.go
+++ b/common/libimage/errno_unix.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package libimage
+
+import "syscall"
+
+const errNoSpace = syscall.ENOSPC

--- a/common/libimage/errno_windows.go
+++ b/common/libimage/errno_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package libimage
+
+import "golang.org/x/sys/windows"
+
+const errNoSpace = windows.ERROR_DISK_FULL

--- a/common/libimage/load.go
+++ b/common/libimage/load.go
@@ -110,6 +110,12 @@ func (r *Runtime) Load(ctx context.Context, path string, options *LoadOptions) (
 			return loadedImages, err
 		}
 		logrus.Debugf("Error loading %s (%s): %v", path, transportName, err)
+
+		if errors.Is(err, errNoSpace) {
+			// %.0w makes err visible to error.Unwrap() without including any text
+			return nil, fmt.Errorf("no space left on device%.0w", err)
+		}
+
 		loadErrors = append(loadErrors, fmt.Errorf("%s: %v", transportName, err))
 	}
 

--- a/storage/pkg/chrootarchive/archive_unix.go
+++ b/storage/pkg/chrootarchive/archive_unix.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -28,6 +29,8 @@ type unpackDestination struct {
 func (dst *unpackDestination) Close() error {
 	return dst.root.Close()
 }
+
+const statusCodeENOSPC = 2
 
 // tarOptionsDescriptor is passed as an extra file
 const tarOptionsDescriptor = 3
@@ -82,6 +85,9 @@ func untar() {
 	}
 
 	if err := archive.Unpack(os.Stdin, dst, &options); err != nil {
+		if errors.Is(err, unix.ENOSPC) {
+			os.Exit(statusCodeENOSPC)
+		}
 		fatal(err)
 	}
 	// fully consume stdin in case it is zero padded
@@ -161,6 +167,14 @@ func invokeUnpack(decompressedArchive io.Reader, dest *unpackDestination, option
 		// pending on write pipe forever
 		if _, err := io.Copy(io.Discard, decompressedArchive); err != nil {
 			return fmt.Errorf("%w\nexhausting input failed (error: %w)", errorOut, err)
+		}
+
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			status := exitErr.ExitCode()
+			if status == statusCodeENOSPC {
+				return unix.ENOSPC
+			}
 		}
 
 		return errorOut


### PR DESCRIPTION
Fix: https://github.com/podman-container-tools/podman/issues/26197

When loading images, exit archive checks when receiving ENOSPC error, and display a clearer exit message for the user.