### PR TITLE
ci: do not use custom ssh user for image tests and update skopeo clone url

### DIFF
--- a/hack/ci/runner.sh
+++ b/hack/ci/runner.sh
@@ -156,7 +156,7 @@ run_image_skopeo() {
     sudo podman umount --latest
     sudo podman rm --latest
 
-    git clone -b "$SKOPEO_CI_BRANCH" https://github.com/containers/skopeo.git "$SKOPEO_PATH"
+    git clone -b "$SKOPEO_CI_BRANCH" https://github.com/podman-container-tools/skopeo.git "$SKOPEO_PATH"
     cd "$SKOPEO_PATH"
     go mod edit -replace "go.podman.io/storage=$GOSRC/storage"
     go mod edit -replace "go.podman.io/image/v5=$GOSRC/image"

--- a/hack/ci/runner.sh
+++ b/hack/ci/runner.sh
@@ -27,33 +27,6 @@ prepare_storage_env() {
     done
 }
 
-prepare_image_env() {
-    ROOTLESS_USER="testuser$$"
-    rootless_uid=$((RANDOM+1000))
-    rootless_gid=$((RANDOM+1000))
-    sudo groupadd -g $rootless_gid $ROOTLESS_USER
-    sudo useradd -g $rootless_gid -u $rootless_uid --no-user-group --create-home $ROOTLESS_USER
-
-    sudo mkdir -p "$(go env GOPATH)"
-    sudo chown -R $ROOTLESS_USER:$ROOTLESS_USER "$(go env GOPATH)"
-    sudo chown -R $ROOTLESS_USER:$ROOTLESS_USER "$(pwd)"
-
-    sudo mkdir -p "/run/user/$rootless_uid"
-    sudo chown $ROOTLESS_USER:$ROOTLESS_USER "/run/user/$rootless_uid"
-
-    sudo mkdir -p /root/.ssh "/home/$ROOTLESS_USER/.ssh"
-    sudo ssh-keygen -t ed25519 -P "" -f /root/.ssh/id_ed25519
-    sudo bash -c "cat /root/.ssh/*.pub >> /home/$ROOTLESS_USER/.ssh/authorized_keys"
-    sudo chmod -R 700 /root/.ssh "/home/$ROOTLESS_USER/.ssh"
-    sudo chown -R $ROOTLESS_USER:$ROOTLESS_USER "/home/$ROOTLESS_USER/.ssh"
-
-    sudo systemctl start sshd || sudo systemctl start ssh
-    sudo ssh-keyscan localhost > /tmp/known_hosts
-    sudo cp /tmp/known_hosts /root/.ssh/known_hosts
-
-    export ROOTLESS_USER rootless_uid
-}
-
 ###############################################################################
 # Test runners
 ###############################################################################
@@ -120,8 +93,8 @@ run_image() {
         sequoia) BUILDTAGS="containers_image_sequoia" ;;
     esac
 
-    GOPATH_DIR="$(go env GOPATH)"
-    GOROOT_DIR="$(go env GOROOT)"
+    GOPATH="$(go env GOPATH)"
+    GOCACHE="$(go env GOCACHE)"
     GOSRC="$(cd .. && pwd)"
 
     git config --global --add safe.directory "$GOSRC"
@@ -143,26 +116,22 @@ run_image() {
         sed -n 's/func \(Test[[:alnum:]]*\)(.*/^\1$$/p' |
         paste -sd "|" -)
     if [ -n "$test_filter" ]; then
-        sudo -E env "PATH=$PATH" "GOPATH=$GOPATH_DIR" "HOME=$HOME" \
+        sudo mkdir -p "$GOPATH" "$GOCACHE"
+        sudo -E env "PATH=$PATH" "GOPATH=$GOPATH" "GOCACHE=$GOCACHE" \
             make test "BUILDTAGS=$BUILDTAGS" "TESTFLAGS=-v -run '$test_filter'" TEST_PACKAGES=./storage
+        # Restore permissions to user
+        sudo chown -R $(id -u):$(id -g) "$GOPATH" "$GOCACHE"
     fi
 
     # Run rootless tests
     cleanup() {
-        sudo ssh -o StrictHostKeyChecking=no -i /root/.ssh/id_ed25519 \
-            $ROOTLESS_USER@localhost \
-            "export XDG_RUNTIME_DIR=/run/user/$rootless_uid && export PATH=$GOROOT_DIR/bin:\$PATH && bash $GOSRC/image/signature/sigstore/rekor/testdata/start-rekor.sh ci remove" || true
-        sudo chown -R $(id -u):$(id -g) "$GOPATH_DIR" "$GOSRC"
+        $GOSRC/image/signature/sigstore/rekor/testdata/start-rekor.sh ci remove || true
     }
     trap cleanup EXIT
 
-    sudo ssh -o StrictHostKeyChecking=no -i /root/.ssh/id_ed25519 \
-        $ROOTLESS_USER@localhost \
-        "export XDG_RUNTIME_DIR=/run/user/$rootless_uid && export PATH=$GOROOT_DIR/bin:\$PATH && export GOPATH=$GOPATH_DIR && bash $GOSRC/image/signature/sigstore/rekor/testdata/start-rekor.sh ci"
-
-    sudo ssh -o StrictHostKeyChecking=no -i /root/.ssh/id_ed25519 \
-        $ROOTLESS_USER@localhost \
-        "export XDG_RUNTIME_DIR=/run/user/$rootless_uid && export PATH=$GOROOT_DIR/bin:\$PATH && export GOPATH=$GOPATH_DIR && cd $GOSRC/image && make test BUILDTAGS='$BUILDTAGS' TESTFLAGS=-v REKOR_SERVER_URL='http://127.0.0.1:3000'"
+    # start custom rekor which is needed by the tests
+    $GOSRC/image/signature/sigstore/rekor/testdata/start-rekor.sh ci
+    make test BUILDTAGS='$BUILDTAGS' TESTFLAGS=-v REKOR_SERVER_URL='http://127.0.0.1:3000'
 }
 
 run_image_skopeo() {


### PR DESCRIPTION
ci: do not use custom ssh user for image tests

With lima we already run as rootless user so just run the tests as that
user.

---

ci: update skopeo clone url to the new org

The link is redirected so it is fine but it is better to just use the
new repo URL to avoid the redirect.