### PR TITLE
unshare: use inode check for detecting the initial user namespace

### DIFF
--- a/storage/pkg/unshare/unshare_linux.go
+++ b/storage/pkg/unshare/unshare_linux.go
@@ -394,17 +394,18 @@ const (
 	UsernsEnvName = "_CONTAINERS_USERNS_CONFIGURED"
 )
 
-// hasFullUsersMappings checks whether the current user namespace has all the IDs mapped.
-func hasFullUsersMappings() (bool, error) {
-	content, err := os.ReadFile("/proc/self/uid_map")
-	if err != nil {
+// inInitUserNamespace checks whether the current process is running in the
+// initial user namespace by comparing the inode of /proc/self/ns/user against
+// the kernel-defined USER_NS_INIT_INO.
+func inInitUserNamespace() (bool, error) {
+	const userNsInitIno uint64 = 0xEFFF_FFFD
+	var st syscall.Stat_t
+	// Stat, not Lstat: /proc/self/ns/user is a magic symlink and we need
+	// to dereference it to obtain the inode of the actual namespace object.
+	if err := syscall.Stat("/proc/self/ns/user", &st); err != nil {
 		return false, err
 	}
-	// The kernel rejects attempts to create mappings where either starting
-	// point is (u32)-1: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/user_namespace.c?id=af3e9579ecfb#n1006 .
-	// So, if the uid_map contains 4294967295, the entire IDs space is available in the
-	// user namespace, so it is likely the initial user namespace.
-	return bytes.Contains(content, []byte("4294967295")), nil
+	return st.Ino == userNsInitIno, nil
 }
 
 var (
@@ -427,11 +428,11 @@ func IsRootless() bool {
 			}
 		}
 		if !isRootless {
-			hasMappings, err := hasFullUsersMappings()
+			initNS, err := inInitUserNamespace()
 			if err != nil {
-				logrus.Warnf("Failed to read current user namespace mappings")
+				logrus.Warnf("Failed to check initial user namespace")
 			}
-			if err == nil && !hasMappings {
+			if err == nil && !initNS {
 				isRootless = true
 			}
 		}


### PR DESCRIPTION
The previous heuristic parsed /proc/self/uid_map looking for a full range mapping (4294967295), assuming only the initial user namespace could have it.  This is incorrect: a non-initial user namespace can also have a full identity map, e.g. with systemd PrivateUsers=full.

Use the kernel-defined USER_NS_INIT_INO inode number on /proc/self/ns/user instead, which is the authoritative way to identify the initial user namespace.

See: https://github.com/containers/crun/issues/2150

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
