### PR TITLE
pkg/retry: don't panic when the retry delay is too small for jitter

### DIFF
--- a/common/pkg/retry/retry.go
+++ b/common/pkg/retry/retry.go
@@ -2,6 +2,7 @@ package retry
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"math"
 	"math/rand/v2"
@@ -35,6 +36,9 @@ func RetryIfNecessary(ctx context.Context, operation func() error, options *Opti
 
 // IfNecessary retries the operation in exponential backoff with the retry Options.
 func IfNecessary(ctx context.Context, operation func() error, options *Options) error {
+	if options.Delay < 0 {
+		return fmt.Errorf("invalid retry delay %v: must not be negative", options.Delay)
+	}
 	var isRetryable func(error) bool
 	if options.IsErrorRetryable != nil {
 		isRetryable = options.IsErrorRetryable
@@ -48,8 +52,12 @@ func IfNecessary(ctx context.Context, operation func() error, options *Options) 
 			delay = options.Delay
 		}
 		logrus.Warnf("Failed, retrying in %s ... (%d/%d). Error: %v", delay, attempt+1, options.MaxRetry, err)
-		delay += rand.N(delay / 10) // 10 % jitter so that a failure blip doesn’t cause a deterministic stampede
-		logrus.Debugf("Retry delay with added jitter: %s", delay)
+		// delay/10 truncates to zero for delays below 10ns, and rand.N panics on a
+		// non-positive argument. Such a delay is honored as-is, just without jitter.
+		if jitter := delay / 10; jitter > 0 {
+			delay += rand.N(jitter) // 10 % jitter so that a failure blip doesn’t cause a deterministic stampede
+			logrus.Debugf("Retry delay with added jitter: %s", delay)
+		}
 		select {
 		case <-time.After(delay):
 			// Do nothing.

--- a/common/pkg/retry/retry_test.go
+++ b/common/pkg/retry/retry_test.go
@@ -1,0 +1,95 @@
+package retry
+
+import (
+	"context"
+	"syscall"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIfNecessary(t *testing.T) {
+	// alwaysFails counts its invocations and always returns a retryable error.
+	alwaysFails := func(attempts *int) func() error {
+		return func() error {
+			*attempts++
+			return syscall.ECONNREFUSED
+		}
+	}
+
+	t.Run("negative delay is rejected", func(t *testing.T) {
+		attempts := 0
+		err := IfNecessary(context.Background(), alwaysFails(&attempts), &Options{
+			MaxRetry: 3,
+			Delay:    -1 * time.Second,
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid retry delay")
+		assert.Zero(t, attempts, "the operation should not run at all")
+	})
+
+	// A delay below 10ns leaves no positive range for rand.N, which panics on a
+	// non-positive argument. Such a delay is used exactly as given.
+	for _, tt := range []struct {
+		name  string
+		delay time.Duration
+	}{
+		{"smallest representable delay", 1 * time.Nanosecond},
+		{"delay below the jitter granularity", 5 * time.Nanosecond},
+		{"largest delay whose jitter range truncates to zero", 9 * time.Nanosecond},
+		{"smallest delay with a non-empty jitter range", 10 * time.Nanosecond},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				attempts := 0
+				start := time.Now()
+				err := IfNecessary(context.Background(), alwaysFails(&attempts), &Options{
+					MaxRetry: 3,
+					Delay:    tt.delay,
+				})
+
+				require.ErrorIs(t, err, syscall.ECONNREFUSED)
+				assert.Equal(t, 4, attempts, "the operation should run once and then be retried MaxRetry times")
+				// rand.N(1) is always 0, so a 10ns delay is not jittered either.
+				assert.Equal(t, 3*tt.delay, time.Since(start))
+			})
+		})
+	}
+
+	t.Run("delay is jittered when the range allows", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			const delay = time.Second
+			attempts := 0
+			start := time.Now()
+			err := IfNecessary(context.Background(), alwaysFails(&attempts), &Options{
+				MaxRetry: 3,
+				Delay:    delay,
+			})
+
+			require.ErrorIs(t, err, syscall.ECONNREFUSED)
+			assert.Equal(t, 4, attempts)
+			elapsed := time.Since(start)
+			assert.GreaterOrEqual(t, elapsed, 3*delay)
+			assert.Less(t, elapsed, 3*delay+3*(delay/10), "jitter should add at most 10 %% per retry")
+		})
+	})
+
+	t.Run("unset delay uses exponential backoff", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			attempts := 0
+			start := time.Now()
+			err := IfNecessary(context.Background(), alwaysFails(&attempts), &Options{MaxRetry: 3})
+
+			require.ErrorIs(t, err, syscall.ECONNREFUSED)
+			assert.Equal(t, 4, attempts)
+			const base = 1*time.Second + 2*time.Second + 4*time.Second
+			elapsed := time.Since(start)
+			assert.GreaterOrEqual(t, elapsed, base)
+			assert.Less(t, elapsed, base+base/10, "jitter should add at most 10 %% per retry")
+		})
+	})
+}


### PR DESCRIPTION
Fixes: #1071

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->

`rand.N` panics on a non-positive argument and `delay / 10` is 0 below 10ns, so any
`Options.Delay` under that panicked `IfNecessary`. Negative delays too.

Only jitter when there's a positive range to jitter over. No change at 10ns and above.

Reachable from `containers.conf`: `[engine] retry_delay` is parsed with
`time.ParseDuration` and reaches `Options.Delay` through libimage with no range check.

The package had no tests, so this adds coverage for the delay handling:
1ns/5ns/9ns/10ns/negative, plus the default exponential path. Reverting the fix makes
them panic at `retry.go:51`.
