### PR TITLE
Revert "storage: improve error message on image mount from r/o store"

### DIFF
--- a/storage/store.go
+++ b/storage/store.go
@@ -3066,17 +3066,7 @@ func (s *store) MountImage(id string, mountOpts []string, mountLabel string) (st
 		MountLabel: mountLabel,
 		Options:    append(mountOpts, "ro"),
 	}
-	if rlstore.Exists(ilayer.ID) {
-		return rlstore.Mount(ilayer.ID, options)
-	}
-	// check if the layer is in a read-only store, and return a better error message
-	for _, store := range lstores {
-		// required read lock is acquired earlier in this function
-		if store.Exists(ilayer.ID) {
-			return "", fmt.Errorf("mounting read/only store images is not allowed: %w", ErrStoreIsReadOnly)
-		}
-	}
-	return "", ErrLayerUnknown
+	return rlstore.Mount(ilayer.ID, options)
 }
 
 func (s *store) Mount(id, mountLabel string) (string, error) {


### PR DESCRIPTION
This reverts commit 006839b60f83b86c0fb36ea137719e33dbf6f155.

This is causes test failures in both podman and buildah tests[1]. The return error was changed so buildah can no longer match it.

For the next podman release we need to vendor some pasta changes so we like a working container-libs. This can be reapplied once podman/buildah are known to work with this.

https://github.com/podman-container-tools/container-libs/pull/945#issuecomment-4892227058

