### PR TITLE
add CI label on PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -9,3 +9,7 @@ image:
 storage:
   - changed-files:
     - any-glob-to-any-file: storage/**
+CI:
+  - changed-files:
+    - any-glob-to-any-file: .github/**
+    - any-glob-to-any-file: hack/ci/**


### PR DESCRIPTION
For maintainers adding the label automatically can be helpful to make them aware that the PR makes changes to the CI which often need to be looked at closely. But also it is useful for some maintainers/reviewers who only work on the CI systems not on the main code base so they have something they can filter on easily.

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
