### PR TITLE
rpm: update broken rootless storage.conf mount option

### DIFF
--- a/common/rpm/00-storage-additional-store.conf
+++ b/common/rpm/00-storage-additional-store.conf
@@ -1,2 +1,0 @@
-[storage.options]
-additionalimagestores = ["/usr/lib/containers/storage"]

--- a/common/rpm/00-storage-rootful.conf
+++ b/common/rpm/00-storage-rootful.conf
@@ -1,0 +1,6 @@
+[storage.options]
+additionalimagestores = ["/usr/lib/containers/storage"]
+
+[storage.options.overlay]
+# mountopt specifies comma separated list of extra mount options
+mountopt = "nodev,metacopy=on"

--- a/common/rpm/00-storage-rootless.conf
+++ b/common/rpm/00-storage-rootless.conf
@@ -1,0 +1,4 @@
+[storage.options.overlay]
+# mountopt specifies comma separated list of extra mount options
+# Note unlike the rootful config we cannot use metacopy=on as rootless user
+mountopt = "nodev"

--- a/common/rpm/00-storage.conf
+++ b/common/rpm/00-storage.conf
@@ -1,6 +1,2 @@
 [storage]
 driver = "overlay"
-
-[storage.options.overlay]
-# mountopt specifies comma separated list of extra mount options
-mountopt = "nodev,metacopy=on"

--- a/common/rpm/containers-common.spec
+++ b/common/rpm/containers-common.spec
@@ -114,7 +114,8 @@ install -Dp -m0644 storage/storage.conf %{buildroot}%{_datadir}/containers/stora
 # install custom vendor overwrites
 install -Dp -m0644 common/rpm/00-containers.conf %{buildroot}%{_datadir}/containers/containers.conf.d/00-vendor.conf
 install -Dp -m0644 common/rpm/00-storage.conf %{buildroot}%{_datadir}/containers/storage.conf.d/00-vendor.conf
-install -Dp -m0644 common/rpm/00-storage-additional-store.conf %{buildroot}%{_datadir}/containers/storage.rootful.conf.d/00-vendor-additional-store.conf
+install -Dp -m0644 common/rpm/00-storage-rootful.conf %{buildroot}%{_datadir}/containers/storage.rootful.conf.d/00-vendor-rootful.conf
+install -Dp -m0644 common/rpm/00-storage-rootless.conf %{buildroot}%{_datadir}/containers/storage.rootless.conf.d/00-vendor-rootless.conf
 
 %if %{defined fedora}
 install -Dp -m0644 common/rpm/00-fedora-registries.conf %{buildroot}%{_datadir}/containers/registries.conf.d/00-vendor.conf
@@ -216,7 +217,9 @@ ln -s ../../../..%{_sysconfdir}/yum.repos.d/redhat.repo %{buildroot}%{_datadir}/
 %dir %{_datadir}/containers/storage.conf.d
 %{_datadir}/containers/storage.conf.d/00-vendor.conf
 %dir %{_datadir}/containers/storage.rootful.conf.d
-%{_datadir}/containers/storage.rootful.conf.d/00-vendor-additional-store.conf
+%{_datadir}/containers/storage.rootful.conf.d/00-vendor-rootful.conf
+%dir %{_datadir}/containers/storage.rootless.conf.d
+%{_datadir}/containers/storage.rootless.conf.d/00-vendor-rootless.conf
 %dir %{_datadir}/rhel
 %dir %{_datadir}/rhel/secrets
 %{_datadir}/rhel/secrets/*


### PR DESCRIPTION
A rootless user cannot use metacopy=on, doing so will work but the kernel then throws a error in demsg and we use the wrong options.

This was reported on arch but the same problem is in the rpm spec: https://gitlab.archlinux.org/archlinux/packaging/packages/containers-common/-/work_items/12

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
