### PR TITLE
Fix a lint failure with the containers_image_sequoia tag

### DIFF
--- a/image/signature/internal/sequoia/sequoia.go
+++ b/image/signature/internal/sequoia/sequoia.go
@@ -149,7 +149,7 @@ func (m *SigningMechanism) ImportKeys(blob []byte) ([]string, error) {
 
 	keyIdentities := []string{}
 	count := C.go_sequoia_import_result_get_count(result)
-	for i := C.size_t(0); i < count; i++ {
+	for i := range C.size_t(count) {
 		var cerr *C.SequoiaError
 		cKeyIdentity := C.go_sequoia_import_result_get_content(result, i, &cerr)
 		if cerr != nil {


### PR DESCRIPTION
To reproduce: `golangci-lint run --build-tags containers_image_sequoia ./image/signature/internal/sequoia`