### PR TITLE
storage/overlay: use userxattr when probing idmapped lower layers

### DIFF
--- a/storage/drivers/overlay/check.go
+++ b/storage/drivers/overlay/check.go
@@ -270,6 +270,9 @@ func supportsIdmappedLowerLayers(home string) (bool, error) {
 	}()
 
 	opts := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", lowerMappedDir, upperDir, workDir)
+	if unshare.IsRootless() {
+		opts += ",userxattr"
+	}
 	flags := uintptr(0)
 	if err := unix.Mount("overlay", mergedDir, "overlay", flags, opts); err != nil {
 		return false, err


### PR DESCRIPTION
From the commit message:

>supportsIdmappedLowerLayers() performs a test overlay mount to detect whether the kernel supports idmapped lower layers. When running rootless, the kernel requires the userxattr mount option for unprivileged overlay mounts, so the probe mount always failed and rootless podman incorrectly reported idmapped mounts as unsupported.
>
>Pass userxattr in the probe mount options when running rootless, so the check reflects actual kernel support.
>
>Fixes: 9eb030e97af9 ("overlay: use idmapped lower layers where supported")

This fix mirrors all of the other code paths for mounting overlay rootless. I've tested this on my local install and I see `/run/user/1000/containers/overlay/idmapped-lower-dir-true` get correctly populated.