### PR TITLE
fileutils: fix wildcard negation directory descent in `archive.TarWithOptions`

### DIFF
--- a/storage/pkg/archive/archive.go
+++ b/storage/pkg/archive/archive.go
@@ -1002,34 +1002,20 @@ func tarWithOptionsTo(dest io.WriteCloser, srcPath string, options *TarOptions) 
 			}
 
 			if skip {
-				// If we want to skip this file and its a directory
-				// then we should first check to see if there's an
-				// excludes pattern (e.g. !dir/file) that starts with this
-				// dir. If so then we can't skip this dir.
+				// If we want to skip this file and it's a directory
+				// then we should first check to see if there's a
+				// negation pattern (e.g. !dir/file or !**/*.go) that
+				// might re-include files under this dir. If so then
+				// we can't skip this dir.
 
-				// Its not a dir then so we can just return/skip.
+				// It's not a dir then so we can just return/skip.
 				if !d.IsDir() {
 					return nil
 				}
 
-				// No exceptions (!...) in patterns so just skip dir
-				if !pm.Exclusions() {
-					return filepath.SkipDir
+				if pm.ShouldDescendExcludedDir(relFilePath) {
+					return nil
 				}
-
-				dirSlash := relFilePath + string(filepath.Separator)
-
-				for _, pat := range pm.Patterns() {
-					if !pat.Exclusion() {
-						continue
-					}
-					if strings.HasPrefix(pat.String()+string(filepath.Separator), dirSlash) {
-						// found a match - so can't skip this dir
-						return nil
-					}
-				}
-
-				// No matching exclusion dir so just skip dir
 				return filepath.SkipDir
 			}
 

--- a/storage/pkg/archive/archive_test.go
+++ b/storage/pkg/archive/archive_test.go
@@ -745,6 +745,41 @@ func TestTarWithOptions(t *testing.T) {
 	}
 }
 
+func TestTarWithOptionsWildcardNegation(t *testing.T) {
+	if runtime.GOOS == windows {
+		t.Skip("Failing on Windows")
+	}
+
+	tmpDirPath := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDirPath, "cmd", "app"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDirPath, "cmd", "main.go"), []byte("package main"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDirPath, "cmd", "app", "app.go"), []byte("package app"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDirPath, "cmd", "main.txt"), []byte("text"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDirPath, "README.md"), []byte("readme"), 0o644))
+
+	archive, err := TarWithOptions(tmpDirPath, &TarOptions{
+		ExcludePatterns: []string{"*", "!**/*.go"},
+	})
+	require.NoError(t, err)
+	defer archive.Close()
+
+	found := make(map[string]bool)
+	tr := tar.NewReader(archive)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		found[hdr.Name] = true
+	}
+
+	assert.True(t, found["cmd/main.go"], "cmd/main.go should be included by !**/*.go")
+	assert.True(t, found["cmd/app/app.go"], "cmd/app/app.go should be included by !**/*.go")
+	assert.False(t, found["cmd/main.txt"], "cmd/main.txt should remain excluded")
+	assert.False(t, found["README.md"], "README.md should remain excluded")
+}
+
 // Some tar archives such as http://haproxy.1wt.eu/download/1.5/src/devel/haproxy-1.5-dev21.tar.gz
 // use PAX Global Extended Headers.
 // Failing prevents the archives from being uncompressed during ADD

--- a/storage/pkg/fileutils/fileutils.go
+++ b/storage/pkg/fileutils/fileutils.go
@@ -299,6 +299,50 @@ func Matches(file string, patterns []string) (bool, error) {
 	return pm.IsMatch(file)
 }
 
+// ShouldDescendExcludedDir checks whether an excluded directory should still be
+// descended into because a negation pattern might match files under it.
+// It handles literal prefix matches (e.g. !cmd/main.go for dir "cmd") and
+// wildcard negations (e.g. !**/*.go, !*/*.go). The wildcard check extracts
+// the literal prefix before the first wildcard and may intentionally
+// overmatch (descend into directories that won't ultimately contain matches),
+// which is safe because actual file-level matching happens later.
+func (pm *PatternMatcher) ShouldDescendExcludedDir(dirPath string) bool {
+	if !pm.exclusions {
+		return false
+	}
+	dir := filepath.ToSlash(strings.Trim(dirPath, string(os.PathSeparator)))
+	for _, pattern := range pm.patterns {
+		if !pattern.Exclusion() {
+			continue
+		}
+		slashPattern := filepath.ToSlash(strings.Trim(pattern.String(), string(os.PathSeparator)))
+
+		// Literal-prefix check: the negation spec starts with this
+		// directory path, for example: !cmd/main.go matches dir "cmd"
+		if strings.HasPrefix(slashPattern, dir+"/") {
+			return true
+		}
+
+		// Wildcard-aware check: extract the literal prefix before
+		// the first wildcard character (*, ?, [), for example: !cmd/**/*.go matches dir "cmd"
+		// if the directory is at or under that literal prefix, a file beneath this
+		// directory could match the negation, so keep descending.
+		if firstWild := strings.IndexAny(slashPattern, "*?["); firstWild >= 0 {
+			var literalPrefix string
+			if idx := strings.LastIndex(slashPattern[:firstWild], "/"); idx >= 0 {
+				literalPrefix = slashPattern[:idx]
+			}
+			if literalPrefix == "" {
+				return true
+			}
+			if dir == literalPrefix || strings.HasPrefix(dir, literalPrefix+"/") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // CopyFile copies from src to dst until either EOF is reached
 // on src or an error occurs. It verifies src exists and removes
 // the dst if it exists.

--- a/storage/pkg/fileutils/fileutils_test.go
+++ b/storage/pkg/fileutils/fileutils_test.go
@@ -617,3 +617,159 @@ func TestMatchesAmount(t *testing.T) {
 		assert.Equal(t, testCase.isMatch, isMatch, desc)
 	}
 }
+
+func TestShouldDescendExcludedDir(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		patterns []string
+		want     bool
+	}{
+		{
+			name:     "no exclusions",
+			path:     "cmd",
+			patterns: []string{"*"},
+			want:     false,
+		},
+		{
+			name:     "literal prefix match",
+			path:     "cmd",
+			patterns: []string{"*", "!cmd/main.go"},
+			want:     true,
+		},
+		{
+			name:     "literal prefix no match",
+			path:     "other",
+			patterns: []string{"*", "!cmd/main.go"},
+			want:     false,
+		},
+		{
+			name:     "double star at start matches any dir",
+			path:     "cmd",
+			patterns: []string{"**", "!**/*.go"},
+			want:     true,
+		},
+		{
+			name:     "double star at start matches nested dir",
+			path:     "cmd/sub",
+			patterns: []string{"**", "!**/*.go"},
+			want:     true,
+		},
+		{
+			name:     "double star with prefix matches dir under prefix",
+			path:     "cmd/sub",
+			patterns: []string{"**", "!cmd/**/*.go"},
+			want:     true,
+		},
+		{
+			name:     "double star with prefix no match for other dir",
+			path:     "other",
+			patterns: []string{"**", "!cmd/**/*.go"},
+			want:     false,
+		},
+		{
+			name:     "single star at start matches any dir",
+			path:     "cmd",
+			patterns: []string{"*", "!*/*.go"},
+			want:     true,
+		},
+		{
+			name:     "single star at start matches nested dir",
+			path:     "cmd/sub",
+			patterns: []string{"*", "!*/*.go"},
+			want:     true,
+		},
+		{
+			name:     "single star with prefix matches dir under prefix",
+			path:     "src/pkg",
+			patterns: []string{"**", "!src/*/*.go"},
+			want:     true,
+		},
+		{
+			name:     "single star with prefix no match for other dir",
+			path:     "other",
+			patterns: []string{"**", "!src/*/*.go"},
+			want:     false,
+		},
+		{
+			name:     "leading slash is stripped",
+			path:     "/cmd",
+			patterns: []string{"*", "!cmd/main.go"},
+			want:     true,
+		},
+		{
+			name:     "deep nested with double star prefix",
+			path:     "src/internal/pkg",
+			patterns: []string{"**", "!src/**/*.go"},
+			want:     true,
+		},
+		{
+			name:     "dir prefix match is not a partial match",
+			path:     "cmds",
+			patterns: []string{"*", "!cmd/main.go"},
+			want:     false,
+		},
+		{
+			name:     "wildcard mid-segment descends parent dir",
+			path:     "cmd/images",
+			patterns: []string{"**", "!cmd/image*/main.go"},
+			want:     true,
+		},
+		{
+			name:     "wildcard mid-segment matches parent",
+			path:     "cmd",
+			patterns: []string{"**", "!cmd/image*"},
+			want:     true,
+		},
+		{
+			name:     "question mark wildcard matches any dir",
+			path:     "cmd",
+			patterns: []string{"**", "!cm?/*.go"},
+			want:     true,
+		},
+		{
+			name:     "question mark wildcard no literal prefix matches any dir",
+			path:     "other",
+			patterns: []string{"**", "!?md/*.go"},
+			want:     true,
+		},
+		{
+			name:     "bracket wildcard matches dir",
+			path:     "cmd",
+			patterns: []string{"**", "!cm[d]/*.go"},
+			want:     true,
+		},
+		{
+			name:     "bracket wildcard no literal prefix matches any dir",
+			path:     "other",
+			patterns: []string{"**", "![c]md/*.go"},
+			want:     true,
+		},
+		{
+			name:     "bracket wildcard with prefix matches dir under prefix",
+			path:     "src/cmd",
+			patterns: []string{"**", "!src/cm[d]/*.go"},
+			want:     true,
+		},
+		{
+			name:     "bracket wildcard with prefix no match for other dir",
+			path:     "other",
+			patterns: []string{"**", "!src/cm[d]/*.go"},
+			want:     false,
+		},
+		{
+			name:     "non-exclusion patterns are ignored",
+			path:     "cmd",
+			patterns: []string{"cmd/**/*.go"},
+			want:     false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pm, err := NewPatternMatcher(tt.patterns)
+			require.NoError(t, err)
+			got := pm.ShouldDescendExcludedDir(tt.path)
+			assert.Equal(t, tt.want, got, "ShouldDescendExcludedDir(%q)", tt.path)
+		})
+	}
+}


### PR DESCRIPTION
The `strings.HasPrefix` check in `tarWithOptionsTo` only worked for literal negation patterns (e.g. `!cmd/main.go`) but failed for wildcard negations like `!**/*.go`, `!*/*.go`, or `!cmd/image*`. This caused excluded directories to be skipped entirely even when negation patterns should have re-included files within them.

Add `ShouldDescendExcludedDir` to `pkg/fileutils` which extracts the literal prefix before the first wildcard character and checks whether the directory is at or under that prefix. When no literal prefix exists (e.g. `!**/*.go`), always descend. Replace the inline loop in tarWithOptionsTo with a call to the new function.

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
