### PR TITLE
image: fix full-width punctuation in registries.conf documentation

### DIFF
--- a/image/docs/containers-registries.conf.5.md
+++ b/image/docs/containers-registries.conf.5.md
@@ -158,11 +158,11 @@ selected source, the remaining sources are tried automatically (see **Blob-level
 fallback** below).
 
 Each TOML table in the `mirror` array can contain the following fields:
-- `location`： same semantics
+- `location`: same semantics
 as specified in the `[[registry]]` TOML table
-- `insecure`： same semantics
+- `insecure`: same semantics
 as specified in the `[[registry]]` TOML table
-- `pull-from-mirror`: `all`, `digest-only` or `tag-only`.  If "digest-only"， mirrors will only be used for digest pulls. Pulling images by tag can potentially yield different images, depending on which endpoint we pull from.  Restricting mirrors to pulls by digest avoids that issue.  If "tag-only", mirrors will only be used for tag pulls.  For a more up-to-date and expensive mirror that it is less likely to be out of sync if tags move, it should not be unnecessarily used for digest references.  Default is "all" (or left empty), mirrors will be used for both digest pulls and tag pulls unless the mirror-by-digest-only is set for the primary registry.
+- `pull-from-mirror`: `all`, `digest-only` or `tag-only`.  If "digest-only", mirrors will only be used for digest pulls. Pulling images by tag can potentially yield different images, depending on which endpoint we pull from.  Restricting mirrors to pulls by digest avoids that issue.  If "tag-only", mirrors will only be used for tag pulls.  For a more up-to-date and expensive mirror that it is less likely to be out of sync if tags move, it should not be unnecessarily used for digest references.  Default is "all" (or left empty), mirrors will be used for both digest pulls and tag pulls unless the mirror-by-digest-only is set for the primary registry.
 Note that this per-mirror setting is allowed only when `mirror-by-digest-only` is not configured for the primary registry.
 
 `mirror-by-digest-only`

--- a/image/pkg/sysregistriesv2/system_registries_v2.go
+++ b/image/pkg/sysregistriesv2/system_registries_v2.go
@@ -46,7 +46,7 @@ type Endpoint struct {
 	Insecure bool `toml:"insecure,omitempty"`
 	// PullFromMirror is used for adding restrictions to image pull through the mirror.
 	// Set to "all", "digest-only", or "tag-only".
-	// If "digest-only"， mirrors will only be used for digest pulls. Pulling images by
+	// If "digest-only", mirrors will only be used for digest pulls. Pulling images by
 	// tag can potentially yield different images, depending on which endpoint
 	// we pull from.  Restricting mirrors to pulls by digest avoids that issue.
 	// If "tag-only", mirrors will only be used for tag pulls.  For a more up-to-date and expensive mirror


### PR DESCRIPTION
This is the same fix as containers/image#2975, reopened here after the migration bot noted that containers/image has moved into this repository.

A few spots in the registries.conf man page and the matching Go doc comment use full-width CJK punctuation instead of plain ASCII. This replaces them with regular ASCII punctuation.

In `image/docs/containers-registries.conf.5.md`, the mirror fields list used a full-width colon (U+FF1A) after `location` and `insecure`, and a full-width comma (U+FF0C) after "digest-only". The same full-width comma also appears in the `PullFromMirror` doc comment in `image/pkg/sysregistriesv2/system_registries_v2.go`, which is where the man page text comes from.

These are just typos. They look off in the rendered man page and are inconsistent with the rest of the file, which already uses ASCII colons and commas (for example the `pull-from-mirror` line right below already uses a normal colon). The change is documentation and comments only, so there is no behavior change.
