### PR TITLE
Fix pesto socket path and document rootless_port_forwarder constraints

### DIFF
--- a/common/docs/containers.conf.5.md
+++ b/common/docs/containers.conf.5.md
@@ -496,6 +496,10 @@ Valid options are `rootlessport` (default) and `pasta`.
 which preserves the original source IP address inside the container.
 The `pasta` option is **experimental** and subject to change.
 
+**Important:** This option must only be changed when no containers are running.
+Switching while containers are active leads to port-forwarding rules being leaked
+or cleanup failures because the running netns was created with the previous setting.
+
 **network_config_dir**="/etc/containers/networks"
 
 Path to the directory where network configuration files are located.

--- a/common/libnetwork/internal/rootlessnetns/netns_freebsd.go
+++ b/common/libnetwork/internal/rootlessnetns/netns_freebsd.go
@@ -31,3 +31,7 @@ func (n *Netns) Run(lock *lockfile.LockFile, toRun func() error) error {
 func (n *Netns) Info() *types.RootlessNetnsInfo {
 	return &types.RootlessNetnsInfo{}
 }
+
+func (n *Netns) PestoSocketPath() string {
+	return ""
+}

--- a/common/libnetwork/internal/rootlessnetns/netns_linux.go
+++ b/common/libnetwork/internal/rootlessnetns/netns_linux.go
@@ -205,10 +205,8 @@ func (n *Netns) setupPasta(nsPath string) error {
 
 	extraOpts := []string{"--pid", pidPath}
 
-	var socketPath string
 	if n.config.Network.RootlessPortForwarder == config.RootlessPortForwarderPasta {
-		socketPath = n.getPath(pestoSocketFile)
-		extraOpts = append(extraOpts, "-c", socketPath)
+		extraOpts = append(extraOpts, "-c", n.getPath(pestoSocketFile))
 	}
 
 	pastaOpts := pasta.SetupOptions{
@@ -248,10 +246,9 @@ func (n *Netns) setupPasta(nsPath string) error {
 	}
 
 	n.info = &types.RootlessNetnsInfo{
-		IPAddresses:     res.IPAddresses,
-		DnsForwardIps:   res.DNSForwardIPs,
-		MapGuestIps:     res.MapGuestAddrIPs,
-		PestoSocketPath: socketPath,
+		IPAddresses:   res.IPAddresses,
+		DnsForwardIps: res.DNSForwardIPs,
+		MapGuestIps:   res.MapGuestAddrIPs,
 	}
 	if err := n.serializeInfo(); err != nil {
 		return wrapError("serialize info", err)
@@ -630,6 +627,11 @@ func (n *Netns) Run(lock *lockfile.LockFile, toRun func() error) error {
 // host.containers.internal entries.
 func (n *Netns) Info() *types.RootlessNetnsInfo {
 	return n.info
+}
+
+// PestoSocketPath returns the path to the pesto control socket.
+func (n *Netns) PestoSocketPath() string {
+	return n.getPath(pestoSocketFile)
 }
 
 func refCount(dir string, inc int) (int, error) {

--- a/common/libnetwork/netavark/run.go
+++ b/common/libnetwork/netavark/run.go
@@ -215,3 +215,11 @@ func (n *netavarkNetwork) RootlessNetnsInfo() (*types.RootlessNetnsInfo, error) 
 	}
 	return n.rootlessNetns.Info(), nil
 }
+
+func (n *netavarkNetwork) PestoSocketPath() string {
+	if n.rootlessNetns == nil {
+		logrus.Debug("PestoSocketPath: rootlessNetns is nil")
+		return ""
+	}
+	return n.rootlessNetns.PestoSocketPath()
+}

--- a/common/libnetwork/types/network.go
+++ b/common/libnetwork/types/network.go
@@ -36,6 +36,10 @@ type ContainerNetwork interface {
 	// Only used as rootless and should return an error as root.
 	RootlessNetnsInfo() (*RootlessNetnsInfo, error)
 
+	// PestoSocketPath returns the path to the pesto control socket
+	// for dynamic port forwarding. Empty when not available.
+	PestoSocketPath() string
+
 	// Drivers will return the list of supported network drivers
 	// for this interface.
 	Drivers() []string
@@ -377,9 +381,6 @@ type RootlessNetnsInfo struct {
 	DnsForwardIps []string
 	// MapGuestIps should be used for the host.containers.internal entry when set
 	MapGuestIps []string
-	// PestoSocketPath is the path to the pasta control socket for dynamic
-	// port forwarding via pesto. Empty when pasta was started without -c.
-	PestoSocketPath string
 }
 
 // FilterFunc can be passed to NetworkList to filter the networks.

--- a/common/pkg/config/config.go
+++ b/common/pkg/config/config.go
@@ -635,6 +635,10 @@ type NetworkConfig struct {
 	// bridge networks. Valid values are RootlessPortForwarderRootlessport
 	// (default, userspace TCP/UDP proxy) and RootlessPortForwarderPasta
 	// (experimental, pasta's kernel splice preserving the original source IP).
+	//
+	// Must only be changed when no containers are running. Switching while
+	// containers are active leads to leaked port-forwarding rules or cleanup
+	// failures.
 	RootlessPortForwarder string `toml:"rootless_port_forwarder,omitempty"`
 }
 

--- a/common/pkg/config/containers.conf
+++ b/common/pkg/config/containers.conf
@@ -416,6 +416,11 @@ default_sysctls = [
 # via kernel splice, which preserves the original source IP address inside the
 # container. This option is experimental and subject to change.
 #
+# Important: This option must only be changed when no containers are running.
+# Switching while containers are active leads to port-forwarding rules being
+# leaked or cleanup failures because the running netns was created with the
+# previous setting.
+#
 #rootless_port_forwarder = "rootlessport"
 
 # Path to the directory where network configuration files are located.


### PR DESCRIPTION
Two fixes for pesto control socket availability:
- Move `PestoSocketPath` from `RootlessNetnsInfo` to its own method on `ContainerNetwork`. The socket path is deterministic, so compute it directly from the netns directory instead of relying on the serialized info cache (which is nil in new podman processes until the first `Setup()/Teardown()` call). Fixes `pesto --delete` being silently skipped during teardown, causing "Forwarding configuration conflict" on network reload and container restart.
  - [Related failure](https://productionresultssa7.blob.core.windows.net/actions-results/e2db7225-c668-4889-9422-298f42ac0425/workflow-job-run-52e12a8f-af6a-54f6-8166-00f75c91c0b1/logs/job/job-logs.txt?rsct=text%2Fplain&se=2026-06-29T13%3A38%3A22Z&sig=FY9HgcydHlF1ZIg3tQgshzggn4USke%2BRGFlAHP6XjGw%3D&ske=2026-06-29T16%3A19%3A47Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2026-06-29T12%3A19%3A47Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-11-05&sp=r&spr=https&sr=b&st=2026-06-29T13%3A28%3A17Z&sv=2025-11-05)
   - [Related failure log](https://github.com/podman-container-tools/podman/actions/runs/28373122719/job/84059324893?pr=29049)
- Document that `rootless_port_forwarder` must only be changed when no containers are running. Switching while containers are active leads to leaked port-forwarding rules or cleanup failures.
