### PR TITLE
Enable and configure the dupl linter.

### DIFF
--- a/storage/.golangci.yml
+++ b/storage/.golangci.yml
@@ -6,13 +6,20 @@ formatters:
 
 linters:
   enable:
+    - dupl
     - nolintlint
     - unconvert
   exclusions:
     presets:
       - comments
       - std-error-handling
+    rules:
+      - path: '(.+)_test\.go'
+        linters:
+          - dupl
   settings:
+    dupl:
+      threshold: 200
     staticcheck:
       checks:
         - all


### PR DESCRIPTION
Adds the dupl linter and adds configuration in accordance with issue #128 

Fixes: https://github.com/podman-container-tools/container-libs/issues/128