### PR TITLE
storage: use -json parameter for `system_profiler SPSoftwareDataType`

### DIFF
--- a/storage/pkg/parsers/kernel/kernel_darwin.go
+++ b/storage/pkg/parsers/kernel/kernel_darwin.go
@@ -5,11 +5,10 @@
 package kernel
 
 import (
+	"encoding/json"
 	"fmt"
 	"os/exec"
 	"strings"
-
-	"github.com/mattn/go-shellwords"
 )
 
 // GetKernelVersion gets the current kernel version.
@@ -24,32 +23,29 @@ func GetKernelVersion() (*VersionInfo, error) {
 
 // getRelease uses `system_profiler SPSoftwareDataType` to get OSX kernel version
 func getRelease() (string, error) {
-	cmd := exec.Command("system_profiler", "SPSoftwareDataType")
-	osName, err := cmd.Output()
+	cmd := exec.Command("system_profiler", "-json", "SPSoftwareDataType")
+	out, err := cmd.Output()
 	if err != nil {
 		return "", err
 	}
 
-	var release string
-	for line := range strings.SplitSeq(string(osName), "\n") {
-		if strings.Contains(line, "Kernel Version") {
-			// It has the format like '      Kernel Version: Darwin 14.5.0'
-			_, val, ok := strings.Cut(line, ":")
-			if !ok {
-				return "", fmt.Errorf("kernel version is invalid")
-			}
-
-			prettyNames, err := shellwords.Parse(val)
-			if err != nil {
-				return "", fmt.Errorf("kernel version is invalid: %w", err)
-			}
-
-			if len(prettyNames) != 2 {
-				return "", fmt.Errorf("kernel version needs to be 'Darwin x.x.x' ")
-			}
-			release = prettyNames[1]
-		}
+	// system_profiler returns other fields in addition to kernel_version.
+	// Do not decode with RejectUnknownMembers.
+	var result struct {
+		SPSoftwareDataType []struct {
+			KernelVersion string `json:"kernel_version"`
+		} `json:"SPSoftwareDataType"`
+	}
+	if err := json.Unmarshal(out, &result); err != nil {
+		return "", fmt.Errorf("parsing system_profiler JSON: %w", err)
+	}
+	if len(result.SPSoftwareDataType) == 0 || result.SPSoftwareDataType[0].KernelVersion == "" {
+		return "", fmt.Errorf("kernel version is invalid")
 	}
 
-	return release, nil
+	prettyNames := strings.Fields(result.SPSoftwareDataType[0].KernelVersion)
+	if len(prettyNames) != 2 {
+		return "", fmt.Errorf("kernel version needs to be 'Darwin x.x.x' ")
+	}
+	return prettyNames[1], nil
 }


### PR DESCRIPTION
Update the `system_profiler SPSoftwareDataType` command to use the `-json` flag. This allows the system to parse OS information without the external `go-shellwords` library.

Fixes: #983
