### PR TITLE
Install policy.json & default.yaml in /usr/share/ instead of /etc/

### DIFF
--- a/image/Makefile
+++ b/image/Makefile
@@ -28,9 +28,9 @@ MANPAGES_MD = $(wildcard docs/*.5.md)
 MANPAGES ?= $(MANPAGES_MD:%.md=%)
 
 ifeq ($(shell uname -s),FreeBSD)
-CONTAINERSCONFDIR ?= /usr/local/etc/containers
+CONTAINERSCONFDIR ?= /usr/local/share/containers
 else
-CONTAINERSCONFDIR ?= /etc/containers
+CONTAINERSCONFDIR ?= /usr/share/containers
 endif
 REGISTRIESDDIR ?= ${CONTAINERSCONFDIR}/registries.d
 


### PR DESCRIPTION
Due to changes in podman 6.0 config file parsing changed[1]. So these files should be installed in /usr/share/containers by packagers and let /etc/containers should be system admins.

This is also followed in common/rpm/containers-common.spec

[1] https://github.com/podman-container-tools/podman/blob/main/contrib/design-docs/config-file-parsing.md

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
