### PR TITLE
ssh: add the ssh:// scheme in golangConnectionDial

### DIFF
--- a/common/pkg/ssh/connection_golang.go
+++ b/common/pkg/ssh/connection_golang.go
@@ -88,7 +88,18 @@ func golangConnectionCreate(options ConnectionCreateOptions) error {
 	})
 }
 
+// hostWithSSHScheme ensures host carries an ssh:// scheme, which Validate (via
+// url.Parse) requires: without it a bare host or IP is parsed as a URL path,
+// leaving the host empty so the dial target degrades to ":<port>" (#46).
+func hostWithSSHScheme(host string) string {
+	if !strings.HasPrefix(host, "ssh://") {
+		return "ssh://" + host
+	}
+	return host
+}
+
 func golangConnectionDial(options ConnectionDialOptions) (*ConnectionDialReport, error) {
+	options.Host = hostWithSSHScheme(options.Host)
 	_, uri, err := Validate(options.User, options.Host, options.Port, options.Identity)
 	if err != nil {
 		return nil, err
@@ -107,9 +118,7 @@ func golangConnectionDial(options ConnectionDialOptions) (*ConnectionDialReport,
 }
 
 func golangConnectionExec(options ConnectionExecOptions, input io.Reader) (*ConnectionExecReport, error) {
-	if !strings.HasPrefix(options.Host, "ssh://") {
-		options.Host = "ssh://" + options.Host
-	}
+	options.Host = hostWithSSHScheme(options.Host)
 	_, uri, err := Validate(options.User, options.Host, options.Port, options.Identity)
 	if err != nil {
 		return nil, err
@@ -138,9 +147,7 @@ func golangConnectionScp(options ConnectionScpOptions) (*ConnectionScpReport, er
 	}
 
 	// removed for parsing
-	if !strings.HasPrefix(host, "ssh://") {
-		host = "ssh://" + host
-	}
+	host = hostWithSSHScheme(host)
 	_, uri, err := Validate(options.User, host, options.Port, options.Identity)
 	if err != nil {
 		return nil, err

--- a/common/pkg/ssh/utils_test.go
+++ b/common/pkg/ssh/utils_test.go
@@ -47,3 +47,21 @@ func TestValidate(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, dst.URI, "ssh://testhost:22/var/run/podman/podman.sock")
 }
+
+func TestHostWithSSHScheme(t *testing.T) {
+	// golangConnectionDial/Exec/Scp normalize their host through this helper.
+	require.Equal(t, "ssh://10.0.0.27", hostWithSSHScheme("10.0.0.27"))
+	require.Equal(t, "ssh://10.0.0.27", hostWithSSHScheme("ssh://10.0.0.27")) // idempotent
+
+	// The normalized host validates to the intended dial target.
+	_, uri, err := Validate(nil, hostWithSSHScheme("10.0.0.27"), 22, "")
+	require.NoError(t, err)
+	require.Equal(t, "10.0.0.27:22", uri.Host)
+	require.Empty(t, uri.Path)
+
+	// A bare host, on the other hand, is parsed as a path and the dial target
+	// degrades to ":22" -- the bug the helper fixes (#46).
+	_, broken, err := Validate(nil, "10.0.0.27", 22, "")
+	require.NoError(t, err)
+	require.Equal(t, ":22", broken.Host)
+}


### PR DESCRIPTION
`golangConnectionDial` passed the bare host to Validate, which parses it with `url.Parse` and needs an ssh:// scheme. Without it the parsed host is empty and the dial target becomes ":22", so remote connections fail with "dial tcp :22: connect: connection refused".

`golangConnectionExec` and `golangConnectionScp` already prefix ssh://. 

Move that idiom into a small helper and use it in all three, so the dial path is fixed and the normalization lives in one place.

Fixes #46
