### PR TITLE
common/pkg/config: add new force_port_listen option

### DIFF
--- a/common/docs/containers.conf.5.md
+++ b/common/docs/containers.conf.5.md
@@ -618,8 +618,10 @@ Determines whether the engine will reserve ports on the host when they are
 forwarded to containers. When enabled, when ports are forwarded to containers,
 they are held open by conmon as long as the container is running, ensuring that
 they cannot be reused by other programs on the host. However, this can cause
-significant memory usage if a container has many ports forwarded to it.
-Disabling this can save memory.
+increased memory usage if a container has many ports forwarded to it.
+Disabling this can save memory but is not recommended as port conflicts are not noticed.
+Note this option is only used for rootful container when ports are forwarded via firewall rules.
+Rootless containers using pasta(1) always have to bind each port.
 
 **env**=[]
 

--- a/common/docs/containers.conf.5.md
+++ b/common/docs/containers.conf.5.md
@@ -663,6 +663,19 @@ Valid values are: `file`, `journald`, and `none`.
 Creates a more verbose container-create event which includes a JSON payload
 with detailed information about the container.  Set to false by default.
 
+**force_port_listen**=false
+
+For rootful containers when reserving the ports Podman will not use listen()
+on TCP ports by default as connections are forwarded via firewall rules.
+This is done to ensure if the firewall rule is bypassed, i.e. a connection
+to "::1", the connection will be correctly refused and not hang forever as we
+never accept() them.
+For applications which only monitor the listening state of a socket it means they
+will not see the bound port then. In that case this option can be set to true in
+order to force Podman to also call listen() on the ports.
+Also see the **enable_port_reservation** option.
+
+
 **healthcheck_events**=true|false
 
 Whenever Podman should log healthcheck events.

--- a/common/pkg/config/config.go
+++ b/common/pkg/config/config.go
@@ -326,6 +326,18 @@ type EngineConfig struct {
 	// information about the container.
 	EventsContainerCreateInspectData bool `toml:"events_container_create_inspect_data,omitempty"`
 
+	// ForcePortListen forces the port reservation to use listen().
+	// For rootful containers when reserving the ports Podman will not use listen()
+	// on TCP ports by default as connections are forwarded via firewall rules.
+	// This is done to ensure if the firewall rule is bypassed, i.e. a connection
+	// to "::1", the connection will be correctly refused and not hang forever as we
+	// never accept() them.
+	// For applications which only monitor the listening state of a socket it means they
+	// will not see the bound port then. In that case this option can be set to true in
+	// order to force Podman to also call listen() on the ports.
+	// Also see the **enable_port_reservation** option.
+	ForcePortListen bool `toml:"force_port_listen,omitempty"`
+
 	// graphRoot internal stores the location of the graphroot
 	graphRoot string
 

--- a/common/pkg/config/config.go
+++ b/common/pkg/config/config.go
@@ -300,9 +300,12 @@ type EngineConfig struct {
 	// host when they are forwarded to containers. When enabled, when ports are
 	// forwarded to containers, they are held open by conmon as long as the
 	// container is running, ensuring that they cannot be reused by other
-	// programs on the host. However, this can cause significant memory usage if
-	// a container has many ports forwarded to it. Disabling this can save
-	// memory.
+	// programs on the host. However, this can cause increased memory usage
+	// if a container has many ports forwarded to it. Disabling this can save
+	// memory but is not recommended as port conflicts are not noticed.
+	// Note this option is only used for rootful container when ports are
+	// forwarded via firewall rules. Rootless containers using pasta(1)
+	// always have to bind each port.
 	EnablePortReservation bool `toml:"enable_port_reservation,omitempty"`
 
 	// Environment variables to be used when running the container engine (e.g., Podman, Buildah). For example "http_proxy=internal.proxy.company.com"

--- a/common/pkg/config/config_test.go
+++ b/common/pkg/config/config_test.go
@@ -319,6 +319,7 @@ image_copy_tmp_dir="storage"`
 			gomega.Expect(config.Containers.CgroupConf.Get()).To(gomega.Equal(cgroupConf))
 			gomega.Expect(*config.Containers.OOMScoreAdj).To(gomega.Equal(int(750)))
 			gomega.Expect(config.Engine.KubeGenerateType).To(gomega.Equal("pod"))
+			gomega.Expect(config.Engine.ForcePortListen).To(gomega.BeTrue())
 		})
 
 		It("contents of passed-in file should override others", func() {

--- a/common/pkg/config/containers.conf
+++ b/common/pkg/config/containers.conf
@@ -529,8 +529,10 @@ default_sysctls = [
 # forwarded to containers. When enabled, when ports are forwarded to containers,
 # ports are held open by as long as the container is running, ensuring that
 # they cannot be reused by other programs on the host. However, this can cause
-# significant memory usage if a container has many ports forwarded to it.
-# Disabling this can save memory.
+# increased memory usage if a container has many ports forwarded to it.
+# Disabling this can save memory but is not recommended as port conflicts are not noticed.
+# Note this option is only used for rootful container when ports are forwarded via firewall rules.
+# Rootless containers using pasta(1) always have to bind each port.
 #
 #enable_port_reservation = true
 

--- a/common/pkg/config/containers.conf
+++ b/common/pkg/config/containers.conf
@@ -568,6 +568,18 @@ default_sysctls = [
 # with detailed information about the container.
 #events_container_create_inspect_data = false
 
+# For rootful containers when reserving the ports Podman will not use listen()
+# on TCP ports by default as connections are forwarded via firewall rules.
+# This is done to ensure if the firewall rule is bypassed, i.e. a connection
+# to "::1", the connection will be correctly refused and not hang forever as we
+# never accept() them.
+# For applications which only monitor the listening state of a socket it means they
+# will not see the bound port then. In that case this option can be set to true in
+# order to force Podman to also call listen() on the ports.
+# Also see the enable_port_reservation option.
+#
+#force_port_listen=false
+
 # Whenever Podman should log healthcheck events.
 # With many running healthcheck on short interval Podman will spam the event
 # log a lot as it generates a event for each single healthcheck run. Because

--- a/common/pkg/config/containers.conf-freebsd
+++ b/common/pkg/config/containers.conf-freebsd
@@ -372,8 +372,10 @@ default_sysctls = [
 # forwarded to containers. When enabled, when ports are forwarded to containers,
 # ports are held open by as long as the container is running, ensuring that
 # they cannot be reused by other programs on the host. However, this can cause
-# significant memory usage if a container has many ports forwarded to it.
-# Disabling this can save memory.
+# increased memory usage if a container has many ports forwarded to it.
+# Disabling this can save memory but is not recommended as port conflicts are not noticed.
+# Note this option is only used for rootful container when ports are forwarded via firewall rules.
+# Rootless containers using pasta(1) always have to bind each port.
 #
 #enable_port_reservation = true
 

--- a/common/pkg/config/containers.conf-freebsd
+++ b/common/pkg/config/containers.conf-freebsd
@@ -407,6 +407,18 @@ default_sysctls = [
 #
 #events_logger = "file"
 
+# For rootful containers when reserving the ports Podman will not use listen()
+# on TCP ports by default as connections are forwarded via firewall rules.
+# This is done to ensure if the firewall rule is bypassed, i.e. a connection
+# to "::1", the connection will be correctly refused and not hang forever as we
+# never accept() them.
+# For applications which only monitor the listening state of a socket it means they
+# will not see the bound port then. In that case this option can be set to true in
+# order to force Podman to also call listen() on the ports.
+# Also see the enable_port_reservation option.
+#
+#force_port_listen=false
+
 # Whenever Podman should log healthcheck events.
 # With many running healthcheck on short interval Podman will spam the event
 # log a lot as it generates a event for each single healthcheck run. Because

--- a/common/pkg/config/testdata/containers_default.conf
+++ b/common/pkg/config/testdata/containers_default.conf
@@ -189,6 +189,8 @@ compose_warning_logs = false
 # Set the env section under [containers] table, if you want to set environment variables for the container.
 env = ["super=duper", "foo=bar"]
 
+force_port_listen=true
+
 # Container init binary
 #init_path = "/usr/libexec/podman/catatonit"
 


### PR DESCRIPTION
With Podman 6 we dropped the listen() call for port reservations.
However on at least WSL this broke the port forwarding logic there as
they only scan listening state ports. As we do not want to use listen by
default we will need a new option we can hard code on our WSL image.

see https://github.com/podman-container-tools/podman/issues/29377

