### PR TITLE
Fix lint on non-Linux

### DIFF
--- a/common/libnetwork/etchosts/ip_unsupported.go
+++ b/common/libnetwork/etchosts/ip_unsupported.go
@@ -3,7 +3,7 @@
 package etchosts
 
 // wslHostIP returns an empty string when running on OSes other than Linux
-// (should never happen)
+// (should never happen).
 func wslHostIP() string {
 	return ""
 }


### PR DESCRIPTION
> ```
> libnetwork/etchosts/ip_unsupported.go:6:1: Comment should end in a period (godot)
> // (should never happen)
> ```