### PR TITLE
apparmor: add signal and ptrace rules for stacked profiles

### DIFF
--- a/common/pkg/apparmor/apparmor_linux_template.go
+++ b/common/pkg/apparmor/apparmor_linux_template.go
@@ -21,6 +21,8 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
   # Allow signals from privileged profiles and from within the same profile
   signal (receive) peer=unconfined,
   signal (send,receive) peer={{.Name}},
+  # With AppArmor 5.0+, child processes get a stacked profile.
+  signal (send,receive) peer={{.Name}}//&*,
   # Allow certain signals from OCI runtimes (podman, runc and crun)
   signal (receive) peer={/usr/bin/,/usr/sbin/,}runc,
   signal (receive) peer={/usr/bin/,/usr/sbin/,}crun*,
@@ -48,6 +50,8 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
 {{if ge .Version 208095}}
   # suppress ptrace denials when using 'ps' inside a container
   ptrace (trace,read) peer={{.Name}},
+  # With AppArmor 5.0+, child processes get a stacked profile.
+  ptrace (trace,read) peer={{.Name}}//&*,
 {{end}}
 }
 `

--- a/common/pkg/apparmor/apparmor_linux_test.go
+++ b/common/pkg/apparmor/apparmor_linux_test.go
@@ -3,8 +3,11 @@
 package apparmor
 
 import (
+	"bytes"
 	"os"
+	"strings"
 	"testing"
+	"text/template"
 )
 
 type versionExpected struct {
@@ -128,6 +131,32 @@ func TestInstallDefault(t *testing.T) {
 		t.Fatalf("Couldn't remove AppArmor profile '%s': %v", profile, err)
 	}
 	checkLoaded(false)
+}
+
+func TestStackedProfileRules(t *testing.T) {
+	compiled, err := template.New("apparmor_profile").Parse(defaultProfileTemplate)
+	if err != nil {
+		t.Fatalf("Failed to parse template: %v", err)
+	}
+
+	p := profileData{
+		Name:    "test-profile",
+		Version: 300000,
+	}
+
+	var buf bytes.Buffer
+	if err := compiled.Execute(&buf, p); err != nil {
+		t.Fatalf("Failed to execute template: %v", err)
+	}
+
+	output := buf.String()
+
+	if !strings.Contains(output, "signal (send,receive) peer=test-profile//&*,") {
+		t.Error("Missing stacked profile signal rule")
+	}
+	if !strings.Contains(output, "ptrace (trace,read) peer=test-profile//&*,") {
+		t.Error("Missing stacked profile ptrace rule")
+	}
 }
 
 func TestDefaultContent(t *testing.T) {


### PR DESCRIPTION
With AppArmor 5.0+, child processes get stacked profiles like profile//&crun. Add //&* wildcard rules for signal and ptrace to match stacked profile peers.

This is a reproducer.
https://gist.github.com/bitoku/6fe0dd11aed0e4dad31eb0171c49279f

This will fix https://github.com/cri-o/cri-o/issues/10036 .

Assisted-by: Claude Code <https://claude.com/claude-code>

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
