### PR TITLE
ci: use larger runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
             driver: overlay-transient
     uses: ./.github/workflows/lima.yml
     with:
-      runner: cncf-ubuntu-2-8-x86
+      runner: cncf-ubuntu-4-16-x86
       module: storage
       distro: ${{ matrix.distro }}
       variant: ${{ matrix.driver }}
@@ -114,7 +114,7 @@ jobs:
         module: [image, image-skopeo]
     uses: ./.github/workflows/lima.yml
     with:
-      runner: cncf-ubuntu-2-8-x86
+      runner: cncf-ubuntu-4-16-x86
       module: ${{ matrix.module }}
       distro: fedora-current
       variant: ${{ matrix.variant }}
@@ -129,7 +129,7 @@ jobs:
     name: "common fedora-current"
     uses: ./.github/workflows/lima.yml
     with:
-      runner: cncf-ubuntu-2-8-x86
+      runner: cncf-ubuntu-4-16-x86
       module: common
       distro: fedora-current
       timeout: 20


### PR DESCRIPTION
For some yet unknown reasons the performance of the runners is a lot worse than before causing timeouts for most tasks. Use some bigger runner to try to work around.

I added a comment on the cncf ci infra channel, it seems we are not the only one with problems.

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
