### PR TITLE
config: remove duplicate compat_api_enforce_docker_hub entry

### DIFF
--- a/common/pkg/config/containers.conf
+++ b/common/pkg/config/containers.conf
@@ -518,11 +518,6 @@ default_sysctls = [
 #  "/usr/local/sbin/conmon"
 #]
 
-# Enforces using docker.io for completing short names in Podman's compatibility
-# REST API. Note that this will ignore unqualified-search-registries and
-# short-name aliases defined in containers-registries.conf(5).
-#compat_api_enforce_docker_hub = true
-
 # Specify the keys sequence used to detach a container.
 # Format is a single character [a-Z] or a comma separated sequence of
 # `ctrl-<value>`, where `<value>` is one of:


### PR DESCRIPTION
The `compat_api_enforce_docker_hub` key and its comment were listed twice in containers.conf. Removed the first occurrence and kept the second.


