### PR TITLE
image/manifest: accept OCI media types in Docker schema2 manifests

### DIFF
--- a/image/manifest/docker_schema2_test.go
+++ b/image/manifest/docker_schema2_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/opencontainers/go-digest"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.podman.io/image/v5/pkg/compression"
@@ -34,6 +35,11 @@ func TestSupportedSchema2MediaType(t *testing.T) {
 		{DockerV2ListMediaType, false},
 		{DockerV2Schema2ForeignLayerMediaType, false},
 		{DockerV2Schema2ForeignLayerMediaTypeGzip, false},
+		{imgspecv1.MediaTypeImageConfig, false},
+		{imgspecv1.MediaTypeImageLayer, false},
+		{imgspecv1.MediaTypeImageLayerGzip, false},
+		{imgspecv1.MediaTypeImageLayerNonDistributable, false},     //nolint:staticcheck // NonDistributable layers are deprecated, but we want to continue to support manipulating pre-existing images.
+		{imgspecv1.MediaTypeImageLayerNonDistributableGzip, false}, //nolint:staticcheck // NonDistributable layers are deprecated, but we want to continue to support manipulating pre-existing images.
 		{"application/vnd.docker.image.rootfs.foreign.diff.unknown", true},
 	}
 	for _, d := range data {

--- a/image/manifest/manifest.go
+++ b/image/manifest/manifest.go
@@ -44,7 +44,12 @@ type NonImageArtifactError = manifest.NonImageArtifactError
 // SupportedSchema2MediaType checks if the specified string is a supported Docker v2s2 media type.
 func SupportedSchema2MediaType(m string) error {
 	switch m {
-	case DockerV2ListMediaType, DockerV2Schema1MediaType, DockerV2Schema1SignedMediaType, DockerV2Schema2ConfigMediaType, DockerV2Schema2ForeignLayerMediaType, DockerV2Schema2ForeignLayerMediaTypeGzip, DockerV2Schema2LayerMediaType, DockerV2Schema2MediaType, DockerV2SchemaLayerMediaTypeUncompressed, DockerV2SchemaLayerMediaTypeZstd:
+	case DockerV2ListMediaType, DockerV2Schema1MediaType, DockerV2Schema1SignedMediaType, DockerV2Schema2ConfigMediaType, DockerV2Schema2ForeignLayerMediaType, DockerV2Schema2ForeignLayerMediaTypeGzip, DockerV2Schema2LayerMediaType, DockerV2Schema2MediaType, DockerV2SchemaLayerMediaTypeUncompressed, DockerV2SchemaLayerMediaTypeZstd,
+		imgspecv1.MediaTypeImageConfig,
+		imgspecv1.MediaTypeImageLayer,
+		imgspecv1.MediaTypeImageLayerGzip,
+		imgspecv1.MediaTypeImageLayerNonDistributable,     //nolint:staticcheck // NonDistributable layers are deprecated, but we want to continue to support manipulating pre-existing images.
+		imgspecv1.MediaTypeImageLayerNonDistributableGzip: //nolint:staticcheck // NonDistributable layers are deprecated, but we want to continue to support manipulating pre-existing images.
 		return nil
 	default:
 		return fmt.Errorf("unsupported docker v2s2 media type: %q", m)


### PR DESCRIPTION
### What

Accept OCI image config and layer media types when validating Docker schema 2 manifests in `go.podman.io/image/v5/manifest`.

This allows `Schema2FromManifest` / `SupportedSchema2MediaType` to handle Docker schema2 manifests with OCI descriptor media types, including `application/vnd.oci.image.layer.v1.tar+gzip`.

### Why

Some registries return Docker schema2 manifests whose config/layer descriptors use OCI media types. Today those fail before copy/inspection can proceed, for example through `skopeo copy --all`:

```text
unsupported docker v2s2 media type: "application/vnd.oci.image.layer.v1.tar+gzip"
```

Fixes #977. This replaces the PR that was first opened against the migrated `containers/image` repo: containers/image#2973.

### Testing

```text
$ docker run --rm -v "$PWD":/src -v ~/.cache/go-mod:/go/pkg/mod -v ~/.cache/go-build:/root/.cache/go-build -w /src/image golang:1.25 sh -lc 'timeout 420 /usr/local/go/bin/go test ./manifest -run TestSupportedSchema2MediaType -count=1 -v'
=== RUN   TestSupportedSchema2MediaType
--- PASS: TestSupportedSchema2MediaType (0.00s)
PASS
ok  	go.podman.io/image/v5/manifest	0.002s
```

Also verified the same code path in a patched `skopeo v1.23.0` build during registry mirroring: manifests with OCI layer media types copied successfully after this change.
