### PR TITLE
libimage: Add methods returning bool for SearchResult "[OK]"

### DIFF
--- a/common/libimage/search.go
+++ b/common/libimage/search.go
@@ -24,6 +24,9 @@ const (
 	// Let's follow Firefox by limiting parallel downloads to 6.  We do the
 	// same when pulling images in c/image.
 	searchMaxParallel = int64(6)
+
+	// searchResultOK represents true for Official and Automated.
+	searchResultOK = "[OK]"
 )
 
 // SearchResult is holding image-search related data.
@@ -42,6 +45,16 @@ type SearchResult struct {
 	Automated string
 	// Tag is the image tag
 	Tag string
+}
+
+// IsAutomated returns true if the image was created by an automated build.
+func (s *SearchResult) IsAutomated() bool {
+	return s.Automated == searchResultOK
+}
+
+// IsOfficial returns true if it's an official image.
+func (s *SearchResult) IsOfficial() bool {
+	return s.Official == searchResultOK
 }
 
 // SearchOptions customize searching images.
@@ -214,11 +227,11 @@ func (r *Runtime) searchImageInRegistry(ctx context.Context, term, registry stri
 		}
 		official := ""
 		if results[i].IsOfficial {
-			official = "[OK]"
+			official = searchResultOK
 		}
 		automated := ""
 		if results[i].IsAutomated {
-			automated = "[OK]"
+			automated = searchResultOK
 		}
 		description := strings.ReplaceAll(results[i].Description, "\n", " ")
 		if len(description) > 44 && !options.NoTrunc {


### PR DESCRIPTION
The Podman compat API needs to convert `[OK]` returned for `SearchResult`'s `Automated` and `Official` fields to `bool` to be compatible with the Docker API format.

Introduce public methods `IsAutomated()` and `IsOfficial()` to make this conversion future-proof.

Related: https://github.com/podman-container-tools/podman/pull/28787 (see https://github.com/podman-container-tools/podman/pull/28787#discussion_r3507849701)
