### PR TITLE
rpm: require passt 0^20260716.g090d739

### DIFF
--- a/common/rpm/containers-common.spec
+++ b/common/rpm/containers-common.spec
@@ -68,7 +68,7 @@ Summary: Extra dependencies for Podman and Buildah
 Requires: %{name} = %{epoch}:%{version}-%{release}
 Requires: container-network-stack
 Requires: oci-runtime
-Requires: passt >= 0:0^20260526.g038c51e
+Requires: passt >= 0:0^20260716.g090d739
 %if %{defined fedora}
 Recommends: composefs
 Recommends: crun


### PR DESCRIPTION
For the new target ip address feature we use we must have pasta/pesto 20260716 installed as otherwise we fail to start containers.

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
