### PR TITLE
feat(system): add MemAvailable field to MemInfo struct

### DIFF
--- a/storage/pkg/system/meminfo.go
+++ b/storage/pkg/system/meminfo.go
@@ -9,6 +9,11 @@ type MemInfo struct {
 	// Amount of free memory.
 	MemFree int64
 
+	// An estimate of how much memory is available for starting new
+	// applications, without swapping.
+	// Set to -1 on platforms where this information is not available.
+	MemAvailable int64
+
 	// Total amount of swap space available.
 	SwapTotal int64
 

--- a/storage/pkg/system/meminfo_freebsd.go
+++ b/storage/pkg/system/meminfo_freebsd.go
@@ -78,6 +78,7 @@ func ReadMemInfo() (*MemInfo, error) {
 	// Total memory is total physical memory less than memory locked by kernel
 	meminfo.MemTotal = MemTotal
 	meminfo.MemFree = MemFree
+	meminfo.MemAvailable = -1
 	meminfo.SwapTotal = SwapTotal
 	meminfo.SwapFree = SwapFree
 

--- a/storage/pkg/system/meminfo_linux.go
+++ b/storage/pkg/system/meminfo_linux.go
@@ -25,7 +25,7 @@ func ReadMemInfo() (*MemInfo, error) {
 // a MemInfo object given an io.Reader to the file.
 // Throws error if there are problems reading from the file
 func parseMemInfo(reader io.Reader) (*MemInfo, error) {
-	meminfo := &MemInfo{}
+	meminfo := &MemInfo{MemAvailable: -1}
 	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {
 		// Expected format: ["MemTotal:", "1234", "kB"]
@@ -48,6 +48,8 @@ func parseMemInfo(reader io.Reader) (*MemInfo, error) {
 			meminfo.MemTotal = bytes
 		case "MemFree:":
 			meminfo.MemFree = bytes
+		case "MemAvailable:":
+			meminfo.MemAvailable = bytes
 		case "SwapTotal:":
 			meminfo.SwapTotal = bytes
 		case "SwapFree:":

--- a/storage/pkg/system/meminfo_solaris.go
+++ b/storage/pkg/system/meminfo_solaris.go
@@ -97,6 +97,7 @@ func ReadMemInfo() (*MemInfo, error) {
 	// Total memory is total physical memory less than memory locked by kernel
 	meminfo.MemTotal = MemTotal - int64(ppKernel)
 	meminfo.MemFree = MemFree
+	meminfo.MemAvailable = -1
 	meminfo.SwapTotal = SwapTotal
 	meminfo.SwapFree = SwapFree
 

--- a/storage/pkg/system/meminfo_unix_test.go
+++ b/storage/pkg/system/meminfo_unix_test.go
@@ -14,6 +14,7 @@ func TestMemInfo(t *testing.T) {
 	const input = `
 	MemTotal:      1 kB
 	MemFree:       2 kB
+	MemAvailable:  5 kB
 	SwapTotal:     3 kB
 	SwapFree:      4 kB
 	Malformed1:
@@ -30,6 +31,9 @@ func TestMemInfo(t *testing.T) {
 	}
 	if meminfo.MemFree != 2*units.KiB {
 		t.Fatalf("Unexpected MemFree: %d", meminfo.MemFree)
+	}
+	if meminfo.MemAvailable != 5*units.KiB {
+		t.Fatalf("Unexpected MemAvailable: %d", meminfo.MemAvailable)
 	}
 	if meminfo.SwapTotal != 3*units.KiB {
 		t.Fatalf("Unexpected SwapTotal: %d", meminfo.SwapTotal)

--- a/storage/pkg/system/meminfo_windows.go
+++ b/storage/pkg/system/meminfo_windows.go
@@ -38,9 +38,10 @@ func ReadMemInfo() (*MemInfo, error) {
 		return &MemInfo{}, nil
 	}
 	return &MemInfo{
-		MemTotal:  int64(msi.ullTotalPhys),
-		MemFree:   int64(msi.ullAvailPhys),
-		SwapTotal: int64(msi.ullTotalPageFile),
-		SwapFree:  int64(msi.ullAvailPageFile),
+		MemTotal:     int64(msi.ullTotalPhys),
+		MemFree:      int64(msi.ullAvailPhys),
+		MemAvailable: -1,
+		SwapTotal:    int64(msi.ullTotalPageFile),
+		SwapFree:     int64(msi.ullAvailPageFile),
 	}, nil
 }


### PR DESCRIPTION
Add MemAvailable to provide a more accurate estimate of memory available for new applications without swapping. On Linux, this is parsed from /proc/meminfo. On FreeBSD, Solaris, and Windows, it falls back to MemFree.

Closes https://github.com/podman-container-tools/container-libs/issues/962
Related to: https://github.com/podman-container-tools/podman/issues/29116
