### PR TITLE
network: distinguish nested root from rootless user

### DIFF
--- a/common/libnetwork/netavark/network.go
+++ b/common/libnetwork/netavark/network.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/moby/sys/capability"
 	"github.com/sirupsen/logrus"
 	"go.podman.io/common/libnetwork/internal/rootlessnetns"
 	"go.podman.io/common/libnetwork/internal/util"
@@ -109,6 +110,11 @@ func NewNetworkInterface(conf *InitConfig) (types.ContainerNetwork, error) {
 	// causes issues as this slower more complicated rootless-netns logic should not be used as root.
 	val, ok := os.LookupEnv(unshare.UsernsEnvName)
 	useRootlessNetns := ok && val == "done"
+	// Preserve rootless netns mode unless UID 0 has the networking capability
+	// needed to manage rootful netavark bridge state.
+	if useRootlessNetns && unshare.GetRootlessUID() == 0 && hasCapNetAdmin() {
+		useRootlessNetns = false
+	}
 	if useRootlessNetns {
 		netns, err = rootlessnetns.New(conf.NetworkRunDir, conf.Config)
 		if err != nil {
@@ -170,6 +176,17 @@ func NewNetworkInterface(conf *InitConfig) (types.ContainerNetwork, error) {
 	}
 
 	return n, nil
+}
+
+func hasCapNetAdmin() bool {
+	currentCaps, err := capability.NewPid2(0)
+	if err != nil {
+		return false
+	}
+	if err = currentCaps.Load(); err != nil {
+		return false
+	}
+	return currentCaps.Get(capability.EFFECTIVE, capability.CAP_NET_ADMIN)
 }
 
 var builtinDrivers = []string{types.BridgeNetworkDriver, types.MacVLANNetworkDriver, types.IPVLANNetworkDriver}

--- a/common/libnetwork/network/interface.go
+++ b/common/libnetwork/network/interface.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/moby/sys/capability"
 	"go.podman.io/common/libnetwork/netavark"
 	"go.podman.io/common/libnetwork/types"
 	"go.podman.io/common/pkg/config"
@@ -55,10 +56,10 @@ func netavarkBackendFromConf(store storage.Store, conf *config.Config, syslog bo
 
 	// We cannot use the runroot for rootful since the network namespace is shared for all
 	// libpod instances they also have to share the same ipam db.
-	// For rootless we have our own network namespace per libpod instances,
+	// For rootless users we have our own network namespace per libpod instances,
 	// so this is not a problem there.
 	runDir := netavarkRunDir
-	if unshare.IsRootless() {
+	if unshare.IsRootless() && (unshare.GetRootlessUID() != 0 || !hasCapNetAdmin()) {
 		runDir = filepath.Join(store.RunRoot(), "networks")
 	}
 
@@ -78,8 +79,21 @@ func netavarkBackendFromConf(store storage.Store, conf *config.Config, syslog bo
 // use the graphroot for rootful since the network namespace is shared for all
 // libpod instances.
 func getDefaultNetavarkConfigDir(store storage.Store) string {
-	if !unshare.IsRootless() {
-		return netavarkConfigDir
+	// Preserve the existing rootless path layout unless UID 0 has the
+	// networking capability needed to manage rootful netavark bridge state.
+	if unshare.IsRootless() && (unshare.GetRootlessUID() != 0 || !hasCapNetAdmin()) {
+		return filepath.Join(store.GraphRoot(), "networks")
 	}
-	return filepath.Join(store.GraphRoot(), "networks")
+	return netavarkConfigDir
+}
+
+func hasCapNetAdmin() bool {
+	currentCaps, err := capability.NewPid2(0)
+	if err != nil {
+		return false
+	}
+	if err = currentCaps.Load(); err != nil {
+		return false
+	}
+	return currentCaps.Get(capability.EFFECTIVE, capability.CAP_NET_ADMIN)
 }


### PR DESCRIPTION
Dependency support for the main Podman fix: https://github.com/podman-container-tools/podman/pull/28995

Bug report: https://github.com/podman-container-tools/podman/issues/18783

## Summary

Network config/runtime path selection should distinguish a real rootless user from UID 0 running inside a nested user namespace. UID 0 in a delegated container environment should continue to use rootful network paths.

This also adds `unshare.HasCapNetAdmin()`, matching the existing cached `HasCapSysAdmin()` helper, so callers can check effective `CAP_NET_ADMIN` without duplicating capability-loading code.

## Rationale

Podman's rootful bridge-networking preflight needs to check `CAP_NET_ADMIN` separately from `CAP_SYS_ADMIN`. Once this is merged and vendored, the Podman PR can replace its temporary local helper with `unshare.HasCapNetAdmin()`.

For network path selection, the relevant question is whether the original caller was a non-root user. The network path decision now uses `unshare.GetRootlessUID() > 0` directly so UID 0 keeps rootful paths, including UID 0 inside a nested user namespace.

## Tests

- `GOOS=linux go test -c -o /private/tmp/container-libs-common-network.test ./libnetwork/network` from `common/`
- `GOOS=linux go test -c -o /private/tmp/container-libs-storage-unshare.test ./pkg/unshare` from `storage/`
