### PR TITLE
Change the fake config in sigstore attachments

### DIFF
--- a/image/docker/docker_image_dest.go
+++ b/image/docker/docker_image_dest.go
@@ -709,27 +709,23 @@ func (d *dockerImageDestination) putSignaturesToSigstoreAttachments(ctx context.
 	if err != nil {
 		return err
 	}
-	var ociConfig imgspecv1.Image // Most fields empty by default
-	if ociManifest == nil {
-		ociManifest = manifest.OCI1FromComponents(imgspecv1.Descriptor{
-			MediaType: imgspecv1.MediaTypeImageConfig,
-			Digest:    "", // We will fill this in later.
-			Size:      0,
-		}, nil)
-		ociConfig.RootFS.Type = "layers"
-	} else {
-		logrus.Debugf("Fetching sigstore attachment config %s", ociManifest.Config.Digest.String())
-		// We don’t benefit from a real BlobInfoCache here because we never try to reuse/mount configs.
-		configBlob, err := d.c.getOCIDescriptorContents(ctx, d.ref, ociManifest.Config, iolimits.MaxConfigBodySize,
-			none.NoCache)
-		if err != nil {
-			return err
-		}
-		if err := json.Unmarshal(configBlob, &ociConfig); err != nil {
-			return fmt.Errorf("parsing sigstore attachment config %s in %s: %w", ociManifest.Config.Digest.String(),
-				d.ref.ref.Name(), err)
-		}
-	}
+    var configBlob []byte
+    if ociManifest == nil {
+        ociManifest = manifest.OCI1FromComponents(imgspecv1.Descriptor{
+            MediaType: imgspecv1.MediaTypeImageConfig,
+            Digest:    "", // We will fill this in later.
+            Size:      0,
+        }, nil)
+        configBlob = []byte("{}") // cosign standard: empty config 
+    } else {
+        logrus.Debugf("Fetching sigstore attachment config %s", ociManifest.Config.Digest.String())
+        var err error
+        configBlob, err = d.c.getOCIDescriptorContents(ctx, d.ref, ociManifest.Config, iolimits.MaxConfigBodySize,
+            none.NoCache)
+        if err != nil {
+            return err
+        }
+    }
 
 	// To make sure we can safely append to the slices of ociManifest, without adding a remote dependency on the code that creates it.
 	ociManifest.Layers = slices.Clone(ociManifest.Layers)
@@ -766,14 +762,9 @@ func (d *dockerImageDestination) putSignaturesToSigstoreAttachments(ctx context.
 		}
 		sigDesc.Annotations = annotations
 		ociManifest.Layers = append(ociManifest.Layers, sigDesc)
-		ociConfig.RootFS.DiffIDs = append(ociConfig.RootFS.DiffIDs, sigDesc.Digest)
 		logrus.Debugf("Adding new signature, digest %s", sigDesc.Digest.String())
 	}
 
-	configBlob, err := json.Marshal(ociConfig)
-	if err != nil {
-		return err
-	}
 	logrus.Debugf("Uploading updated sigstore attachment config")
 	// We don’t benefit from a real BlobInfoCache here because we never try to reuse/mount configs.
 	configDesc, err := d.putBlobBytesAsOCI(ctx, configBlob, imgspecv1.MediaTypeImageConfig, private.PutBlobOptions{


### PR DESCRIPTION
## Summary

Bump `github.com/containers/image/v5` to pick up the sigstore attachment
config fix in [containers/image@7f71ddf](https://github.com/containers/image/commit/7f71ddf0f08165ecec140f5de7791ece341e3029),
which resolves `manifest invalid` errors when mirroring cosign signature
OCI artifacts to self-hosted Quay registries.

Closes #1478

---

## Problem

When mirroring OCP release images to a self-hosted Quay registry with
`--remove-signatures=false`, cosign signature manifests (`sha256-*.sig`)
fail to push with HTTP 400 `manifest invalid` for any component image
whose sig manifest contains repeated identical layer digests.

This affects OCP component images that have been signed multiple times
(e.g. images shared across multiple OCP releases), which accumulate one
identical cosign layer per signing operation. A typical affected manifest
has 8 layers all with the same digest.

The error surfaces as:

[ERROR]: [Worker] error mirroring image quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:<digest>
error: writing signatures: uploading manifest sha256-<digest>.sig to <registry>/platform/openshift/release: manifest invalid



---

## Root Cause

In `putSignaturesToSigstoreAttachments` (docker/docker_image_dest.go in
containers/image), when a sig manifest has duplicate layer digests, all
but the first are detected as duplicates and skipped. The function then
constructs a new 1-layer manifest with a freshly serialized OCI image
config containing:

```json
{"rootfs": {"type": "layers", "diff_ids": ["sha256:<cosign-payload-digest>"]}}
diff_ids is an OCI image concept for uncompressed tar layer digests.
The value written here is the digest of a 334-byte cosign JSON payload,
not a tar archive. Quay validates diff_ids entries against the OCI
image spec and rejects the manifest.

Manually pushing the verbatim source manifest (which uses a correct empty
{} config, the cosign standard) succeeds with HTTP 201, confirming the
issue is in how containers/image constructs the config — not in Quay or
the manifest content itself.

Fix
The upstream fix in containers/image@7f71ddf removes the intermediate
imgspecv1.Image struct entirely. For new sig manifests it uses
[]byte("{}") directly (the correct cosign empty config). For existing
manifests it fetches the config blob verbatim without
unmarshalling/remarshalling, preserving whatever the registry already
has. The DiffIDs append and final json.Marshal are removed.

Testing
Mirrored OCP stable-4.18 (4.18.33–4.18.48), stable-4.19, and stable-4.20 channels to a self-hosted Quay 3.16 instance
Confirmed zero manifest invalid errors across all sig manifest pushes
Spoke clusters validated image signatures successfully post-sync
Reproduced the failure on the previous vendor version and confirmed it is resolved with this bump