### PR TITLE
fix rootless netns cleanup when PID file is empty

### DIFF
--- a/common/libnetwork/internal/rootlessnetns/netns_linux.go
+++ b/common/libnetwork/internal/rootlessnetns/netns_linux.go
@@ -50,6 +50,8 @@ const (
 	resolvConfName = "resolv.conf"
 )
 
+var errEmptyPIDFile = errors.New("PID file is empty")
+
 type Netns struct {
 	// dir used for the rootless netns
 	dir string
@@ -330,12 +332,18 @@ func (n *Netns) cleanupRootlessNetns() error {
 		logrus.Debugf("Rootless netns conn pid file does not exist %s", pidFile)
 		return nil
 	}
-	if err == nil {
-		// kill the slirp/pasta process so we do not leak it
-		err = unix.Kill(pid, unix.SIGTERM)
-		if err == unix.ESRCH {
-			err = nil
-		}
+	// if the pid file is empty, pasta failed to start so there is nothing to clean up
+	if errors.Is(err, errEmptyPIDFile) {
+		logrus.Debugf("Rootless netns conn pid file is empty, nothing to clean up")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("reading pid file: %w", err)
+	}
+	// kill the slirp/pasta process so we do not leak it
+	err = unix.Kill(pid, unix.SIGTERM)
+	if err == unix.ESRCH {
+		err = nil
 	}
 	return err
 }
@@ -616,9 +624,12 @@ func (n *Netns) Run(lock *lockfile.LockFile, toRun func() error) error {
 	}
 
 	if count == 0 {
-		err = n.cleanup()
-		if err != nil {
-			return wrapError("cleanup", err)
+		cleanupErr := n.cleanup()
+		if cleanupErr != nil {
+			if inErr != nil {
+				return wrapError("cleanup", errors.Join(inErr, cleanupErr))
+			}
+			return wrapError("cleanup", cleanupErr)
 		}
 	}
 
@@ -666,7 +677,11 @@ func readPidFile(path string) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	return strconv.Atoi(strings.TrimSpace(string(b)))
+	s := strings.TrimSpace(string(b))
+	if s == "" {
+		return 0, errEmptyPIDFile
+	}
+	return strconv.Atoi(s)
 }
 
 func (n *Netns) serializeInfo() error {

--- a/common/libnetwork/internal/rootlessnetns/netns_linux_test.go
+++ b/common/libnetwork/internal/rootlessnetns/netns_linux_test.go
@@ -75,3 +75,66 @@ func Test_refCount(t *testing.T) {
 		})
 	}
 }
+
+func TestReadPidFile(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		create  bool
+		wantErr error
+		wantPid int
+	}{
+		{
+			name:    "valid pid",
+			content: "1234\n",
+			create:  true,
+			wantPid: 1234,
+		},
+		{
+			name:    "valid pid no newline",
+			content: "5678",
+			create:  true,
+			wantPid: 5678,
+		},
+		{
+			name:    "empty pid file",
+			content: "",
+			create:  true,
+			wantErr: errEmptyPIDFile,
+		},
+		{
+			name:    "only whitespace",
+			content: "  \n ",
+			create:  true,
+			wantErr: errEmptyPIDFile,
+		},
+		{
+			name:    "non-existent file",
+			create:  false,
+			wantErr: os.ErrNotExist,
+		},
+		{
+			name:    "invalid content",
+			content: "abc",
+			create:  true,
+			wantErr: strconv.ErrSyntax,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "pidfile")
+			if tt.create {
+				err := os.WriteFile(path, []byte(tt.content), 0o600)
+				assert.NoError(t, err)
+			}
+			pid, err := readPidFile(path)
+			if tt.wantErr != nil {
+				assert.Error(t, err)
+				assert.ErrorIs(t, err, tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantPid, pid)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/podman-container-tools/podman/issues/28441

Based on the previous PR #759 

When pasta fails to start, it can leave an empty PID file behind. Rootless netns cleanup then tried to parse that file and failed, even though there was no process to clean up.

This change treats an empty or whitespace-only PID file as a no-op during cleanup, while still returning real parse errors. It also uses errors.Join when both the inner operation and cleanup fail, so both errors keep their type information.

Main fixes
- Add errEmptyPIDFile and return it from readPidFile for empty/whitespace content
- Handle errEmptyPIDFile in cleanupRootlessNetns without failing cleanup
- Join inner and cleanup errors with errors.Join instead of fmt.Errorf
- Add TestReadPidFile unit tests