### PR TITLE
ci: make the automation release renovate managed

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -20,7 +20,7 @@
    https://docs.renovatebot.com/configuration-options/
 
    Monitoring Dashboard:
-   https://app.renovatebot.com/dashboard#github/containers
+   https://developer.mend.io/github/podman-container-tools
 
    Note: The Renovate bot will create/manage it's business on
          branches named 'renovate/*'.  Otherwise, and by
@@ -38,8 +38,8 @@
 
   // Re-use predefined sets of configuration options to DRY
   "extends": [
-    // https://github.com/containers/automation/blob/main/renovate/defaults.json5
-    "github>containers/automation//renovate/defaults.json5"
+    // https://github.com/podman-container-tools/automation/blob/main/renovate/defaults.json5
+    "github>podman-container-tools/automation//renovate/defaults.json5"
   ],
 
   // Permit automatic rebasing when base-branch changes by more than

--- a/.github/workflows/lima.yml
+++ b/.github/workflows/lima.yml
@@ -22,6 +22,12 @@ on:
 permissions:
   contents: read
 
+env:
+  # CI automation repo release for the VM image downloads in ci.sh.
+  # ENV is managed by renovate, do not change the name without
+  # updating the renovate config in the automation repo.
+  AUTOMATION_RELEASE: 20260616t073924z
+
 jobs:
   lima:
     name: lima # main name is set by who spawns this job

--- a/hack/ci/ci.sh
+++ b/hack/ci/ci.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" && pwd )
 
 source "$SCRIPT_DIR/lib.sh"
 
-AUTOMATION_RELEASE="20260616t073924z" # FIXME: should be Renovate-managed
+AUTOMATION_RELEASE="${AUTOMATION_RELEASE:-$(get_automation_release)}"
 LIMA_VM_NAME=container-libs-ci
 
 MODULE=${1:?must give module as first argument}

--- a/hack/ci/lib.sh
+++ b/hack/ci/lib.sh
@@ -68,3 +68,9 @@ function validate_variant() {
             ;;
     esac
 }
+
+# Reads and prints the AUTOMATION_RELEASE value from the workflow file.
+# Used for local runs where ci.sh is not triggered by gh actions.
+function get_automation_release() {
+    sed -En 's/.*AUTOMATION_RELEASE:\s(.*)/\1/p' .github/workflows/lima.yml
+}

--- a/hack/ci/runner.sh
+++ b/hack/ci/runner.sh
@@ -175,7 +175,8 @@ run_image_skopeo() {
 
     GOSRC="$(pwd)"
     SKOPEO_PATH="/var/tmp/skopeo"
-    SKOPEO_CIDEV_CONTAINER_FQIN="ghcr.io/podman-container-tools/skopeo_cidev:20260616t073924z" # FIXME: should be Renovate-managed
+    AUTOMATION_RELEASE="${AUTOMATION_RELEASE:-$(get_automation_release)}"
+    SKOPEO_CIDEV_CONTAINER_FQIN="ghcr.io/podman-container-tools/skopeo_cidev:$AUTOMATION_RELEASE"
 
     sudo podman pull --quiet "$SKOPEO_CIDEV_CONTAINER_FQIN"
     ctr_id=$(sudo podman create "$SKOPEO_CIDEV_CONTAINER_FQIN")


### PR DESCRIPTION
Put the variable in the workflow file like the renovate config expects,
see https://github.com/podman-container-tools/automation/pull/29

To ensure the local runs keep working we need a fall back to parse the
file manually.

Same as the podman change for this which is known to work:
https://github.com/podman-container-tools/podman/commit/8e74c1efd88e39d462e1f4411dc741e5cd9739bb
https://github.com/podman-container-tools/podman/pull/29186

Also update the latest image manually once here while at it.