### PR TITLE
Revert "storage: improve error message on image mount from r/o store"

### DIFF
--- a/storage/store.go
+++ b/storage/store.go
@@ -3066,17 +3066,7 @@ func (s *store) MountImage(id string, mountOpts []string, mountLabel string) (st
 		MountLabel: mountLabel,
 		Options:    append(mountOpts, "ro"),
 	}
-	if rlstore.Exists(ilayer.ID) {
-		return rlstore.Mount(ilayer.ID, options)
-	}
-	// check if the layer is in a read-only store, and return a better error message
-	for _, store := range lstores {
-		// required read lock is acquired earlier in this function
-		if store.Exists(ilayer.ID) {
-			return "", fmt.Errorf("mounting read/only store images is not allowed: %w", ErrStoreIsReadOnly)
-		}
-	}
-	return "", ErrLayerUnknown
+	return rlstore.Mount(ilayer.ID, options)
 }
 
 func (s *store) Mount(id, mountLabel string) (string, error) {


### PR DESCRIPTION
Reverts podman-container-tools/container-libs#945

We need to revert this because the change breaks Podman and Buildah. We need to adapt both tools for this change and investigate the root cause of the problem. Since we need to vendor container-libs for the next release to allow other important fixes into Podman, we are reverting this for now. We will reapply the change later once we have investigated and implemented the proper fixes in Buildah and Podman.