### PR TITLE
Add DialNetContext for context-aware SSH dialing

### DIFF
--- a/common/pkg/ssh/utils.go
+++ b/common/pkg/ssh/utils.go
@@ -1,6 +1,7 @@
 package ssh
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -167,6 +168,13 @@ func ParseScpArgs(options ConnectionScpOptions) (string, string, string, bool, e
 }
 
 func DialNet(sshClient *ssh.Client, mode string, url *url.URL) (net.Conn, error) {
+	return DialNetContext(context.Background(), sshClient, mode, url)
+}
+
+// DialNetContext is like DialNet but accepts a context for cancellation.
+// If the context expires before the connection is established, ctx.Err()
+// is returned.
+func DialNetContext(ctx context.Context, sshClient *ssh.Client, mode string, url *url.URL) (net.Conn, error) {
 	port := sshdPort
 	if url.Port() != "" {
 		p, err := strconv.Atoi(url.Port())
@@ -178,7 +186,7 @@ func DialNet(sshClient *ssh.Client, mode string, url *url.URL) (net.Conn, error)
 	if _, _, err := Validate(url.User, url.Hostname(), port, ""); err != nil {
 		return nil, err
 	}
-	return sshClient.Dial(mode, url.Path)
+	return sshClient.DialContext(ctx, mode, url.Path)
 }
 
 func DefineMode(flag string) EngineMode {

--- a/common/pkg/ssh/utils_test.go
+++ b/common/pkg/ssh/utils_test.go
@@ -1,11 +1,23 @@
 package ssh
 
 import (
+	"context"
 	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestDialNetContext_CancelledContext(t *testing.T) {
+	u, err := url.Parse("ssh://testhost/run/podman/podman.sock")
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = DialNetContext(ctx, nil, "tcp", u)
+	require.ErrorIs(t, err, context.Canceled)
+}
 
 func TestValidate(t *testing.T) {
 	// Test adding ssh port


### PR DESCRIPTION
Allow callers to pass a context for cancellation/timeout when establishing SSH connections via DialNet. The existing DialNet function now delegates to DialNetContext with context.Background().

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
