### PR TITLE
build man pages consistently across libs

### DIFF
--- a/common/docs/Makefile
+++ b/common/docs/Makefile
@@ -1,19 +1,7 @@
 PREFIX := /usr/local
-DATADIR := ${PREFIX}/share
-MANDIR := $(DATADIR)/man
-GOMD2MAN ?= $(shell command -v go-md2man || echo '$(GOBIN)/go-md2man')
+MAN_INSTALL_DIR := $(PREFIX)/share/man/man5
 
-docs: $(patsubst %.md,%,$(wildcard *.md))
+MANPAGES := $(patsubst %.md,%,$(wildcard *.md))
+MAN_LINKS := $(shell ls -A links/ 2>/dev/null | sed 's|^|links/|')
 
-%.5:  %.5.md
-	$(GOMD2MAN) -in $^ -out $@
-
-.PHONY: install
-install:
-	install -d ${DESTDIR}/${MANDIR}/man5
-	install -m 0644 *5 ${DESTDIR}/${MANDIR}/man5
-	install -m 0644 links/.*.5 ${DESTDIR}/${MANDIR}/man5
-
-.PHONY: clean
-clean:
-	$(RM) *.5
+include ../../hack/man-docs.mk

--- a/hack/man-docs.mk
+++ b/hack/man-docs.mk
@@ -1,0 +1,44 @@
+# Shared man page build rules
+#
+# Shared logic for building man pages from markdown sources using go-md2man.
+# Include this file from your docs/Makefile after setting following variables
+# before include.
+#
+# - MANPAGES: list of man page targets ("foo.5 bar.5 ...")
+# - MAN_INSTALL_DIR: installation path under DESTDIR ("/usr/share/man/man5")
+#
+# Optional variables:
+# - MAN_LINKS: additional .so link files or pre-built man pages to install
+#
+# Targets provided can then be used in top-level Makefile:
+# - docs: build all man pages from their .md sources
+# - install: install man pages (and links) into DESTDIR$(MAN_INSTALL_DIR)
+# - clean: remove built man pages
+
+GOMD2MAN ?= $(shell command -v go-md2man || echo '$(GOBIN)/go-md2man')
+
+# Pattern rules: convert .5.md -> .5, .1.md -> .1
+%.5: %.5.md
+	$(GOMD2MAN) -in $< -out $@
+
+%.1: %.1.md
+	$(GOMD2MAN) -in $< -out $@
+
+# Catch-all for .md without section suffix (e.g., storage command pages)
+%.1: %.md
+	$(GOMD2MAN) -in $< -out $@
+
+.PHONY: docs
+docs: $(MANPAGES)
+
+.PHONY: install
+install: $(MANPAGES)
+	install -d -m 755 $(DESTDIR)$(MAN_INSTALL_DIR)
+	install -m 644 $(MANPAGES) $(DESTDIR)$(MAN_INSTALL_DIR)/
+ifneq ($(MAN_LINKS),)
+	install -m 644 $(MAN_LINKS) $(DESTDIR)$(MAN_INSTALL_DIR)/
+endif
+
+.PHONY: clean
+clean:
+	rm -f $(MANPAGES)

--- a/image/.gitignore
+++ b/image/.gitignore
@@ -10,3 +10,6 @@ tools.timestamp
 
 # trash
 trash.lock
+
+# Generated man pages
+*.5

--- a/image/Makefile
+++ b/image/Makefile
@@ -21,12 +21,6 @@ TEST_PACKAGES := ./...
 PACKAGES := $(shell go list $(BUILDFLAGS) ./...)
 SOURCE_DIRS = $(shell echo $(PACKAGES) | awk 'BEGIN{FS="/"; RS=" "}{print $$4}' | uniq)
 
-PREFIX ?= ${DESTDIR}/usr
-MANINSTALLDIR=${PREFIX}/share/man
-GOMD2MAN ?= $(shell command -v go-md2man || echo '$(GOBIN)/go-md2man')
-MANPAGES_MD = $(wildcard docs/*.5.md)
-MANPAGES ?= $(MANPAGES_MD:%.md=%)
-
 ifeq ($(shell uname -s),FreeBSD)
 CONTAINERSCONFDIR ?= /usr/local/share/containers
 else
@@ -43,15 +37,13 @@ all: test lint
 build:
 	go build $(BUILDFLAGS) ./...
 
-$(MANPAGES): %: %.md
-	$(GOMD2MAN) -in $< -out $@
-
-docs: $(MANPAGES)
+.PHONY: docs
+docs:
+	$(MAKE) -C docs docs
 
 .PHONY: install-docs
 install-docs: docs
-	install -d -m 755 ${MANINSTALLDIR}/man5
-	install -m 644 docs/*.5 ${MANINSTALLDIR}/man5/
+	$(MAKE) -C docs install
 
 .PHONY: install
 install: install-docs
@@ -67,7 +59,7 @@ cross:
 
 .PHONY: clean
 clean:
-	rm -rf $(MANPAGES)
+	$(MAKE) -C docs clean
 
 .PHONY: test
 test:

--- a/image/docs/Makefile
+++ b/image/docs/Makefile
@@ -1,0 +1,6 @@
+MAN_INSTALL_DIR=/usr/share/man/man5
+
+MANPAGES := $(patsubst %.5.md,%.5,$(wildcard *.5.md))
+MAN_LINKS := containers-registries.conf.d.5
+
+include ../../hack/man-docs.mk

--- a/storage/Makefile
+++ b/storage/Makefile
@@ -29,7 +29,8 @@ TESTFLAGS := $(shell $(GO) test -race $(BUILDFLAGS) ./pkg/stringutils 2>&1 > /de
 default all: local-binary docs local-cross ## build and cross-build\nbinaries and docs
 
 clean: ## remove all built files
-	$(RM) -f containers-storage containers-storage.* docs/*.1 docs/*.5
+	$(RM) -f containers-storage containers-storage.*
+	$(MAKE) -C docs clean
 
 containers-storage: ## build using gc on the host
 	$(GO) build -compiler gc $(BUILDFLAGS) ./cmd/containers-storage

--- a/storage/docs/Makefile
+++ b/storage/docs/Makefile
@@ -1,19 +1,5 @@
-GOMD2MAN ?= $(shell command -v go-md2man || echo '$(GOBIN)/go-md2man')
-PREFIX ?= ${DESTDIR}/usr
-MANINSTALLDIR=${PREFIX}/share/man
-MANPAGES_MD = $(wildcard docs/*.5.md)
-MANPAGES ?= $(MANPAGES_MD:%.md=%)
+MAN_INSTALL_DIR=/usr/share/man/man5
 
-.PHONY: docs
-docs: $(patsubst %.md,%.1,$(filter-out %.5.md,$(wildcard *.md))) containers-storage.conf.5
+MANPAGES := $(patsubst %.5.md,%.5,$(wildcard *.5.md)) $(patsubst %.md,%.1,$(filter-out %.5.md,$(wildcard *.md)))
 
-%.1: %.md
-	$(GOMD2MAN) -in $^ -out $@
-
-containers-storage.conf.5: containers-storage.conf.5.md
-	$(GOMD2MAN) -in $^ -out $@
-
-.PHONY: install
-install:
-	install -d -m 755 ${MANINSTALLDIR}/man5
-	install -m 644 *.5 ${MANINSTALLDIR}/man5/
+include ../../hack/man-docs.mk


### PR DESCRIPTION
This wants to address #827 by adopting the exact same filtering found at https://github.com/podman-container-tools/podman/blob/63cf53d26a579ca8891d83f68fbaa1bf9c957a20/Makefile#L583.

Note that, as of PR creation, the only affected link is found at https://github.com/podman-container-tools/container-libs/blob/4e1a536aa2526d2e0fbe7a8069ffa0b4d6fb4b3c/common/docs/containers.conf.5.md?plain=1#L339
though it should then be safer to add more, if merged.