### PR TITLE
lint: add modernize

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,26 +95,6 @@ jobs:
         working-directory: ./storage
         run: make cross
 
-  storage-gofix:
-    needs: path-filter
-    if: github.event_name == 'push' || needs.path-filter.outputs.storage == 'true'
-    runs-on: ubuntu-24.04
-    timeout-minutes: 15
-    name: "Storage: gofix"
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
-        with:
-          go-version: stable
-          cache-dependency-path: "./storage/go.sum"
-      - name: Install dependencies
-        run: |
-          sudo apt-get -qq update
-          sudo apt-get -qq install -y libbtrfs-dev libgpgme-dev libdevmapper-dev
-      - name: Run go fix
-        working-directory: ./storage
-        run: go fix -diff ./...
-
   image-cross:
     needs: path-filter
     if: github.event_name == 'push' || needs.path-filter.outputs.image == 'true'
@@ -226,7 +206,6 @@ jobs:
     needs:
       - storage-test
       - storage-cross
-      - storage-gofix
       - image-cross
       - image-test
       - image-test-skopeo

--- a/common/.golangci.yml
+++ b/common/.golangci.yml
@@ -43,6 +43,7 @@ linters:
     - makezero
     - mirror
     - misspell
+    - modernize
     - nilnesserr
     - nosprintfhostport
     - perfsprint

--- a/common/pkg/seccomp/seccomp_linux.go
+++ b/common/pkg/seccomp/seccomp_linux.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"strconv"
 
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -54,17 +55,6 @@ var nativeToSeccomp = map[string]Arch{
 	"mipsel64":    ArchMIPSEL64,
 	"mipsel64n32": ArchMIPSEL64N32,
 	"s390x":       ArchS390X,
-}
-
-// inSlice tests whether a string is contained in a slice of strings or not.
-// Comparison is case sensitive.
-func inSlice(slice []string, s string) bool {
-	for _, ss := range slice {
-		if s == ss {
-			return true
-		}
-	}
-	return false
 }
 
 func getArchitectures(config *Seccomp, newConfig *specs.LinuxSeccomp) error {
@@ -153,25 +143,25 @@ Loop:
 	// Loop through all syscall blocks and convert them to libcontainer format after filtering them
 	for _, call := range config.Syscalls {
 		if len(call.Excludes.Arches) > 0 {
-			if inSlice(call.Excludes.Arches, arch) {
+			if slices.Contains(call.Excludes.Arches, arch) {
 				continue Loop
 			}
 		}
 		if len(call.Excludes.Caps) > 0 {
 			for _, c := range call.Excludes.Caps {
-				if rs != nil && rs.Process != nil && rs.Process.Capabilities != nil && inSlice(rs.Process.Capabilities.Bounding, c) {
+				if rs != nil && rs.Process != nil && rs.Process.Capabilities != nil && slices.Contains(rs.Process.Capabilities.Bounding, c) {
 					continue Loop
 				}
 			}
 		}
 		if len(call.Includes.Arches) > 0 {
-			if !inSlice(call.Includes.Arches, arch) {
+			if !slices.Contains(call.Includes.Arches, arch) {
 				continue Loop
 			}
 		}
 		if len(call.Includes.Caps) > 0 {
 			for _, c := range call.Includes.Caps {
-				if rs != nil && rs.Process != nil && rs.Process.Capabilities != nil && !inSlice(rs.Process.Capabilities.Bounding, c) {
+				if rs != nil && rs.Process != nil && rs.Process.Capabilities != nil && !slices.Contains(rs.Process.Capabilities.Bounding, c) {
 					continue Loop
 				}
 			}

--- a/image/.golangci.yml
+++ b/image/.golangci.yml
@@ -7,6 +7,7 @@ formatters:
 linters:
   enable:
     - errorlint
+    - modernize
   settings:
     errorlint:
       # See https://golangci-lint.run/usage/linters/#errorlint.

--- a/image/internal/image/docker_schema1.go
+++ b/image/internal/image/docker_schema1.go
@@ -3,6 +3,7 @@ package image
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -189,7 +190,7 @@ func (m *manifestSchema1) convertToManifestSchema2(_ context.Context, options *t
 	// Build a list of the diffIDs for the non-empty layers.
 	diffIDs := []digest.Digest{}
 	var layers []manifest.Schema2Descriptor
-	for v1Index := len(m.m.ExtractedV1Compatibility) - 1; v1Index >= 0; v1Index-- {
+	for v1Index := range slices.Backward(m.m.ExtractedV1Compatibility) {
 		v2Index := (len(m.m.ExtractedV1Compatibility) - 1) - v1Index
 
 		if !m.m.ExtractedV1Compatibility[v1Index].ThrowAway {

--- a/storage/.golangci.yml
+++ b/storage/.golangci.yml
@@ -6,6 +6,7 @@ formatters:
 
 linters:
   enable:
+    - modernize
     - nolintlint
     - unconvert
   exclusions:

--- a/storage/drivers/btrfs/btrfs.go
+++ b/storage/drivers/btrfs/btrfs.go
@@ -530,7 +530,7 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts, readOnl
 		if err := os.MkdirAll(quotas, 0o700); err != nil {
 			return err
 		}
-		if err := os.WriteFile(path.Join(quotas, id), []byte(fmt.Sprint(quota.size)), 0o644); err != nil {
+		if err := os.WriteFile(path.Join(quotas, id), []byte(strconv.FormatUint(quota.size, 10)), 0o644); err != nil {
 			return err
 		}
 	}

--- a/storage/pkg/chunked/storage_linux.go
+++ b/storage/pkg/chunked/storage_linux.go
@@ -2055,7 +2055,7 @@ func (c *chunkedDiffer) mergeTocEntries(fileType compressedFileType, entries []m
 	}
 	// stargz/estargz doesn't store EndOffset so let's calculate it here
 	lastOffset := c.tocOffset
-	for i := len(mergedEntries) - 1; i >= 0; i-- {
+	for i := range slices.Backward(mergedEntries) {
 		if mergedEntries[i].EndOffset == 0 {
 			mergedEntries[i].EndOffset = lastOffset
 		}
@@ -2064,7 +2064,7 @@ func (c *chunkedDiffer) mergeTocEntries(fileType compressedFileType, entries []m
 		}
 
 		lastChunkOffset := mergedEntries[i].EndOffset
-		for j := len(mergedEntries[i].chunks) - 1; j >= 0; j-- {
+		for j := range slices.Backward(mergedEntries[i].chunks) {
 			mergedEntries[i].chunks[j].EndOffset = lastChunkOffset
 			mergedEntries[i].chunks[j].Size = mergedEntries[i].chunks[j].EndOffset - mergedEntries[i].chunks[j].Offset
 			lastChunkOffset = mergedEntries[i].chunks[j].Offset


### PR DESCRIPTION
It performs checks that go fix would apply so it prevents us from adding
back old code patterns.

https://golangci-lint.run/docs/linters/configuration/#modernize

Fix one found issue in common and with that we can drop the extra ci job for go fix.
