### PR TITLE
storage/overlay: allow native overlay on Lustre in user namespaces

### DIFF
--- a/storage/drivers/overlay/overlay.go
+++ b/storage/drivers/overlay/overlay.go
@@ -319,6 +319,19 @@ func isNetworkFileSystem(fsMagic graphdriver.FsMagic) bool {
 	return false
 }
 
+func isIdmapNetworkFileSystem(fsMagic graphdriver.FsMagic) bool {
+	switch fsMagic {
+	// network file systems with idmapped mounts support...
+	case graphdriver.FsMagicLUSTRE:
+		return true
+	}
+	return false
+}
+
+func isNonIdmapNetworkFileSystem(fsMagic graphdriver.FsMagic) bool {
+	return isNetworkFileSystem(fsMagic) && !isIdmapNetworkFileSystem(fsMagic)
+}
+
 // Init returns the a native diff driver for overlay filesystem.
 // If overlay filesystem is not supported on the host, a wrapped graphdriver.ErrNotSupported is returned as error.
 // If an overlay filesystem is not supported over an existing filesystem then a wrapped graphdriver.ErrIncompatibleFS is returned.
@@ -390,7 +403,7 @@ func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) 
 		case graphdriver.FsMagicAufs, graphdriver.FsMagicOverlay, graphdriver.FsMagicEcryptfs:
 			return nil, fmt.Errorf("'overlay' is not supported over %s, a mount_program is required: %w", backingFs, graphdriver.ErrIncompatibleFS)
 		}
-		if unshare.IsRootless() && isNetworkFileSystem(fsMagic) {
+		if unshare.IsRootless() && isNonIdmapNetworkFileSystem(fsMagic) {
 			return nil, fmt.Errorf("a network file system with user namespaces is not supported.  Please use a mount_program: %w", graphdriver.ErrIncompatibleFS)
 		}
 	}


### PR DESCRIPTION
From the commit message:

> Native overlay is rejected on network file system backing stores when running in a user namespace. However, Lustre can potentially support idmapped mounts, which is enough for native overlay to work rootless.
>
> Add an allow list of network file systems with idmapped mounts support, currently just Lustre, and only reject network file systems that are not on it.
>
> Not all version of Lustre will support either native overlayfs or ID mapping, so we still need to probe for support at runtime.

I've tested this on my own Lustre system - and podman will correctly use native overlayfs and ID mapping.

I think the code could be structured better. I'm open to suggestions. `isNetworkFileSystem()` seems to be a proxy for "this filesystem doesn't support either native overlayfs or ID mapping". In an upcoming release, Lustre will support both native overlayfs and ID mapping. A given version of Lustre may have one, the other, or both. I'd want to fall back to the existing behavior (i.e. emitting a helpful warning) when the support is incomplete. I know podman usually does runtime feature checks for this kind of stuff - but network filesystem seem like an odd edge case where we want to give the user extra guidance. I'm wary of removing Lustre from the network filesystem list outright - most Lustre filesystems in production won't support native overlayfs or ID mapping. So I have this compromise solution. Thoughts?