### PR TITLE
archive: fix loss of setuid/setgid bits during bsd untar

### DIFF
--- a/storage/pkg/archive/archive_bsd.go
+++ b/storage/pkg/archive/archive_bsd.go
@@ -9,10 +9,26 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// syscallMode maps a Go os.FileMode to chmod(2) bits, preserving the
+// setuid/setgid/sticky bits that a raw uint32(FileMode) cast silently drops.
+func syscallMode(i os.FileMode) (o uint32) {
+	o = uint32(i.Perm())
+	if i&os.ModeSetuid != 0 {
+		o |= unix.S_ISUID
+	}
+	if i&os.ModeSetgid != 0 {
+		o |= unix.S_ISGID
+	}
+	if i&os.ModeSticky != 0 {
+		o |= unix.S_ISVTX
+	}
+	return o
+}
+
 func handleLChmod(_ *tar.Header, path string, hdrInfo os.FileInfo, forceMask *os.FileMode) error {
 	permissionsMask := hdrInfo.Mode()
 	if forceMask != nil {
 		permissionsMask = *forceMask
 	}
-	return unix.Fchmodat(unix.AT_FDCWD, path, uint32(permissionsMask), unix.AT_SYMLINK_NOFOLLOW)
+	return unix.Fchmodat(unix.AT_FDCWD, path, syscallMode(permissionsMask), unix.AT_SYMLINK_NOFOLLOW)
 }

--- a/storage/pkg/archive/setuid_bsd_test.go
+++ b/storage/pkg/archive/setuid_bsd_test.go
@@ -1,0 +1,21 @@
+//go:build freebsd || netbsd || darwin
+
+package archive
+
+import (
+	"os"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// TestSyscallMode verifies that Go's os.FileMode high-order bits
+// correctly translate to POSIX chmod(2) bits.
+func TestSyscallMode(t *testing.T) {
+	mode := syscallMode(os.ModeSetuid | os.ModeSetgid | os.ModeSticky | 0o755)
+	expected := uint32(unix.S_ISUID | unix.S_ISGID | unix.S_ISVTX | 0o755)
+
+	if mode != expected {
+		t.Fatalf("expected %#o, got %#o", expected, mode)
+	}
+}


### PR DESCRIPTION
BSD `handleLChmod` casts `os.FileMode` straight to `Fchmodat`, but setuid, setgid & sticky live in `os.FileMode`'s high bits, not the chmod positions, so the cast silently drops them and binaries like `ping` & `su` lose setuid on unpack.  Fix: map the bits via a `syscallMode()` helper.

Thanks to @dfr for helping with the diagnosis.